### PR TITLE
decompiler.cc: passive data segments do not have offsets

### DIFF
--- a/src/decompiler.cc
+++ b/src/decompiler.cc
@@ -770,7 +770,11 @@ struct Decompiler {
 
     // Data.
     for (auto dat : mc.module.data_segments) {
-      s += cat("data ", dat->name, "(offset: ", InitExp(dat->offset), ") =");
+      s += cat("data ", dat->name,
+               dat->kind != SegmentKind::Passive
+                   ? cat("(offset: ", InitExp(dat->offset))
+                   : "(passive",
+               ") =");
       auto ds = BinaryToString(dat->data);
       if (ds.size() > target_exp_width / 2) {
         s += "\n";

--- a/test/decompile/passive-data.txt
+++ b/test/decompile/passive-data.txt
@@ -1,0 +1,9 @@
+;;; TOOL: run-wasm-decompile
+(memory 1)
+(data $p "x")
+(;; STDOUT ;;;
+memory M_a(initial: 1, max: 0);
+
+data d_a(passive) = "x";
+
+;;; STDOUT ;;)


### PR DESCRIPTION
Passive data segments do not have offsets, thus the offset ExprList is empty:
https://github.com/WebAssembly/wabt/blob/main/src/binary-reader.cc#L2812

This causes wasm-decompile to fail when trying to decompile wasm files containing passive data segments, as it tries to call InitExp on the empty offset, causing an assertion in InitExpr to fail:
https://github.com/WebAssembly/wabt/blob/main/src/decompiler.cc#L773
https://github.com/WebAssembly/wabt/blob/main/src/decompiler.cc#L688

The fix is to skip printing of the non-existent offset for passive data segments.

Fixes #2164 