### PR TITLE
fix wasm2c tests on 32-bit

### DIFF
--- a/test/spec-wasm2c-prefix.c
+++ b/test/spec-wasm2c-prefix.c
@@ -200,7 +200,7 @@ static bool is_equal_wasm_rt_funcref_t(wasm_rt_funcref_t x,
          (x.module_instance == y.module_instance);
 }
 
-wasm_rt_externref_t spectest_make_externref(u64 x) {
+wasm_rt_externref_t spectest_make_externref(uintptr_t x) {
   return (wasm_rt_externref_t)(x + 1);  // externref(0) is not null
 }
 


### PR DESCRIPTION
The spectest_make_externref() in [test/spec-wasm2c-prefix.c:203](https://github.com/WebAssembly/wabt/blob/main/test/spec-wasm2c-prefix.c#L203) assumes that `u64` (`uint64_t`) can be converted to `wasm_rt_externref_t` (`void *`). This is not the case on 32-bit platforms.

```
- test/regress/regress-2039.txt
  expected error code 0, got 1.
  STDERR MISMATCH:
  --- expected
  +++ actual
  @@ -0,0 +1,19 @@
  +out/test/regress/regress-2039/regress-2039-main.c: In function ‘spectest_make_externref’:
  +out/test/regress/regress-2039/regress-2039-main.c:205:10: error: cast to pointer from integer of different size [-Werror=int-to-pointer-cast]
  +  205 |   return (wasm_rt_externref_t)(x + 1);  // externref(0) is not null
  +      |          ^
```

The same error occurs with all wasm2c tests.

This fixes #2099.