### PR TITLE
Update wasm2c examples to reflect new wasm_rt_allocate_memory() param

### DIFF
--- a/wasm2c/README.md
+++ b/wasm2c/README.md
@@ -284,7 +284,7 @@ void wasm_rt_free(void);
 void wasm_rt_trap(wasm_rt_trap_t) __attribute__((noreturn));
 const char* wasm_rt_strerror(wasm_rt_trap_t trap);
 uint32_t wasm_rt_register_func_type(uint32_t params, uint32_t results, ...);
-void wasm_rt_allocate_memory(wasm_rt_memory_t*, uint32_t initial_pages, uint32_t max_pages);
+void wasm_rt_allocate_memory(wasm_rt_memory_t*, uint32_t initial_pages, uint32_t max_pages, bool is64);
 uint32_t wasm_rt_grow_memory(wasm_rt_memory_t*, uint32_t pages);
 void wasm_rt_free_memory(wasm_rt_memory_t*);
 void wasm_rt_allocate_funcref_table(wasm_rt_table_t*, uint32_t elements, uint32_t max_elements);
@@ -319,7 +319,8 @@ type as
 
 `wasm_rt_allocate_memory` initializes a memory instance, and allocates at least
 enough space for the given number of initial pages. The memory must be cleared
-to zero.
+to zero. The `is64` parameter indicates if the memory is indexed with
+an i32 or i64 address.
 
 `wasm_rt_grow_memory` must grow the given memory instance by the given number
 of pages. If there isn't enough memory to do so, or the new page count would be
@@ -588,8 +589,8 @@ int main(int argc, char** argv) {
   struct Z_host_instance_t host_instance_1;
   struct Z_host_instance_t host_instance_2;
   /* Allocate 1 page of wasm memory (64KiB). */
-  wasm_rt_allocate_memory(&host_instance_1.memory, 1, 1);
-  wasm_rt_allocate_memory(&host_instance_2.memory, 1, 1);
+  wasm_rt_allocate_memory(&host_instance_1.memory, 1, 1, false);
+  wasm_rt_allocate_memory(&host_instance_2.memory, 1, 1, false);
 
   /* Construct the module instances */
   Z_rot13_instantiate(&rot13_instance_1, &host_instance_1);

--- a/wasm2c/examples/fac/fac.c
+++ b/wasm2c/examples/fac/fac.c
@@ -35,9 +35,20 @@
        TRAP(CALL_INDIRECT),                             \
    ((t)table.data[x].func)(__VA_ARGS__))
 
+#ifdef SUPPORT_MEMORY64
+#define RANGE_CHECK(mem, offset, len)              \
+  do {                                             \
+    uint64_t res;                                  \
+    if (__builtin_add_overflow(offset, len, &res)) \
+      TRAP(OOB);                                   \
+    if (UNLIKELY(res > mem->size))                 \
+      TRAP(OOB);                                   \
+  } while (0);
+#else
 #define RANGE_CHECK(mem, offset, len)               \
   if (UNLIKELY(offset + (uint64_t)len > mem->size)) \
     TRAP(OOB);
+#endif
 
 #if WASM_RT_MEMCHECK_SIGNAL_HANDLER
 #define MEMCHECK(mem, a, t)

--- a/wasm2c/examples/rot13/main.c
+++ b/wasm2c/examples/rot13/main.c
@@ -62,7 +62,7 @@ int main(int argc, char** argv) {
   /* Create a `host` module instance to store the memory and current string */
   struct Z_host_instance_t host_instance;
   /* Allocate 1 page of wasm memory (64KiB). */
-  wasm_rt_allocate_memory(&host_instance.memory, 1, 1);
+  wasm_rt_allocate_memory(&host_instance.memory, 1, 1, false);
 
   /* Construct the module instance */
   Z_rot13_instantiate(&rot13_instance, &host_instance);

--- a/wasm2c/wasm-rt.h
+++ b/wasm2c/wasm-rt.h
@@ -351,12 +351,13 @@ void* wasm_rt_exception(void);
 
 /**
  * Initialize a Memory object with an initial page size of `initial_pages` and
- * a maximum page size of `max_pages`.
+ * a maximum page size of `max_pages`, indexed with an i32 or i64.
  *
  *  ```
  *    wasm_rt_memory_t my_memory;
- *    // 1 initial page (65536 bytes), and a maximum of 2 pages.
- *    wasm_rt_allocate_memory(&my_memory, 1, 2);
+ *    // 1 initial page (65536 bytes), and a maximum of 2 pages,
+ *    // indexed with an i32
+ *    wasm_rt_allocate_memory(&my_memory, 1, 2, false);
  *  ```
  */
 void wasm_rt_allocate_memory(wasm_rt_memory_t*,


### PR DESCRIPTION
The rot13 example was failing to build after the addition of memory64 support to the wasm2c runtime API.