### PR TITLE
wasm2c: eliminate wasm_rt_register_tag()

### DIFF
--- a/src/c-writer.cc
+++ b/src/c-writer.cc
@@ -1089,7 +1089,7 @@ void CWriter::WriteTags() {
       // The data stored in this variable is never read.
       if (tag_index == module_->num_tag_imports) {
         Write(Newline());
-        Write("typedef bool wasm_tag_placeholder_t;", Newline());
+        Write("typedef char wasm_tag_placeholder_t;", Newline());
       }
       Write("static const wasm_tag_placeholder_t ",
             DefineGlobalScopeName(ModuleFieldType::Tag, tag->name), ";",

--- a/wasm2c/README.md
+++ b/wasm2c/README.md
@@ -347,8 +347,7 @@ Several additional symbols must be defined if wasm2c is being run with
 support for exceptions (`--enable-exceptions`):
 
 ```c
-uint32_t wasm_rt_register_tag(uint32_t size);
-void wasm_rt_load_exception(uint32_t tag, uint32_t size, const void* values);
+void wasm_rt_load_exception(const char* tag, uint32_t size, const void* values);
 WASM_RT_NO_RETURN void wasm_rt_throw(void);
 WASM_RT_UNWIND_TARGET
 WASM_RT_UNWIND_TARGET* wasm_rt_get_unwind_target(void);
@@ -361,8 +360,6 @@ wasm_rt_try(target)
 
 A C implementation of these functions is also available in
 [`wasm-rt-impl.h`](wasm-rt-impl.h) and [`wasm-rt-impl.c`](wasm-rt-impl.c).
-
-`wasm_rt_register_tag` registers an exception type (a tag) with a given size.
 
 `wasm_rt_load_exception` sets the active exception to a given tag, size, and contents.
 

--- a/wasm2c/wasm-rt-impl.c
+++ b/wasm2c/wasm-rt-impl.c
@@ -71,7 +71,7 @@ static uint32_t g_func_type_count;
 
 wasm_rt_jmp_buf g_wasm_rt_jmp_buf;
 
-static const char* g_active_exception_tag;
+static wasm_rt_tag_t g_active_exception_tag;
 static uint8_t g_active_exception[MAX_EXCEPTION_SIZE];
 static uint32_t g_active_exception_size;
 
@@ -144,7 +144,7 @@ uint32_t wasm_rt_register_func_type(uint32_t param_count,
   return idx + 1;
 }
 
-void wasm_rt_load_exception(const char* tag,
+void wasm_rt_load_exception(const wasm_rt_tag_t tag,
                             uint32_t size,
                             const void* values) {
   if (size > MAX_EXCEPTION_SIZE) {
@@ -171,7 +171,7 @@ void wasm_rt_set_unwind_target(WASM_RT_UNWIND_TARGET* target) {
   g_unwind_target = target;
 }
 
-const char* wasm_rt_exception_tag(void) {
+wasm_rt_tag_t wasm_rt_exception_tag(void) {
   return g_active_exception_tag;
 }
 

--- a/wasm2c/wasm-rt-impl.c
+++ b/wasm2c/wasm-rt-impl.c
@@ -71,7 +71,7 @@ static uint32_t g_func_type_count;
 
 wasm_rt_jmp_buf g_wasm_rt_jmp_buf;
 
-static uint32_t g_active_exception_tag;
+static const char* g_active_exception_tag;
 static uint8_t g_active_exception[MAX_EXCEPTION_SIZE];
 static uint32_t g_active_exception_size;
 
@@ -144,17 +144,12 @@ uint32_t wasm_rt_register_func_type(uint32_t param_count,
   return idx + 1;
 }
 
-uint32_t wasm_rt_register_tag(uint32_t size) {
-  static uint32_t s_tag_count = 0;
-
+void wasm_rt_load_exception(const char* tag,
+                            uint32_t size,
+                            const void* values) {
   if (size > MAX_EXCEPTION_SIZE) {
     wasm_rt_trap(WASM_RT_TRAP_EXHAUSTION);
   }
-  return s_tag_count++;
-}
-
-void wasm_rt_load_exception(uint32_t tag, uint32_t size, const void* values) {
-  assert(size <= MAX_EXCEPTION_SIZE);
 
   g_active_exception_tag = tag;
   g_active_exception_size = size;
@@ -176,7 +171,7 @@ void wasm_rt_set_unwind_target(WASM_RT_UNWIND_TARGET* target) {
   g_unwind_target = target;
 }
 
-uint32_t wasm_rt_exception_tag(void) {
+const char* wasm_rt_exception_tag(void) {
   return g_active_exception_tag;
 }
 

--- a/wasm2c/wasm-rt.h
+++ b/wasm2c/wasm-rt.h
@@ -268,14 +268,9 @@ const char* wasm_rt_strerror(wasm_rt_trap_t trap);
 uint32_t wasm_rt_register_func_type(uint32_t params, uint32_t results, ...);
 
 /**
- * Register a tag with the given size. Returns the tag.
- */
-uint32_t wasm_rt_register_tag(uint32_t size);
-
-/**
  * Set the active exception to given tag, size, and contents.
  */
-void wasm_rt_load_exception(uint32_t tag, uint32_t size, const void* values);
+void wasm_rt_load_exception(const char* tag, uint32_t size, const void* values);
 
 /**
  * Throw the active exception.
@@ -310,7 +305,7 @@ void wasm_rt_set_unwind_target(WASM_RT_UNWIND_TARGET* target);
 /**
  * Tag of the active exception.
  */
-uint32_t wasm_rt_exception_tag(void);
+const char* wasm_rt_exception_tag(void);
 
 /**
  * Size of the active exception.

--- a/wasm2c/wasm-rt.h
+++ b/wasm2c/wasm-rt.h
@@ -268,9 +268,16 @@ const char* wasm_rt_strerror(wasm_rt_trap_t trap);
 uint32_t wasm_rt_register_func_type(uint32_t params, uint32_t results, ...);
 
 /**
+ * An tag is represented as an arbitrary pointer.
+ */
+typedef const void* wasm_rt_tag_t;
+
+/**
  * Set the active exception to given tag, size, and contents.
  */
-void wasm_rt_load_exception(const char* tag, uint32_t size, const void* values);
+void wasm_rt_load_exception(const wasm_rt_tag_t tag,
+                            uint32_t size,
+                            const void* values);
 
 /**
  * Throw the active exception.
@@ -305,7 +312,7 @@ void wasm_rt_set_unwind_target(WASM_RT_UNWIND_TARGET* target);
 /**
  * Tag of the active exception.
  */
-const char* wasm_rt_exception_tag(void);
+wasm_rt_tag_t wasm_rt_exception_tag(void);
 
 /**
  * Size of the active exception.


### PR DESCRIPTION
This lets exception tags be pre-assigned at compile-time (link-time?), instead of making the runtime keep an incrementing counter. 

Since every declared tag is unique (unlike with function types which are only unique if the types differ), this is pretty feasible to do in advance -- the tag value just becomes a pointer to a static dummy variable that belongs to the module. We can count on the OS not to load two modules in the same address of virtual memory!

Another step towards reducing the need for the runtime to keep global state.

If we merge #2120 and this one, we'll end up eliminating everything that [modname]_init_module does -- that function could go away as the modules wouldn't need any runtime initialization.