### PR TITLE
src/wast-parser.cc: Accept non abbreviated forms of result for select

### DIFF
--- a/src/wast-parser.cc
+++ b/src/wast-parser.cc
@@ -2119,9 +2119,8 @@ Result WastParser::ParsePlainInstr(std::unique_ptr<Expr>* out_expr) {
       Consume();
       TypeVector result;
       if (options_->features.reference_types_enabled() &&
-          MatchLpar(TokenType::Result)) {
-        CHECK_RESULT(ParseValueTypeList(&result, nullptr));
-        EXPECT(Rpar);
+          PeekMatchLpar(TokenType::Result)) {
+        CHECK_RESULT(ParseResultList(&result, nullptr));
       }
       out_expr->reset(new SelectExpr(result, loc));
       break;


### PR DESCRIPTION
eg. "select (result i32) (result)"

cf. https://github.com/WebAssembly/spec/pull/1567