### PR TITLE
wasm-rt.h: MSVC doesn't support _Thread_local, even in C11 mode

### DIFF
--- a/wasm2c/wasm-rt.h
+++ b/wasm2c/wasm-rt.h
@@ -51,7 +51,9 @@ extern "C" {
 #define wasm_rt_unreachable abort
 #endif
 
-#if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L)
+#ifdef _MSC_VER
+#define WASM_RT_THREAD_LOCAL __declspec(thread)
+#elif defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L)
 #define WASM_RT_THREAD_LOCAL _Thread_local
 #else
 #define WASM_RT_THREAD_LOCAL


### PR DESCRIPTION
Fixup from #2126. MSVC in C11 mode sets `__STDC_VERSION__` >= 201112L but doesn't support `_Thread_local`. It does appear to support `__declspec(thread)`.