### PR TITLE
wast-parser.cc: disallow exception tag unless exceptions enabled

### DIFF
--- a/src/wast-parser.cc
+++ b/src/wast-parser.cc
@@ -1346,6 +1346,10 @@ Result WastParser::ParseElemModuleField(Module* module) {
 
 Result WastParser::ParseTagModuleField(Module* module) {
   WABT_TRACE(ParseTagModuleField);
+  if (!options_->features.exceptions_enabled()) {
+    Error(Consume().loc, "tag not allowed");
+    return Result::Error;
+  }
   EXPECT(Lpar);
   EXPECT(Tag);
   std::string name;

--- a/test/dump/tag.txt
+++ b/test/dump/tag.txt
@@ -1,5 +1,5 @@
 ;;; TOOL: run-objdump
-;;; ARGS0: -v
+;;; ARGS0: -v --enable-exceptions
 ;;; ARGS1: -x
 (module
   (tag)

--- a/test/regress/regress-2110.txt
+++ b/test/regress/regress-2110.txt
@@ -5,7 +5,7 @@
 )
 
 (;; STDERR ;;;
-out/test/regress/regress-38.txt:4:3: error: tag not allowed
+out/test/regress/regress-2110.txt:4:3: error: tag not allowed
   (tag $e0 (param i32))
   ^
 ;;; STDERR ;;)

--- a/test/regress/regress-38.txt
+++ b/test/regress/regress-38.txt
@@ -1,0 +1,11 @@
+;;; TOOL: wat2wasm
+;;; ERROR: 1
+(module
+  (tag $e0 (param i32))
+)
+
+(;; STDERR ;;;
+out/test/regress/regress-38.txt:4:3: error: tag not allowed
+  (tag $e0 (param i32))
+  ^
+;;; STDERR ;;)


### PR DESCRIPTION
Fixes a bug first noticed at #1906.