### PR TITLE
Improve lexing and parsing of invalid annotations (again)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -18,6 +18,8 @@ docs/demo/third_party/codemirror/codemirror.js binary
 test/parse/bad-crlf.txt binary
 test/parse/bad-string-eof.txt binary
 test/regress/regress-31.txt binary
+test/regress/bad-annotation* binary
+test/regress/unterminated-annotation* binary
 
 # Highlight tests like .wast files when displayed on GitHub.
 test/**/*.txt linguist-language=WebAssembly

--- a/include/wabt/wast-lexer.h
+++ b/include/wabt/wast-lexer.h
@@ -95,7 +95,7 @@ class WastLexer {
   Token GetInfToken();
   Token GetNanToken();
   Token GetNameEqNumToken(std::string_view name, TokenType);
-  Token GetIdToken();
+  Token GetIdChars();
   Token GetKeywordToken();
   Token GetReservedToken();
 

--- a/src/wast-parser.cc
+++ b/src/wast-parser.cc
@@ -623,6 +623,11 @@ TokenType WastParser::Peek(size_t n) {
             indent--;
             break;
 
+          case TokenType::Eof:
+            indent = 0;
+            Error(cur.loc, "unterminated annotation");
+            break;
+
           default:
             break;
         }
@@ -1956,10 +1961,7 @@ Result WastParser::ParseCodeMetadataAnnotation(ExprList* exprs) {
   CHECK_RESULT(ParseQuotedText(&data_text, false));
   std::vector<uint8_t> data(data_text.begin(), data_text.end());
   exprs->push_back(std::make_unique<CodeMetadataExpr>(name, std::move(data)));
-  TokenType rpar = Peek();
-  WABT_USE(rpar);
-  assert(rpar == TokenType::Rpar);
-  Consume();
+  EXPECT(Rpar);
   return Result::Ok;
 }
 

--- a/test/regress/bad-annotation.txt
+++ b/test/regress/bad-annotation.txt
@@ -3,10 +3,10 @@
 (@"annotation
 
 (;; STDERR ;;;
-out/test/regress/bad-annotation.txt:3:1: error: annotations not enabled: "annotation
+out/test/regress/bad-annotation.txt:3:14: error: newline in string
 (@"annotation
-^^^^^^^^^^^^^
-out/test/regress/bad-annotation.txt:3:1: error: unexpected token "Invalid", expected a module field or a module.
-(@"annotation
-^^^^^^^^^^^^^
+             ^
+out/test/regress/bad-annotation.txt:4:1: error: newline in string
+out/test/regress/bad-annotation.txt:5:1: error: annotations not enabled: 
+out/test/regress/bad-annotation.txt:5:1: error: unexpected token "Invalid", expected a module field or a module.
 ;;; STDERR ;;)

--- a/test/regress/bad-annotation2.txt
+++ b/test/regress/bad-annotation2.txt
@@ -1,0 +1,11 @@
+;;; TOOL: wat2wasm
+;;; ERROR: 1
+(module (memory $mem 1)
+   (@_memory" (memory $mem))
+(;; STDERR ;;;
+out/test/regress/bad-annotation2.txt:4:29: error: newline in string
+   (@_memory" (memory $mem))
+                            ^
+out/test/regress/bad-annotation2.txt:5:1: error: annotations not enabled: 
+out/test/regress/bad-annotation2.txt:5:1: error: unexpected token Invalid, expected ).
+;;; STDERR ;;)

--- a/test/regress/unterminated-annotation.txt
+++ b/test/regress/unterminated-annotation.txt
@@ -1,0 +1,8 @@
+;;; TOOL: wat2wasm
+;;; ARGS: --enable-annotations --enable-code-metadata
+;;; ERROR: 1
+(module
+   (func (@metadata.code.data "this is a test"
+(;; STDERR ;;;
+out/test/regress/unterminated-annotation.txt:6:1: error: unexpected token EOF, expected ).
+;;; STDERR ;;)

--- a/test/regress/unterminated-annotation2.txt
+++ b/test/regress/unterminated-annotation2.txt
@@ -1,0 +1,9 @@
+;;; TOOL: wat2wasm
+;;; ARGS: --enable-annotations
+;;; ERROR: 1
+(module
+   (func (@hello "this is a test"
+(;; STDERR ;;;
+out/test/regress/unterminated-annotation2.txt:6:1: error: unterminated annotation
+out/test/regress/unterminated-annotation2.txt:6:1: error: unexpected token EOF, expected ).
+;;; STDERR ;;)


### PR DESCRIPTION
This adds a bounds-check to WastLexer::GetText to handle the case when the offset is earlier than token_start (e.g. because GetStringToken found a newline in the string and reset token_start to point to it).

Also revises GetIdToken -> GetIdChars to stop skipping the initial char in an annotation delimiter, which is an idchar+ but not an id token.

Also fixes the WastParser to handle EOF when reading for the end of an annotation, both for code metadata annotation and other kinds. Previously this produced an infinite loop (but only when --enable-annotations was provided).

Fixes #2165 and adds some more regression tests.

This is sort of deja vu after #2150, sigh.