### PR TITLE
Remove some old emcc link flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -487,10 +487,8 @@ function(wabt_executable)
   target_link_libraries(${EXE_NAME} ${EXE_LIBS})
 
   if (EMSCRIPTEN)
-    # build to JS for now, as node.js doesn't have code caching for wasm yet,
-    # and wasm startup times are slower
     set(EXTRA_LINK_FLAGS
-      "${EXTRA_LINK_FLAGS} -s NODERAWFS -s SINGLE_FILE -s WASM=0 -Oz -s ALLOW_MEMORY_GROWTH=1"
+      "${EXTRA_LINK_FLAGS} -sNODERAWFS -Oz -sALLOW_MEMORY_GROWTH"
     )
   endif ()
 


### PR DESCRIPTION
I don't think there is any need to use `WASM=0` these days.  If anybody really cares about node performance and this turns out still to be faster they can always add this back in.