### PR TITLE
Fix longstanding typo

### DIFF
--- a/src/tools/wasm2c.cc
+++ b/src/tools/wasm2c.cc
@@ -57,7 +57,7 @@ examples:
 )";
 
 static const std::string supported_features[] = {
-    "multi-memory", "multi-value", "sign-extend", "saturating-float-to-int",
+    "multi-memory", "multi-value", "sign-extension", "saturating-float-to-int",
     "exceptions",   "memory64"};
 
 static bool IsFeatureSupported(const std::string& feature) {


### PR DESCRIPTION
Makes it possible to wasm2c --disable-sign-extension

(Yes, this typo is our fault... sorry!)