### PR TITLE
wasm-strip: Add `-k/--keep-section` flag to prevent sections with specific names from getting stripped

### DIFF
--- a/test/strip/keep_section.txt
+++ b/test/strip/keep_section.txt
@@ -1,0 +1,34 @@
+;;; RUN: %(gen_wasm_py)s %(in_file)s -o %(temp_file)s.wasm
+;;; RUN: %(wasm-strip)s -k one %(temp_file)s.wasm -o %(temp_file)s_stripped.wasm
+;;; RUN: %(wasm-objdump)s -h %(temp_file)s_stripped.wasm
+magic
+version
+section("one") { "Lorem ipsum dolor sit amet," }
+section(TYPE) { count[1] function params[0] results[1] i32 }
+section("two") { "consectetur adipiscing elit," }
+section(FUNCTION) { count[1] type[0] }
+section("three") { "sed do eiusmod tempor incididunt" }
+section(EXPORT) { count[1] str("main") func_kind func[0] }
+section("four") { "ut labore et dolore magna aliqua." }
+section(CODE) {
+  count[1]
+  func {
+    locals[0]
+    i32.const
+    leb_i32(-420)
+    return
+  }
+}
+section("five") { "Ut enim ad minim veniam," }
+(;; STDOUT ;;;
+
+keep_section_stripped.wasm:	file format wasm 0x1
+
+Sections:
+
+   Custom start=0x0000000a end=0x00000029 (size=0x0000001f) "one"
+     Type start=0x0000002b end=0x00000030 (size=0x00000005) count: 1
+ Function start=0x00000032 end=0x00000034 (size=0x00000002) count: 1
+   Export start=0x00000036 end=0x0000003e (size=0x00000008) count: 1
+     Code start=0x00000040 end=0x00000048 (size=0x00000008) count: 1
+;;; STDOUT ;;)

--- a/test/strip/keep_section.txt
+++ b/test/strip/keep_section.txt
@@ -1,5 +1,5 @@
 ;;; RUN: %(gen_wasm_py)s %(in_file)s -o %(temp_file)s.wasm
-;;; RUN: %(wasm-strip)s -k one %(temp_file)s.wasm -o %(temp_file)s_stripped.wasm
+;;; RUN: %(wasm-strip)s --keep-section one %(temp_file)s.wasm -o %(temp_file)s_stripped.wasm
 ;;; RUN: %(wasm-objdump)s -h %(temp_file)s_stripped.wasm
 magic
 version


### PR DESCRIPTION
## TL;DR

This PR proposes the addition of the `-k/--keep-section <SECTION NAME>` flag, that can be specified multiple times to prevent sections with a specific name from getting stripped.

Below you’ll find some context why I think this is useful. WDYT?

## Context
This PR is motivated by my desire to strip everything _but_ the `name` section. I have found that for example Rust embeds a lot of other custom sections, which makes module size analysis quite noisy. Here, for example, the percentages become almost meaningless due to the size of the custom sections:

```
$ twiggy top bindgen.wasm -n 20
 Shallow Bytes │ Shallow % │ Item
───────────────┼───────────┼────────────────────────────────────────────────────────────────────────────
        652300 ┊    36.33% ┊ custom section '.debug_str'
        404594 ┊    22.53% ┊ custom section '.debug_info'
        285988 ┊    15.93% ┊ custom section '.debug_line'
        254962 ┊    14.20% ┊ custom section '.debug_pubnames'
        176000 ┊     9.80% ┊ custom section '.debug_ranges'
          4917 ┊     0.27% ┊ dlmalloc::dlmalloc::Dlmalloc<A>::malloc::h6c2f92ea78996c54
          4181 ┊     0.23% ┊ custom section '.debug_abbrev'
          3951 ┊     0.22% ┊ "function names" subsection
          1437 ┊     0.08% ┊ dlmalloc::dlmalloc::Dlmalloc<A>::free::h9921c2b76eae2534
          1129 ┊     0.06% ┊ __rdl_realloc
           725 ┊     0.04% ┊ dlmalloc::dlmalloc::Dlmalloc<A>::dispose_chunk::ha50595baecb6fca0
           553 ┊     0.03% ┊ __externref_table_alloc
           511 ┊     0.03% ┊ dlmalloc::Dlmalloc<A>::malloc::hd8efb8c25e917a05
           387 ┊     0.02% ┊ dlmalloc::dlmalloc::Dlmalloc<A>::release_unused_segments::he6aa823ad463a901
           352 ┊     0.02% ┊ dlmalloc::dlmalloc::Dlmalloc<A>::insert_large_chunk::hdf12b63cafdb133b
           346 ┊     0.02% ┊ dlmalloc::dlmalloc::Dlmalloc<A>::unlink_large_chunk::hb9b09f5b80b6743e
           324 ┊     0.02% ┊ custom section '.debug_pubtypes'
           319 ┊     0.02% ┊ compiler_builtins::mem::memcpy::h10893781353244d9
           307 ┊     0.02% ┊ __externref_table_dealloc
           259 ┊     0.01% ┊ __externref_heap_live_count
          2134 ┊     0.12% ┊ ... and 111 more.
       1795676 ┊   100.00% ┊ Σ [131 Total Rows]
```

