### PR TITLE
wasm2c: tweak newline handling to cap blank lines between sections (NFC)

### DIFF
--- a/src/template/wasm2c.bottom.h
+++ b/src/template/wasm2c.bottom.h
@@ -1,4 +1,3 @@
-
 #ifdef __cplusplus
 }
 #endif

--- a/test/wasm2c/export-names.txt
+++ b/test/wasm2c/export-names.txt
@@ -55,9 +55,7 @@ void wasm2c_test_instantiate(w2c_test*, struct w2c_0x5Cmodule*);
 void wasm2c_test_free(w2c_test*);
 wasm_rt_func_type_t wasm2c_test_get_func_type(uint32_t param_count, uint32_t result_count, ...);
 
-
 extern const u32 wasm2c_test_min_0x5Cmodule_import0x200x2A0x2F;
-
 extern const u32 wasm2c_test_max_0x5Cmodule_import0x200x2A0x2F;
 
 /* export: '' */
@@ -848,7 +846,6 @@ static void init_instance_import(w2c_test* instance, struct w2c_0x5Cmodule* w2c_
 }
 
 const u32 wasm2c_test_min_0x5Cmodule_import0x200x2A0x2F = 0;
-
 const u32 wasm2c_test_max_0x5Cmodule_import0x200x2A0x2F = 4294967295;
 
 void wasm2c_test_instantiate(w2c_test* instance, struct w2c_0x5Cmodule* w2c_0x5Cmodule_instance) {

--- a/test/wasm2c/hello.txt
+++ b/test/wasm2c/hello.txt
@@ -72,6 +72,7 @@ wasm_rt_func_type_t wasm2c_test_get_func_type(uint32_t param_count, uint32_t res
 
 /* import: 'wasi_snapshot_preview1' 'fd_write' */
 u32 w2c_wasi__snapshot__preview1_fd_write(struct w2c_wasi__snapshot__preview1*, u32, u32, u32, u32);
+
 /* import: 'wasi_snapshot_preview1' 'proc_exit' */
 void w2c_wasi__snapshot__preview1_proc_exit(struct w2c_wasi__snapshot__preview1*, u32);
 
@@ -830,6 +831,7 @@ static void init_memories(w2c_test* instance) {
 
 static void init_data_instances(w2c_test *instance) {
 }
+
 static const wasm_elem_segment_expr_t elem_segment_exprs_w2c_test_e0[] = {
   {w2c_test_t0, (wasm_rt_function_ptr_t)w2c_wasi__snapshot__preview1_fd_write, offsetof(w2c_test, w2c_wasi__snapshot__preview1_instance)},
 };


### PR DESCRIPTION
This will hopefully make things a bit easier for us going forward -- I think we have been expending effort to try to make every "section" of the wasm2c output start with exactly one blank line, which means some bookkeeping to make sure the newline isn't printed unless the "section" is also going to print a non-blank line, etc. (And in some cases we were printing double blank lines despite our best efforts.)

This PR makes the writer compress consecutive Newlines so that extra newlines become (even more) harmless; it caps the number of completely blank lines in a row at 1 and cleans up the output slightly.