### PR TITLE
c-writer.cc: compute type values internally when possible

### DIFF
--- a/test/wasm2c/add.txt
+++ b/test/wasm2c/add.txt
@@ -626,11 +626,7 @@ DEFINE_TABLE_FILL(externref)
 
 static bool s_module_initialized = false;
 
-static u32 func_types[1];
-
-static void init_func_types(void) {
-  func_types[0] = wasm_rt_register_func_type(2, 1, WASM_RT_I32, WASM_RT_I32, WASM_RT_I32);
-}
+static const u32 func_types[1] = {0, };
 
 static u32 w2c_add(Z_test_instance_t*, u32, u32);
 
@@ -652,7 +648,6 @@ u32 Z_testZ_add(Z_test_instance_t* instance, u32 w2c_p0, u32 w2c_p1) {
 void Z_test_init_module(void) {
   assert(wasm_rt_is_initialized());
   s_module_initialized = true;
-  init_func_types();
 }
 
 void Z_test_instantiate(Z_test_instance_t* instance) {

--- a/test/wasm2c/hello.txt
+++ b/test/wasm2c/hello.txt
@@ -656,13 +656,7 @@ DEFINE_TABLE_FILL(externref)
 
 static bool s_module_initialized = false;
 
-static u32 func_types[3];
-
-static void init_func_types(void) {
-  func_types[0] = wasm_rt_register_func_type(4, 1, WASM_RT_I32, WASM_RT_I32, WASM_RT_I32, WASM_RT_I32, WASM_RT_I32);
-  func_types[1] = wasm_rt_register_func_type(1, 0, WASM_RT_I32);
-  func_types[2] = wasm_rt_register_func_type(0, 0);
-}
+static const u32 func_types[3] = {0, 1, 2, };
 
 static void w2c__start(Z_test_instance_t*);
 
@@ -726,7 +720,6 @@ static void init_instance_import(Z_test_instance_t* instance, struct Z_wasi_snap
 void Z_test_init_module(void) {
   assert(wasm_rt_is_initialized());
   s_module_initialized = true;
-  init_func_types();
 }
 
 void Z_test_instantiate(Z_test_instance_t* instance, struct Z_wasi_snapshot_preview1_instance_t* Z_wasi_snapshot_preview1_instance) {

--- a/wasm2c/README.md
+++ b/wasm2c/README.md
@@ -229,8 +229,8 @@ signature, it is necessary to convert them to a canonical form:
 typedef void (*wasm_rt_funcref_t)(void);
 ```
 
-Next are the definitions for a table element. `func_type` is a function index
-as returned by `wasm_rt_register_func_type` described below. `module_instance`
+Next are the definitions for a table element. `func_type` is a function type value
+possibly returned by `wasm_rt_register_func_type` described below. `module_instance`
 is the pointer to the module instance that should be passed in when the func is
 called.
 
@@ -310,7 +310,8 @@ wasm2c_custom_trap_handler`. It is recommended that you add this macro
 definition via a compiler flag
 (`-DWASM_RT_MEMCHECK_SIGNAL_HANDLER=wasm2c_custom_trap_handler` on clang/gcc).
 
-`wasm_rt_register_func_type` is a function that registers a function type. It
+For modules that import or export function references, `wasm_rt_register_func_type`
+registers each function type to have a consistent value across modules. It
 is a variadic function where the first two arguments give the number of
 parameters and results, and the following arguments are the types. For example,
 the function `func (param i32 f32) (result f64)` would register the function

--- a/wasm2c/examples/fac/fac.c
+++ b/wasm2c/examples/fac/fac.c
@@ -577,11 +577,7 @@ DEFINE_TABLE_FILL(externref)
 
 static bool s_module_initialized = false;
 
-static u32 func_types[1];
-
-static void init_func_types(void) {
-  func_types[0] = wasm_rt_register_func_type(1, 1, WASM_RT_I32, WASM_RT_I32);
-}
+static const u32 func_types[1] = {0, };
 
 static u32 w2c_fac(Z_fac_instance_t*, u32);
 
@@ -613,7 +609,6 @@ u32 Z_facZ_fac(Z_fac_instance_t* instance, u32 w2c_p0) {
 void Z_fac_init_module(void) {
   assert(wasm_rt_is_initialized());
   s_module_initialized = true;
-  init_func_types();
 }
 
 void Z_fac_instantiate(Z_fac_instance_t* instance) {


### PR DESCRIPTION
This PR minimizes calls from wasm2c-generated modules to the runtime's `wasm_rt_register_func_type` function.

- Modules that don't import or export funcrefs end up never calling the runtime; they just assign deduplicated type values internally at wasm2c-time. (These are modules that have no imports or exports that are funcref-typed globals, funcref-typed tables, or functions with a funcref-typed param or result.)
- Other modules only call the runtime for non-duplicate internal types.

I think this gets us a significant distance in many practical situations towards allowing the runtime to eliminate the global functype registry; most modules just don't need it (and if you know your modules don't need it, your runtime doesn't need to implement `wasm_rt_register_func_type`). And this is vastly simpler than #2120 so perhaps easier to stomach.