However, `wasm-strip` removes the `names` section by default, which means that after stripping, I have no idea what is contributing to the size:

```
$ twiggy top bindgen.wasm -n 20
 Shallow Bytes │ Shallow % │ Item
───────────────┼───────────┼─────────────────────────────────────────────────────────────────────────
          4917 ┊    37.93% ┊ code[19]
          1437 ┊    11.08% ┊ code[24]
          1129 ┊     8.71% ┊ code[29]
           725 ┊     5.59% ┊ code[20]
           553 ┊     4.27% ┊ code[7]
           511 ┊     3.94% ┊ code[18]
           387 ┊     2.99% ┊ code[23]
           352 ┊     2.72% ┊ code[22]
           346 ┊     2.67% ┊ code[21]
           319 ┊     2.46% ┊ code[66]
           307 ┊     2.37% ┊ code[8]
           259 ┊     2.00% ┊ code[10]
           157 ┊     1.21% ┊ code[25]
            67 ┊     0.52% ┊ import __wbindgen_externref_xform__::__wbindgen_externref_table_set_null
            63 ┊     0.49% ┊ import __wbindgen_externref_xform__::__wbindgen_externref_table_grow
            63 ┊     0.49% ┊ code[14]
            59 ┊     0.46% ┊ code[59]
            58 ┊     0.45% ┊ code[1]
            49 ┊     0.38% ┊ code[9]
            48 ┊     0.37% ┊ code[16]
          1158 ┊     8.93% ┊ ... and 86 more.
         12964 ┊   100.00% ┊ Σ [106 Total Rows]
```

With this PR, I can keep the `name` section around (maybe also the `producers`), making the output useful again.

```
$ ./wasm-strip -k name -k producers bindgen.wasm
$ twiggy top bindgen.wasm -n 20
 Shallow Bytes │ Shallow % │ Item
───────────────┼───────────┼────────────────────────────────────────────────────────────────────────────
          4917 ┊    28.89% ┊ dlmalloc::dlmalloc::Dlmalloc<A>::malloc::h6c2f92ea78996c54
          3951 ┊    23.21% ┊ "function names" subsection
          1437 ┊     8.44% ┊ dlmalloc::dlmalloc::Dlmalloc<A>::free::h9921c2b76eae2534
          1129 ┊     6.63% ┊ __rdl_realloc
           725 ┊     4.26% ┊ dlmalloc::dlmalloc::Dlmalloc<A>::dispose_chunk::ha50595baecb6fca0
           553 ┊     3.25% ┊ __externref_table_alloc
           511 ┊     3.00% ┊ dlmalloc::Dlmalloc<A>::malloc::hd8efb8c25e917a05
           387 ┊     2.27% ┊ dlmalloc::dlmalloc::Dlmalloc<A>::release_unused_segments::he6aa823ad463a901
           352 ┊     2.07% ┊ dlmalloc::dlmalloc::Dlmalloc<A>::insert_large_chunk::hdf12b63cafdb133b
           346 ┊     2.03% ┊ dlmalloc::dlmalloc::Dlmalloc<A>::unlink_large_chunk::hb9b09f5b80b6743e
           319 ┊     1.87% ┊ compiler_builtins::mem::memcpy::h10893781353244d9
           307 ┊     1.80% ┊ __externref_table_dealloc
           259 ┊     1.52% ┊ __externref_heap_live_count
           157 ┊     0.92% ┊ dlmalloc::dlmalloc::Dlmalloc<A>::init_top::hd19f596040fbda30
            67 ┊     0.39% ┊ import __wbindgen_externref_xform__::__wbindgen_externref_table_set_null
            67 ┊     0.39% ┊ custom section 'producers'
            63 ┊     0.37% ┊ import __wbindgen_externref_xform__::__wbindgen_externref_table_grow
            63 ┊     0.37% ┊ __wbindgen_malloc
            59 ┊     0.35% ┊ <dlmalloc::sys::System as dlmalloc::Allocator>::alloc::hacc9295cf6d00ed7
            58 ┊     0.34% ┊ __wbindgen_describe_add
          1295 ┊     7.61% ┊ ... and 91 more.
         17022 ┊   100.00% ┊ Σ [111 Total Rows]
```