### PR TITLE
Base 64 output is incorrect

### DIFF
--- a/docs/demo/wat2wasm/demo.js
+++ b/docs/demo/wat2wasm/demo.js
@@ -117,7 +117,9 @@ function compile() {
     var binaryOutput = module.toBinary({log: true, write_debug_names:true});
     outputLog = binaryOutput.log;
     binaryBuffer = binaryOutput.buffer;
-    outputBase64 = btoa(binaryBuffer);
+    // binaryBuffer is a Uint8Array, so we need to convert it to a string to use btoa
+    // https://stackoverflow.com/questions/12710001/how-to-convert-uint8-array-to-base64-encoded-string
+    outputBase64 = btoa((String.fromCharCode.apply(null, binaryBuffer));
 
     var blob = new Blob([binaryOutput.buffer]);
     if (binaryBlobUrl) {


### PR DESCRIPTION
For simple, it decodes to:
MCw5NywxMTUsMTA5LDEsMCwwLDAsMSw2LDEsOTYsMSwxMjQsMSwxMjQsMywyLDEsMCw3LDcsMSwzLDEwMiw5Nyw5OSwwLDAsMTAsNDYsMSw0NCwwLDMyLDAsNjgsMCwwLDAsMCwwLDAsMjQwLDYzLDk5LDQsMTI0LDY4LDAsMCwwLDAsMCwwLDI0MCw2Myw1LDMyLDAsMzIsMCw2OCwwLDAsMCwwLDAsMCwyNDAsNjMsMTYxLDE2LDAsMTYyLDExLDExLDAsMTgsNCwxMTAsOTcsMTA5LDEwMSwxLDYsMSwwLDMsMTAyLDk3LDk5LDIsMywxLDAsMA== which is base64 for the literal string:
'0,97,115,109,1,0,0,0,1,7,1,96,2,127,127,1,127,3,2,1,0,7,10,1,6,97,100,100,84,119,111,0,0,10,9,1,7,0,32,0,32,1,106,11,0,10,4,110,97,109,101,2,3,1,0,0'

This is the Uint8 array encoded as a string, which is not what we want! We want the numbers as bytes encoded in base64.

This answer changes the base64 to:
AGFzbQEAAAABBgFgAXwBfAMCAQAHBwEDZmFjAAAKLgEsACAARAAAAAAAAPA/YwR8RAAAAAAAAPA/BSAAIABEAAAAAAAA8D+hEACiCwsAEgRuYW1lAQYBAANmYWMCAwEAAA==

Which decodes properly. In Node:
```
> Buffer.from("AGFzbQEAAAABBgFgAXwBfAMCAQAHBwEDZmFjAAAKLgEsACAARAAAAAAAAPA/YwR8RAAAAAAAAPA/BSAAIABEAAAAAAAA8D+hEACiCwsAEgRuYW1lAQYBAANmYWMCAwEAAA==", 'base64')
<Buffer 00 61 73 6d 01 00 00 00 01 06 01 60 01 7c 01 7c 03 02 01 00 07 07 01 03 66 61 63 00 00 0a 2e 01 2c 00 20 00 44 00 00 00 00 00 00 f0 3f 63 04 7c 44 00 ... 47 more bytes>
```
You can see the magic wasm header there.