### PR TITLE
wasm2c: harden set/longjmp to check for uninit jmp_buf

### DIFF
--- a/wasm2c/wasm-rt-impl.c
+++ b/wasm2c/wasm-rt-impl.c
@@ -69,13 +69,13 @@ uint32_t wasm_rt_saved_call_stack_depth;
 static FuncType* g_func_types;
 static uint32_t g_func_type_count;
 
-jmp_buf wasm_rt_jmp_buf;
+wasm_rt_jmp_buf g_wasm_rt_jmp_buf;
 
 static uint32_t g_active_exception_tag;
 static uint8_t g_active_exception[MAX_EXCEPTION_SIZE];
 static uint32_t g_active_exception_size;
 
-static jmp_buf* g_unwind_target;
+static wasm_rt_jmp_buf* g_unwind_target;
 
 void wasm_rt_trap(wasm_rt_trap_t code) {
   assert(code != WASM_RT_TRAP_NONE);
@@ -87,7 +87,7 @@ void wasm_rt_trap(wasm_rt_trap_t code) {
   WASM_RT_TRAP_HANDLER(code);
   wasm_rt_unreachable();
 #else
-  WASM_RT_LONGJMP(wasm_rt_jmp_buf, code);
+  WASM_RT_LONGJMP(g_wasm_rt_jmp_buf, code);
 #endif
 }
 


### PR DESCRIPTION
Use of powerful primitives like longjmp is of some security concern for the Firefox context. While the Firefox use case would leave all setjmp/longjmp use cases as dead code, there is still some concerns. This PR makes the wasm2c generated code more defensive when using `longjmp`. The code now checks that `jmp_buf` is initialized by `setjmp` before use with `longjmp`.

**Costs**: The costs here are minor: (1) a variable initialization during wasm_rt_try, and (2) a conditional check during exceptions or traps (which are usually not the critical path in programs). 