### PR TITLE
Improve lexing of invalid annotations (fixes fuzz failure)

### DIFF
--- a/src/wast-lexer.cc
+++ b/src/wast-lexer.cc
@@ -70,7 +70,7 @@ Token WastLexer::GetToken() {
           }
           return BareToken(TokenType::Eof);
         } else if (MatchString("(@")) {
-          ReadReservedChars();
+          GetIdToken();
           // offset=2 to skip the "(@" prefix
           return TextToken(TokenType::LparAnn, 2);
         } else {

--- a/test/regress/bad-annotation.txt
+++ b/test/regress/bad-annotation.txt
@@ -1,0 +1,12 @@
+;;; TOOL: wat2wasm
+;;; ERROR: 1
+(@"annotation
+
+(;; STDERR ;;;
+out/test/regress/bad-annotation.txt:3:1: error: annotations not enabled: "annotation
+(@"annotation
+^^^^^^^^^^^^^
+out/test/regress/bad-annotation.txt:3:1: error: unexpected token "Invalid", expected a module field or a module.
+(@"annotation
+^^^^^^^^^^^^^
+;;; STDERR ;;)


### PR DESCRIPTION
`wat2wasm` had been crashing on some invalid annotations, even with annotations disabled (as found by oss-fuzz in issue 53935).

I missed this in #2001 when updating the parser to match the updated spec (WebAssembly/spec#1499). This PR fixes the lexer and adds a regression test.

Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=53935

N.B. With annotations enabled, `wat2wasm` seems to go into an infinite loop on this same input; will require further investigation.