### PR TITLE
run-spec-wasm2c.py: move WASM2C_CFLAGS to end of compiler command line

### DIFF
--- a/test/run-spec-wasm2c.py
+++ b/test/run-spec-wasm2c.py
@@ -511,7 +511,7 @@ def main(args):
             '--enable-multi-memory': options.enable_multi_memory})
 
         options.cflags += shlex.split(os.environ.get('WASM2C_CFLAGS', ''))
-        cc = utils.Executable(options.cc, after_args=options.cflags, forward_stderr=True,
+        cc = utils.Executable(options.cc, *options.cflags, forward_stderr=True,
                               forward_stdout=False)
         cc.verbose = options.print_cmd
 

--- a/test/run-spec-wasm2c.py
+++ b/test/run-spec-wasm2c.py
@@ -440,7 +440,7 @@ def main(args):
     default_compiler = 'cc'
     if IS_WINDOWS:
         default_compiler = 'cl.exe'
-    default_compiler = os.getenv('CC', default_compiler)
+    default_compiler = os.getenv('WASM2C_CC', os.getenv('CC', default_compiler))
     parser = argparse.ArgumentParser()
     parser.add_argument('-o', '--out-dir', metavar='PATH',
                         help='output directory for files.')
@@ -511,7 +511,7 @@ def main(args):
             '--enable-multi-memory': options.enable_multi_memory})
 
         options.cflags += shlex.split(os.environ.get('WASM2C_CFLAGS', ''))
-        cc = utils.Executable(options.cc, *options.cflags, forward_stderr=True,
+        cc = utils.Executable(options.cc, after_args=options.cflags, forward_stderr=True,
                               forward_stdout=False)
         cc.verbose = options.print_cmd
 

--- a/test/utils.py
+++ b/test/utils.py
@@ -40,7 +40,7 @@ class Executable(object):
     def __init__(self, exe, *before_args, **kwargs):
         self.exe = exe
         self.before_args = list(before_args)
-        self.after_args = []
+        self.after_args = kwargs.get('after_args', [])
         self.basename = kwargs.get('basename',
                                    os.path.basename(exe)).replace('.exe', '')
         self.error_cmdline = kwargs.get('error_cmdline', True)

--- a/test/utils.py
+++ b/test/utils.py
@@ -37,10 +37,9 @@ class Error(Exception):
 
 class Executable(object):
 
-    def __init__(self, exe, *before_args, **kwargs):
+    def __init__(self, exe, *after_args, **kwargs):
         self.exe = exe
-        self.before_args = list(before_args)
-        self.after_args = kwargs.get('after_args', [])
+        self.after_args = list(after_args)
         self.basename = kwargs.get('basename',
                                    os.path.basename(exe)).replace('.exe', '')
         self.error_cmdline = kwargs.get('error_cmdline', True)
@@ -52,7 +51,7 @@ class Executable(object):
         return None if forward else subprocess.PIPE
 
     def _RunWithArgsInternal(self, *args, **kwargs):
-        cmd = [self.exe] + self.before_args + list(args) + self.after_args
+        cmd = [self.exe] + list(args) + self.after_args
         cmd_str = shlex.join(cmd)
         if self.verbose:
             print(cmd_str)


### PR DESCRIPTION
This allows CMake to override flags like -O2 by appending -O0 from the env var.

This is helpful for allowing a "debug" test of wasm2c output, since this way we
can disable optimization by adding `-O0` to the environment variable (as used in #2081).

Split out from #2081 per request.

Once we reach convergence on #2080/#2081/#2134, I think we're ready to merge #2119 (SIMD).