### PR TITLE
c-writer.cc: omit dummy_member in one case where it was unnecessary (NFC)

### DIFF
--- a/src/c-writer.cc
+++ b/src/c-writer.cc
@@ -1594,7 +1594,7 @@ void CWriter::WriteModuleInstance() {
 
   // C forbids an empty struct
   if (module_->globals.empty() && module_->memories.empty() &&
-      module_->tables.empty()) {
+      module_->tables.empty() && import_func_module_set_.empty()) {
     Write("char dummy_member;", Newline());
   }
 


### PR DESCRIPTION
I saw this when looking at some of test output from the `imports.wast` test. The `dummy_member` was being added to the module instance structure unnecessarily in the case of a module that imports functions but has no other elements.