### PR TITLE
wasm2c rt: mark temp storage for traps/exceptions as thread_local

### DIFF
--- a/wasm2c/wasm-rt-impl.c
+++ b/wasm2c/wasm-rt-impl.c
@@ -62,20 +62,20 @@ static char* g_alt_stack = 0;
 #endif
 
 #if WASM_RT_USE_STACK_DEPTH_COUNT
-uint32_t wasm_rt_call_stack_depth;
-uint32_t wasm_rt_saved_call_stack_depth;
+WASM_RT_THREAD_LOCAL uint32_t wasm_rt_call_stack_depth;
+WASM_RT_THREAD_LOCAL uint32_t wasm_rt_saved_call_stack_depth;
 #endif
 
 static FuncType* g_func_types;
 static uint32_t g_func_type_count;
 
-wasm_rt_jmp_buf g_wasm_rt_jmp_buf;
+WASM_RT_THREAD_LOCAL wasm_rt_jmp_buf g_wasm_rt_jmp_buf;
 
-static wasm_rt_tag_t g_active_exception_tag;
-static uint8_t g_active_exception[MAX_EXCEPTION_SIZE];
-static uint32_t g_active_exception_size;
+static WASM_RT_THREAD_LOCAL wasm_rt_tag_t g_active_exception_tag;
+static WASM_RT_THREAD_LOCAL uint8_t g_active_exception[MAX_EXCEPTION_SIZE];
+static WASM_RT_THREAD_LOCAL uint32_t g_active_exception_size;
 
-static wasm_rt_jmp_buf* g_unwind_target;
+static WASM_RT_THREAD_LOCAL wasm_rt_jmp_buf* g_unwind_target;
 
 void wasm_rt_trap(wasm_rt_trap_t code) {
   assert(code != WASM_RT_TRAP_NONE);

--- a/wasm2c/wasm-rt-impl.h
+++ b/wasm2c/wasm-rt-impl.h
@@ -28,7 +28,7 @@ extern "C" {
 #endif
 
 /** A setjmp buffer used for handling traps. */
-extern wasm_rt_jmp_buf g_wasm_rt_jmp_buf;
+extern WASM_RT_THREAD_LOCAL wasm_rt_jmp_buf g_wasm_rt_jmp_buf;
 
 #if WASM_RT_MEMCHECK_SIGNAL_HANDLER && !defined(_WIN32)
 #define WASM_RT_LONGJMP_UNCHECKED(buf, val) siglongjmp(buf, val)
@@ -45,7 +45,7 @@ extern wasm_rt_jmp_buf g_wasm_rt_jmp_buf;
 
 #if WASM_RT_USE_STACK_DEPTH_COUNT
 /** Saved call stack depth that will be restored in case a trap occurs. */
-extern uint32_t wasm_rt_saved_call_stack_depth;
+extern WASM_RT_THREAD_LOCAL uint32_t wasm_rt_saved_call_stack_depth;
 #define WASM_RT_SAVE_STACK_DEPTH() \
   wasm_rt_saved_call_stack_depth = wasm_rt_call_stack_depth
 #else

--- a/wasm2c/wasm-rt.h
+++ b/wasm2c/wasm-rt.h
@@ -51,6 +51,12 @@ extern "C" {
 #define wasm_rt_unreachable abort
 #endif
 
+#if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L)
+#define WASM_RT_THREAD_LOCAL _Thread_local
+#else
+#define WASM_RT_THREAD_LOCAL
+#endif
+
 /**
  * Enable memory checking via a signal handler via the following definition:
  *
@@ -116,7 +122,7 @@ extern "C" {
 #endif
 
 /** Current call stack depth. */
-extern uint32_t wasm_rt_call_stack_depth;
+extern WASM_RT_THREAD_LOCAL uint32_t wasm_rt_call_stack_depth;
 
 #endif
 


### PR DESCRIPTION
This PR marks the temporary storage used to handle traps, exceptions, and the call-stack limit as thread-local (when the runtime is compiled as C11 or later so `thread_local` is available).

Other than this, I _think_ the only remaining sources of "MT-unsafety" in the runtime are:

- the function type registry (removed in #2120)
- the use of sigaltstack to handle segfaults. I think we will need to refactor the runtime API for this because sigaltstack needs to be called on a per-thread basis (and the alt-stack may need to be malloc'ed and freed on a per-thread basis if we can't make it a static thread-local array).

(Also, it would be nice to have a multithreaded test of the runtime to make sure it really does work re-entrantly.)