### PR TITLE
Deprecate wasm-c-api on big-endian and fix rot13 test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -191,6 +191,7 @@ jobs:
       run: docker run --rm -t wabt cmake --build build --target run-unittests
 
     - name: C API tests
+      if: ${{ matrix.arch != 's390x' }}
       run: docker run --rm -t wabt cmake --build build --target run-c-api-tests
 
     - name: Tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -167,3 +167,31 @@ jobs:
       run: cmake --build out --target run-c-api-tests
     - name: tests
       run: cmake --build out --target run-tests
+
+  build-arch:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [s390x, i386]
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        submodules: true
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+      with:
+        platforms: ${{matrix.arch}}
+
+    - name: Build image
+      run: docker build --platform linux/${{matrix.arch}} -t wabt -f scripts/Dockerfile .
+
+    - name: Unit tests
+      run: docker run --rm -t wabt cmake --build build --target run-unittests
+
+    - name: C API tests
+      run: docker run --rm -t wabt cmake --build build --target run-c-api-tests
+
+    - name: Tests
+      run: docker run --rm -t wabt cmake --build build --target run-tests

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -5,11 +5,12 @@ WORKDIR /ws
 ARG DEBIAN_FRONTEND=noninteractive
 ENV TZ=UTC
 
-COPY . .
-
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && \
     echo $TZ > /etc/timezone && \
     apt-get update && \
-    apt-get install -y git g++ cmake ninja-build python3 file && \
-    cmake -G Ninja -S . -B build -DCMAKE_BUILD_TYPE=Release && \
+    apt-get install -y git g++ cmake ninja-build python3 file
+
+COPY . .
+
+RUN cmake -G Ninja -S . -B build -DCMAKE_BUILD_TYPE=Release && \
     cmake --build build

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,0 +1,15 @@
+FROM debian:latest
+
+WORKDIR /ws
+
+ARG DEBIAN_FRONTEND=noninteractive
+ENV TZ=UTC
+
+COPY . .
+
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && \
+    echo $TZ > /etc/timezone && \
+    apt-get update && \
+    apt-get install -y git g++ cmake ninja-build python3 file && \
+    cmake -G Ninja -S . -B build -DCMAKE_BUILD_TYPE=Release && \
+    cmake --build build

--- a/src/test-interp.cc
+++ b/src/test-interp.cc
@@ -505,8 +505,13 @@ TEST_F(InterpTest, Rot13) {
 
     EXPECT_LT(ptr + size, memory->ByteSize());
 
+#if WABT_BIG_ENDIAN
+    std::copy(string_data.rbegin(), string_data.rbegin() + size,
+              memory->UnsafeData() + memory->ByteSize() - ptr - size);
+#else
     std::copy(string_data.begin(), string_data.begin() + size,
               memory->UnsafeData() + ptr);
+#endif
 
     results[0].Set(size);
     return Result::Ok;
@@ -527,8 +532,14 @@ TEST_F(InterpTest, Rot13) {
     EXPECT_LT(ptr + size, memory->ByteSize());
 
     string_data.resize(size);
+#if WABT_BIG_ENDIAN
+    std::copy(memory->UnsafeData() + memory->ByteSize() - ptr - size,
+              memory->UnsafeData() + memory->ByteSize() - ptr,
+              string_data.rbegin());
+#else
     std::copy(memory->UnsafeData() + ptr, memory->UnsafeData() + ptr + size,
               string_data.begin());
+#endif
 
     return Result::Ok;
   };


### PR DESCRIPTION
This includes #1971 and fixes #1972

Rationale in https://github.com/WebAssembly/wabt/issues/1972#issuecomment-1782130770