### PR TITLE
Update testsuite

### DIFF
--- a/src/wast-parser.cc
+++ b/src/wast-parser.cc
@@ -2327,34 +2327,45 @@ Result WastParser::ParsePlainInstr(std::unique_ptr<Expr>* out_expr) {
       break;
     }
 
-    case TokenType::TableGet:
+    case TokenType::TableGet: {
       ErrorUnlessOpcodeEnabled(Consume());
-      CHECK_RESULT(ParsePlainInstrVar<TableGetExpr>(loc, out_expr));
+      Var table_index(0, loc);
+      ParseVarOpt(&table_index, table_index);
+      out_expr->reset(new TableGetExpr(table_index, loc));
       break;
+    }
 
-    case TokenType::TableSet:
+    case TokenType::TableSet: {
       ErrorUnlessOpcodeEnabled(Consume());
-      // TODO: Table index.
-      CHECK_RESULT(ParsePlainInstrVar<TableSetExpr>(loc, out_expr));
+      Var table_index(0, loc);
+      ParseVarOpt(&table_index, table_index);
+      out_expr->reset(new TableSetExpr(table_index, loc));
       break;
+    }
 
-    case TokenType::TableGrow:
+    case TokenType::TableGrow: {
       ErrorUnlessOpcodeEnabled(Consume());
-      // TODO: Table index.
-      CHECK_RESULT(ParsePlainInstrVar<TableGrowExpr>(loc, out_expr));
+      Var table_index(0, loc);
+      ParseVarOpt(&table_index, table_index);
+      out_expr->reset(new TableGrowExpr(table_index, loc));
       break;
+    }
 
-    case TokenType::TableSize:
+    case TokenType::TableSize: {
       ErrorUnlessOpcodeEnabled(Consume());
-      // TODO: Table index.
-      CHECK_RESULT(ParsePlainInstrVar<TableSizeExpr>(loc, out_expr));
+      Var table_index(0, loc);
+      ParseVarOpt(&table_index, table_index);
+      out_expr->reset(new TableSizeExpr(table_index, loc));
       break;
+    }
 
-    case TokenType::TableFill:
+    case TokenType::TableFill: {
       ErrorUnlessOpcodeEnabled(Consume());
-      // TODO: Table index.
-      CHECK_RESULT(ParsePlainInstrVar<TableFillExpr>(loc, out_expr));
+      Var table_index(0, loc);
+      ParseVarOpt(&table_index, table_index);
+      out_expr->reset(new TableFillExpr(table_index, loc));
       break;
+    }
 
     case TokenType::RefFunc:
       ErrorUnlessOpcodeEnabled(Consume());

--- a/test/spec/binary.txt
+++ b/test/spec/binary.txt
@@ -58,7 +58,7 @@ out/test/spec/binary.wast:44: assert_malformed passed:
 out/test/spec/binary.wast:45: assert_malformed passed:
   0000008: error: bad wasm file version: 0x1000000 (expected 0x1)
 out/test/spec/binary.wast:48: assert_malformed passed:
-  000000a: error: invalid section code: 13
+  000000a: error: invalid section code: 14
 out/test/spec/binary.wast:49: assert_malformed passed:
   000000a: error: invalid section code: 127
 out/test/spec/binary.wast:50: assert_malformed passed:

--- a/test/spec/call_indirect.txt
+++ b/test/spec/call_indirect.txt
@@ -150,5 +150,5 @@ out/test/spec/call_indirect.wast:1004: assert_invalid passed:
 out/test/spec/call_indirect.wast:1015: assert_invalid passed:
   out/test/spec/call_indirect/call_indirect.34.wasm:0000018: error: function variable out of range: 0 (max 0)
   0000018: error: OnElemSegmentElemExpr_RefFunc callback failed
-169/169 tests passed.
+170/170 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/elem.txt
+++ b/test/spec/elem.txt
@@ -1,88 +1,88 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/elem.wast
 (;; STDOUT ;;;
-out/test/spec/elem.wast:152: assert_invalid passed:
-  out/test/spec/elem/elem.9.wasm:0000026: error: initializer expression can only reference an imported global
-  0000026: error: OnGlobalGetExpr callback failed
-out/test/spec/elem.wast:156: assert_invalid passed:
+out/test/spec/elem.wast:171: assert_invalid passed:
   out/test/spec/elem/elem.10.wasm:0000026: error: initializer expression can only reference an imported global
   0000026: error: OnGlobalGetExpr callback failed
-out/test/spec/elem.wast:331: assert_trap passed: out of bounds table access: table.init out of bounds
-out/test/spec/elem.wast:341: assert_trap passed: out of bounds table access: table.init out of bounds
-out/test/spec/elem.wast:346: assert_invalid passed:
-  out/test/spec/elem/elem.35.wasm:0000016: error: table variable out of range: 0 (max 0)
+out/test/spec/elem.wast:175: assert_invalid passed:
+  out/test/spec/elem/elem.11.wasm:0000026: error: initializer expression can only reference an imported global
+  0000026: error: OnGlobalGetExpr callback failed
+out/test/spec/elem.wast:350: assert_trap passed: out of bounds table access: table.init out of bounds
+out/test/spec/elem.wast:360: assert_trap passed: out of bounds table access: table.init out of bounds
+out/test/spec/elem.wast:365: assert_invalid passed:
+  out/test/spec/elem/elem.36.wasm:0000016: error: table variable out of range: 0 (max 0)
   0000016: error: BeginElemSegment callback failed
-out/test/spec/elem.wast:356: assert_invalid passed:
-  out/test/spec/elem/elem.36.wasm:0000014: error: type mismatch in initializer expression, expected [i32] but got [i64]
+out/test/spec/elem.wast:375: assert_invalid passed:
+  out/test/spec/elem/elem.37.wasm:0000014: error: type mismatch in initializer expression, expected [i32] but got [i64]
   0000015: error: EndElemSegmentInitExpr callback failed
-out/test/spec/elem.wast:364: assert_invalid passed:
-  out/test/spec/elem/elem.37.wasm:0000014: error: type mismatch in initializer expression, expected [i32] but got [funcref]
+out/test/spec/elem.wast:383: assert_invalid passed:
+  out/test/spec/elem/elem.38.wasm:0000014: error: type mismatch in initializer expression, expected [i32] but got [funcref]
   0000015: error: EndElemSegmentInitExpr callback failed
-out/test/spec/elem.wast:372: assert_invalid passed:
-  out/test/spec/elem/elem.38.wasm:0000012: error: type mismatch in initializer expression, expected [i32] but got []
+out/test/spec/elem.wast:391: assert_invalid passed:
+  out/test/spec/elem/elem.39.wasm:0000012: error: type mismatch in initializer expression, expected [i32] but got []
   0000013: error: EndElemSegmentInitExpr callback failed
-out/test/spec/elem.wast:380: assert_invalid passed:
-  out/test/spec/elem/elem.39.wasm:0000016: error: type mismatch at end of initializer expression, expected [] but got [i32]
+out/test/spec/elem.wast:399: assert_invalid passed:
+  out/test/spec/elem/elem.40.wasm:0000016: error: type mismatch at end of initializer expression, expected [] but got [i32]
   0000017: error: EndElemSegmentInitExpr callback failed
-out/test/spec/elem.wast:388: assert_invalid passed:
-  out/test/spec/elem/elem.40.wasm:000002c: error: type mismatch at end of initializer expression, expected [] but got [i32]
-  000002d: error: EndElemSegmentInitExpr callback failed
-out/test/spec/elem.wast:397: assert_invalid passed:
+out/test/spec/elem.wast:407: assert_invalid passed:
   out/test/spec/elem/elem.41.wasm:000002c: error: type mismatch at end of initializer expression, expected [] but got [i32]
   000002d: error: EndElemSegmentInitExpr callback failed
-out/test/spec/elem.wast:407: assert_invalid passed:
-  out/test/spec/elem/elem.42.wasm:0000015: error: invalid initializer: instruction not valid in initializer expression: i32.ctz
+out/test/spec/elem.wast:416: assert_invalid passed:
+  out/test/spec/elem/elem.42.wasm:000002c: error: type mismatch at end of initializer expression, expected [] but got [i32]
+  000002d: error: EndElemSegmentInitExpr callback failed
+out/test/spec/elem.wast:426: assert_invalid passed:
+  out/test/spec/elem/elem.43.wasm:0000015: error: invalid initializer: instruction not valid in initializer expression: i32.ctz
   0000015: error: OnUnaryExpr callback failed
-out/test/spec/elem.wast:415: assert_invalid passed:
-  out/test/spec/elem/elem.43.wasm:0000013: error: invalid initializer: instruction not valid in initializer expression: nop
-  0000013: error: OnNopExpr callback failed
-out/test/spec/elem.wast:423: assert_invalid passed:
+out/test/spec/elem.wast:434: assert_invalid passed:
   out/test/spec/elem/elem.44.wasm:0000013: error: invalid initializer: instruction not valid in initializer expression: nop
   0000013: error: OnNopExpr callback failed
-out/test/spec/elem.wast:431: assert_invalid passed:
-  out/test/spec/elem/elem.45.wasm:0000015: error: invalid initializer: instruction not valid in initializer expression: nop
+out/test/spec/elem.wast:442: assert_invalid passed:
+  out/test/spec/elem/elem.45.wasm:0000013: error: invalid initializer: instruction not valid in initializer expression: nop
+  0000013: error: OnNopExpr callback failed
+out/test/spec/elem.wast:450: assert_invalid passed:
+  out/test/spec/elem/elem.46.wasm:0000015: error: invalid initializer: instruction not valid in initializer expression: nop
   0000015: error: OnNopExpr callback failed
-out/test/spec/elem.wast:439: assert_invalid passed:
-  out/test/spec/elem/elem.46.wasm:0000021: error: initializer expression cannot reference a mutable global
+out/test/spec/elem.wast:458: assert_invalid passed:
+  out/test/spec/elem/elem.47.wasm:0000021: error: initializer expression cannot reference a mutable global
   0000021: error: OnGlobalGetExpr callback failed
-out/test/spec/elem.wast:448: assert_invalid passed:
-  out/test/spec/elem/elem.47.wasm:0000014: error: global variable out of range: 0 (max 0)
+out/test/spec/elem.wast:467: assert_invalid passed:
+  out/test/spec/elem/elem.48.wasm:0000014: error: global variable out of range: 0 (max 0)
   0000014: error: OnGlobalGetExpr callback failed
-out/test/spec/elem.wast:456: assert_invalid passed:
-  out/test/spec/elem/elem.48.wasm:000002a: error: global variable out of range: 1 (max 1)
+out/test/spec/elem.wast:475: assert_invalid passed:
+  out/test/spec/elem/elem.49.wasm:000002a: error: global variable out of range: 1 (max 1)
   000002a: error: OnGlobalGetExpr callback failed
-out/test/spec/elem.wast:465: assert_invalid passed:
-  out/test/spec/elem/elem.49.wasm:000002e: error: initializer expression cannot reference a mutable global
-  000002e: error: OnGlobalGetExpr callback failed
-out/test/spec/elem.wast:476: assert_invalid passed:
-  out/test/spec/elem/elem.50.wasm:0000018: error: type mismatch at elem expression. got externref, expected funcref
-  0000018: error: OnElemSegmentElemExpr_RefNull callback failed
 out/test/spec/elem.wast:484: assert_invalid passed:
+  out/test/spec/elem/elem.50.wasm:000002e: error: initializer expression cannot reference a mutable global
+  000002e: error: OnGlobalGetExpr callback failed
+out/test/spec/elem.wast:495: assert_invalid passed:
+  out/test/spec/elem/elem.51.wasm:0000018: error: type mismatch at elem expression. got externref, expected funcref
+  0000018: error: OnElemSegmentElemExpr_RefNull callback failed
+out/test/spec/elem.wast:503: assert_invalid passed:
   0000019: error: expected END opcode after element expression
-out/test/spec/elem.wast:492: assert_invalid passed:
+out/test/spec/elem.wast:511: assert_invalid passed:
   0000017: error: expected ref.null or ref.func in passive element segment
   0000018: error: expected END opcode after element expression
-out/test/spec/elem.wast:500: assert_invalid passed:
+out/test/spec/elem.wast:519: assert_invalid passed:
   0000017: error: expected ref.null or ref.func in passive element segment
   0000018: error: expected END opcode after element expression
-out/test/spec/elem.wast:508: assert_invalid passed:
+out/test/spec/elem.wast:527: assert_invalid passed:
   0000022: error: expected ref.null or ref.func in passive element segment
   0000023: error: expected END opcode after element expression
-out/test/spec/elem.wast:517: assert_invalid passed:
+out/test/spec/elem.wast:536: assert_invalid passed:
   0000017: error: expected ref.null or ref.func in passive element segment
   0000018: error: expected END opcode after element expression
-out/test/spec/elem.wast:574: assert_trap passed: uninitialized table element
-out/test/spec/elem.wast:607: assert_invalid passed:
-  out/test/spec/elem/elem.61.wasm:000001f: error: type mismatch at elem segment. got externref, expected funcref
-  000001f: error: OnElemSegmentElemType callback failed
-out/test/spec/elem.wast:612: assert_invalid passed:
-  out/test/spec/elem/elem.62.wasm:0000017: error: type mismatch at elem segment. got funcref, expected externref
-  0000017: error: OnElemSegmentElemType callback failed
-out/test/spec/elem.wast:617: assert_invalid passed:
-  out/test/spec/elem/elem.63.wasm:0000032: error: type mismatch at table.init. got funcref, expected externref
-  0000032: error: OnTableInitExpr callback failed
+out/test/spec/elem.wast:593: assert_trap passed: uninitialized table element
 out/test/spec/elem.wast:626: assert_invalid passed:
-  out/test/spec/elem/elem.64.wasm:0000030: error: type mismatch at table.init. got externref, expected funcref
+  out/test/spec/elem/elem.62.wasm:000001f: error: type mismatch at elem segment. got externref, expected funcref
+  000001f: error: OnElemSegmentElemType callback failed
+out/test/spec/elem.wast:631: assert_invalid passed:
+  out/test/spec/elem/elem.63.wasm:0000017: error: type mismatch at elem segment. got funcref, expected externref
+  0000017: error: OnElemSegmentElemType callback failed
+out/test/spec/elem.wast:636: assert_invalid passed:
+  out/test/spec/elem/elem.64.wasm:0000032: error: type mismatch at table.init. got funcref, expected externref
+  0000032: error: OnTableInitExpr callback failed
+out/test/spec/elem.wast:645: assert_invalid passed:
+  out/test/spec/elem/elem.65.wasm:0000030: error: type mismatch at table.init. got externref, expected funcref
   0000030: error: OnTableInitExpr callback failed
-90/90 tests passed.
+93/93 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/extended-const/elem.txt
+++ b/test/spec/extended-const/elem.txt
@@ -2,88 +2,88 @@
 ;;; STDIN_FILE: third_party/testsuite/proposals/extended-const/elem.wast
 ;;; ARGS*: --enable-extended-const
 (;; STDOUT ;;;
-out/test/spec/extended-const/elem.wast:152: assert_invalid passed:
-  out/test/spec/extended-const/elem/elem.9.wasm:0000026: error: initializer expression can only reference an imported global
-  0000026: error: OnGlobalGetExpr callback failed
-out/test/spec/extended-const/elem.wast:156: assert_invalid passed:
+out/test/spec/extended-const/elem.wast:171: assert_invalid passed:
   out/test/spec/extended-const/elem/elem.10.wasm:0000026: error: initializer expression can only reference an imported global
   0000026: error: OnGlobalGetExpr callback failed
-out/test/spec/extended-const/elem.wast:331: assert_trap passed: out of bounds table access: table.init out of bounds
-out/test/spec/extended-const/elem.wast:341: assert_trap passed: out of bounds table access: table.init out of bounds
-out/test/spec/extended-const/elem.wast:346: assert_invalid passed:
-  out/test/spec/extended-const/elem/elem.35.wasm:0000016: error: table variable out of range: 0 (max 0)
+out/test/spec/extended-const/elem.wast:175: assert_invalid passed:
+  out/test/spec/extended-const/elem/elem.11.wasm:0000026: error: initializer expression can only reference an imported global
+  0000026: error: OnGlobalGetExpr callback failed
+out/test/spec/extended-const/elem.wast:350: assert_trap passed: out of bounds table access: table.init out of bounds
+out/test/spec/extended-const/elem.wast:360: assert_trap passed: out of bounds table access: table.init out of bounds
+out/test/spec/extended-const/elem.wast:365: assert_invalid passed:
+  out/test/spec/extended-const/elem/elem.36.wasm:0000016: error: table variable out of range: 0 (max 0)
   0000016: error: BeginElemSegment callback failed
-out/test/spec/extended-const/elem.wast:356: assert_invalid passed:
-  out/test/spec/extended-const/elem/elem.36.wasm:0000014: error: type mismatch in initializer expression, expected [i32] but got [i64]
+out/test/spec/extended-const/elem.wast:375: assert_invalid passed:
+  out/test/spec/extended-const/elem/elem.37.wasm:0000014: error: type mismatch in initializer expression, expected [i32] but got [i64]
   0000015: error: EndElemSegmentInitExpr callback failed
-out/test/spec/extended-const/elem.wast:364: assert_invalid passed:
-  out/test/spec/extended-const/elem/elem.37.wasm:0000014: error: type mismatch in initializer expression, expected [i32] but got [funcref]
+out/test/spec/extended-const/elem.wast:383: assert_invalid passed:
+  out/test/spec/extended-const/elem/elem.38.wasm:0000014: error: type mismatch in initializer expression, expected [i32] but got [funcref]
   0000015: error: EndElemSegmentInitExpr callback failed
-out/test/spec/extended-const/elem.wast:372: assert_invalid passed:
-  out/test/spec/extended-const/elem/elem.38.wasm:0000012: error: type mismatch in initializer expression, expected [i32] but got []
+out/test/spec/extended-const/elem.wast:391: assert_invalid passed:
+  out/test/spec/extended-const/elem/elem.39.wasm:0000012: error: type mismatch in initializer expression, expected [i32] but got []
   0000013: error: EndElemSegmentInitExpr callback failed
-out/test/spec/extended-const/elem.wast:380: assert_invalid passed:
-  out/test/spec/extended-const/elem/elem.39.wasm:0000016: error: type mismatch at end of initializer expression, expected [] but got [i32]
+out/test/spec/extended-const/elem.wast:399: assert_invalid passed:
+  out/test/spec/extended-const/elem/elem.40.wasm:0000016: error: type mismatch at end of initializer expression, expected [] but got [i32]
   0000017: error: EndElemSegmentInitExpr callback failed
-out/test/spec/extended-const/elem.wast:388: assert_invalid passed:
-  out/test/spec/extended-const/elem/elem.40.wasm:000002c: error: type mismatch at end of initializer expression, expected [] but got [i32]
-  000002d: error: EndElemSegmentInitExpr callback failed
-out/test/spec/extended-const/elem.wast:397: assert_invalid passed:
+out/test/spec/extended-const/elem.wast:407: assert_invalid passed:
   out/test/spec/extended-const/elem/elem.41.wasm:000002c: error: type mismatch at end of initializer expression, expected [] but got [i32]
   000002d: error: EndElemSegmentInitExpr callback failed
-out/test/spec/extended-const/elem.wast:407: assert_invalid passed:
-  out/test/spec/extended-const/elem/elem.42.wasm:0000015: error: invalid initializer: instruction not valid in initializer expression: i32.ctz
+out/test/spec/extended-const/elem.wast:416: assert_invalid passed:
+  out/test/spec/extended-const/elem/elem.42.wasm:000002c: error: type mismatch at end of initializer expression, expected [] but got [i32]
+  000002d: error: EndElemSegmentInitExpr callback failed
+out/test/spec/extended-const/elem.wast:426: assert_invalid passed:
+  out/test/spec/extended-const/elem/elem.43.wasm:0000015: error: invalid initializer: instruction not valid in initializer expression: i32.ctz
   0000015: error: OnUnaryExpr callback failed
-out/test/spec/extended-const/elem.wast:415: assert_invalid passed:
-  out/test/spec/extended-const/elem/elem.43.wasm:0000013: error: invalid initializer: instruction not valid in initializer expression: nop
-  0000013: error: OnNopExpr callback failed
-out/test/spec/extended-const/elem.wast:423: assert_invalid passed:
+out/test/spec/extended-const/elem.wast:434: assert_invalid passed:
   out/test/spec/extended-const/elem/elem.44.wasm:0000013: error: invalid initializer: instruction not valid in initializer expression: nop
   0000013: error: OnNopExpr callback failed
-out/test/spec/extended-const/elem.wast:431: assert_invalid passed:
-  out/test/spec/extended-const/elem/elem.45.wasm:0000015: error: invalid initializer: instruction not valid in initializer expression: nop
+out/test/spec/extended-const/elem.wast:442: assert_invalid passed:
+  out/test/spec/extended-const/elem/elem.45.wasm:0000013: error: invalid initializer: instruction not valid in initializer expression: nop
+  0000013: error: OnNopExpr callback failed
+out/test/spec/extended-const/elem.wast:450: assert_invalid passed:
+  out/test/spec/extended-const/elem/elem.46.wasm:0000015: error: invalid initializer: instruction not valid in initializer expression: nop
   0000015: error: OnNopExpr callback failed
-out/test/spec/extended-const/elem.wast:439: assert_invalid passed:
-  out/test/spec/extended-const/elem/elem.46.wasm:0000021: error: initializer expression cannot reference a mutable global
+out/test/spec/extended-const/elem.wast:458: assert_invalid passed:
+  out/test/spec/extended-const/elem/elem.47.wasm:0000021: error: initializer expression cannot reference a mutable global
   0000021: error: OnGlobalGetExpr callback failed
-out/test/spec/extended-const/elem.wast:448: assert_invalid passed:
-  out/test/spec/extended-const/elem/elem.47.wasm:0000014: error: global variable out of range: 0 (max 0)
+out/test/spec/extended-const/elem.wast:467: assert_invalid passed:
+  out/test/spec/extended-const/elem/elem.48.wasm:0000014: error: global variable out of range: 0 (max 0)
   0000014: error: OnGlobalGetExpr callback failed
-out/test/spec/extended-const/elem.wast:456: assert_invalid passed:
-  out/test/spec/extended-const/elem/elem.48.wasm:000002a: error: global variable out of range: 1 (max 1)
+out/test/spec/extended-const/elem.wast:475: assert_invalid passed:
+  out/test/spec/extended-const/elem/elem.49.wasm:000002a: error: global variable out of range: 1 (max 1)
   000002a: error: OnGlobalGetExpr callback failed
-out/test/spec/extended-const/elem.wast:465: assert_invalid passed:
-  out/test/spec/extended-const/elem/elem.49.wasm:000002e: error: initializer expression cannot reference a mutable global
-  000002e: error: OnGlobalGetExpr callback failed
-out/test/spec/extended-const/elem.wast:476: assert_invalid passed:
-  out/test/spec/extended-const/elem/elem.50.wasm:0000018: error: type mismatch at elem expression. got externref, expected funcref
-  0000018: error: OnElemSegmentElemExpr_RefNull callback failed
 out/test/spec/extended-const/elem.wast:484: assert_invalid passed:
+  out/test/spec/extended-const/elem/elem.50.wasm:000002e: error: initializer expression cannot reference a mutable global
+  000002e: error: OnGlobalGetExpr callback failed
+out/test/spec/extended-const/elem.wast:495: assert_invalid passed:
+  out/test/spec/extended-const/elem/elem.51.wasm:0000018: error: type mismatch at elem expression. got externref, expected funcref
+  0000018: error: OnElemSegmentElemExpr_RefNull callback failed
+out/test/spec/extended-const/elem.wast:503: assert_invalid passed:
   0000019: error: expected END opcode after element expression
-out/test/spec/extended-const/elem.wast:492: assert_invalid passed:
+out/test/spec/extended-const/elem.wast:511: assert_invalid passed:
   0000017: error: expected ref.null or ref.func in passive element segment
   0000018: error: expected END opcode after element expression
-out/test/spec/extended-const/elem.wast:500: assert_invalid passed:
+out/test/spec/extended-const/elem.wast:519: assert_invalid passed:
   0000017: error: expected ref.null or ref.func in passive element segment
   0000018: error: expected END opcode after element expression
-out/test/spec/extended-const/elem.wast:508: assert_invalid passed:
+out/test/spec/extended-const/elem.wast:527: assert_invalid passed:
   0000022: error: expected ref.null or ref.func in passive element segment
   0000023: error: expected END opcode after element expression
-out/test/spec/extended-const/elem.wast:517: assert_invalid passed:
+out/test/spec/extended-const/elem.wast:536: assert_invalid passed:
   0000022: error: expected ref.null or ref.func in passive element segment
   0000023: error: expected END opcode after element expression
-out/test/spec/extended-const/elem.wast:575: assert_trap passed: uninitialized table element
-out/test/spec/extended-const/elem.wast:608: assert_invalid passed:
-  out/test/spec/extended-const/elem/elem.61.wasm:000001f: error: type mismatch at elem segment. got externref, expected funcref
-  000001f: error: OnElemSegmentElemType callback failed
-out/test/spec/extended-const/elem.wast:613: assert_invalid passed:
-  out/test/spec/extended-const/elem/elem.62.wasm:0000017: error: type mismatch at elem segment. got funcref, expected externref
-  0000017: error: OnElemSegmentElemType callback failed
-out/test/spec/extended-const/elem.wast:618: assert_invalid passed:
-  out/test/spec/extended-const/elem/elem.63.wasm:0000032: error: type mismatch at table.init. got funcref, expected externref
-  0000032: error: OnTableInitExpr callback failed
+out/test/spec/extended-const/elem.wast:594: assert_trap passed: uninitialized table element
 out/test/spec/extended-const/elem.wast:627: assert_invalid passed:
-  out/test/spec/extended-const/elem/elem.64.wasm:0000030: error: type mismatch at table.init. got externref, expected funcref
+  out/test/spec/extended-const/elem/elem.62.wasm:000001f: error: type mismatch at elem segment. got externref, expected funcref
+  000001f: error: OnElemSegmentElemType callback failed
+out/test/spec/extended-const/elem.wast:632: assert_invalid passed:
+  out/test/spec/extended-const/elem/elem.63.wasm:0000017: error: type mismatch at elem segment. got funcref, expected externref
+  0000017: error: OnElemSegmentElemType callback failed
+out/test/spec/extended-const/elem.wast:637: assert_invalid passed:
+  out/test/spec/extended-const/elem/elem.64.wasm:0000032: error: type mismatch at table.init. got funcref, expected externref
+  0000032: error: OnTableInitExpr callback failed
+out/test/spec/extended-const/elem.wast:646: assert_invalid passed:
+  out/test/spec/extended-const/elem/elem.65.wasm:0000030: error: type mismatch at table.init. got externref, expected funcref
   0000030: error: OnTableInitExpr callback failed
-90/90 tests passed.
+93/93 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/multi-memory/binary.txt
+++ b/test/spec/multi-memory/binary.txt
@@ -59,7 +59,7 @@ out/test/spec/multi-memory/binary.wast:44: assert_malformed passed:
 out/test/spec/multi-memory/binary.wast:45: assert_malformed passed:
   0000008: error: bad wasm file version: 0x1000000 (expected 0x1)
 out/test/spec/multi-memory/binary.wast:48: assert_malformed passed:
-  000000a: error: invalid section code: 13
+  000000a: error: invalid section code: 14
 out/test/spec/multi-memory/binary.wast:49: assert_malformed passed:
   000000a: error: invalid section code: 127
 out/test/spec/multi-memory/binary.wast:50: assert_malformed passed:

--- a/test/spec/multi-memory/memory-multi.txt
+++ b/test/spec/multi-memory/memory-multi.txt
@@ -2,5 +2,5 @@
 ;;; STDIN_FILE: third_party/testsuite/proposals/multi-memory/memory-multi.wast
 ;;; ARGS*: --enable-multi-memory
 (;; STDOUT ;;;
-7/7 tests passed.
+6/6 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/relaxed-simd/i16x8_relaxed_q15mulr_s.txt
+++ b/test/spec/relaxed-simd/i16x8_relaxed_q15mulr_s.txt
@@ -2,5 +2,5 @@
 ;;; STDIN_FILE: third_party/testsuite/proposals/relaxed-simd/i16x8_relaxed_q15mulr_s.wast
 ;;; ARGS*: --enable-relaxed-simd
 (;; STDOUT ;;;
-2/2 tests passed.
+3/3 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/relaxed-simd/i32x4_relaxed_trunc.txt
+++ b/test/spec/relaxed-simd/i32x4_relaxed_trunc.txt
@@ -2,5 +2,5 @@
 ;;; STDIN_FILE: third_party/testsuite/proposals/relaxed-simd/i32x4_relaxed_trunc.wast
 ;;; ARGS*: --enable-relaxed-simd
 (;; STDOUT ;;;
-9/9 tests passed.
+17/17 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/relaxed-simd/i8x16_relaxed_swizzle.txt
+++ b/test/spec/relaxed-simd/i8x16_relaxed_swizzle.txt
@@ -2,5 +2,5 @@
 ;;; STDIN_FILE: third_party/testsuite/proposals/relaxed-simd/i8x16_relaxed_swizzle.wast
 ;;; ARGS*: --enable-relaxed-simd
 (;; STDOUT ;;;
-4/4 tests passed.
+6/6 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/relaxed-simd/relaxed_laneselect.txt
+++ b/test/spec/relaxed-simd/relaxed_laneselect.txt
@@ -2,5 +2,5 @@
 ;;; STDIN_FILE: third_party/testsuite/proposals/relaxed-simd/relaxed_laneselect.wast
 ;;; ARGS*: --enable-relaxed-simd
 (;; STDOUT ;;;
-6/6 tests passed.
+11/11 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/relaxed-simd/relaxed_madd_nmadd.txt
+++ b/test/spec/relaxed-simd/relaxed_madd_nmadd.txt
@@ -2,5 +2,5 @@
 ;;; STDIN_FILE: third_party/testsuite/proposals/relaxed-simd/relaxed_madd_nmadd.wast
 ;;; ARGS*: --enable-relaxed-simd
 (;; STDOUT ;;;
-7/7 tests passed.
+17/17 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/relaxed-simd/relaxed_min_max.txt
+++ b/test/spec/relaxed-simd/relaxed_min_max.txt
@@ -2,5 +2,5 @@
 ;;; STDIN_FILE: third_party/testsuite/proposals/relaxed-simd/relaxed_min_max.wast
 ;;; ARGS*: --enable-relaxed-simd
 (;; STDOUT ;;;
-13/13 tests passed.
+25/25 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/select.txt
+++ b/test/spec/select.txt
@@ -87,5 +87,5 @@ out/test/spec/select.wast:504: assert_invalid passed:
 out/test/spec/select.wast:511: assert_invalid passed:
   out/test/spec/select/select.28.wasm:0000020: error: type mismatch in implicit return, expected [i32] but got [i64]
   0000020: error: EndFunctionBody callback failed
-147/147 tests passed.
+148/148 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/table_fill.txt
+++ b/test/spec/table_fill.txt
@@ -1,34 +1,34 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/table_fill.wast
 (;; STDOUT ;;;
-out/test/spec/table_fill.wast:50: assert_trap passed: out of bounds table access: table.fill out of bounds
-out/test/spec/table_fill.wast:58: assert_trap passed: out of bounds table access: table.fill out of bounds
-out/test/spec/table_fill.wast:63: assert_trap passed: out of bounds table access: table.fill out of bounds
-out/test/spec/table_fill.wast:71: assert_invalid passed:
+out/test/spec/table_fill.wast:54: assert_trap passed: out of bounds table access: table.fill out of bounds
+out/test/spec/table_fill.wast:62: assert_trap passed: out of bounds table access: table.fill out of bounds
+out/test/spec/table_fill.wast:67: assert_trap passed: out of bounds table access: table.fill out of bounds
+out/test/spec/table_fill.wast:75: assert_invalid passed:
   out/test/spec/table_fill/table_fill.1.wasm:0000020: error: type mismatch in table.fill, expected [i32, externref, i32] but got []
   0000020: error: OnTableFillExpr callback failed
-out/test/spec/table_fill.wast:80: assert_invalid passed:
+out/test/spec/table_fill.wast:84: assert_invalid passed:
   out/test/spec/table_fill/table_fill.2.wasm:0000024: error: type mismatch in table.fill, expected [i32, externref, i32] but got [externref, i32]
   0000024: error: OnTableFillExpr callback failed
-out/test/spec/table_fill.wast:89: assert_invalid passed:
+out/test/spec/table_fill.wast:93: assert_invalid passed:
   out/test/spec/table_fill/table_fill.3.wasm:0000024: error: type mismatch in table.fill, expected [i32, externref, i32] but got [i32, i32]
   0000024: error: OnTableFillExpr callback failed
-out/test/spec/table_fill.wast:98: assert_invalid passed:
+out/test/spec/table_fill.wast:102: assert_invalid passed:
   out/test/spec/table_fill/table_fill.4.wasm:0000024: error: type mismatch in table.fill, expected [i32, externref, i32] but got [i32, externref]
   0000024: error: OnTableFillExpr callback failed
-out/test/spec/table_fill.wast:107: assert_invalid passed:
+out/test/spec/table_fill.wast:111: assert_invalid passed:
   out/test/spec/table_fill/table_fill.5.wasm:0000029: error: type mismatch in table.fill, expected [i32, externref, i32] but got [f32, externref, i32]
   0000029: error: OnTableFillExpr callback failed
-out/test/spec/table_fill.wast:116: assert_invalid passed:
+out/test/spec/table_fill.wast:120: assert_invalid passed:
   out/test/spec/table_fill/table_fill.6.wasm:0000027: error: type mismatch in table.fill, expected [i32, funcref, i32] but got [i32, externref, i32]
   0000027: error: OnTableFillExpr callback failed
-out/test/spec/table_fill.wast:125: assert_invalid passed:
+out/test/spec/table_fill.wast:129: assert_invalid passed:
   out/test/spec/table_fill/table_fill.7.wasm:0000029: error: type mismatch in table.fill, expected [i32, externref, i32] but got [i32, externref, f32]
   0000029: error: OnTableFillExpr callback failed
-out/test/spec/table_fill.wast:135: assert_invalid passed:
+out/test/spec/table_fill.wast:139: assert_invalid passed:
   out/test/spec/table_fill/table_fill.8.wasm:000002a: error: type mismatch in table.fill, expected [i32, funcref, i32] but got [i32, externref, i32]
   000002a: error: OnTableFillExpr callback failed
-out/test/spec/table_fill.wast:146: assert_invalid passed:
+out/test/spec/table_fill.wast:150: assert_invalid passed:
   out/test/spec/table_fill/table_fill.9.wasm:0000028: error: type mismatch in implicit return, expected [i32] but got []
   0000028: error: EndFunctionBody callback failed
 45/45 tests passed.

--- a/test/spec/table_grow.txt
+++ b/test/spec/table_grow.txt
@@ -1,31 +1,31 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/table_grow.wast
 (;; STDOUT ;;;
-out/test/spec/table_grow.wast:14: assert_trap passed: out of bounds table access: table.set at 0 >= max value 0
-out/test/spec/table_grow.wast:15: assert_trap passed: out of bounds table access: table.get at 0 >= max value 0
-out/test/spec/table_grow.wast:22: assert_trap passed: out of bounds table access: table.set at 1 >= max value 1
-out/test/spec/table_grow.wast:23: assert_trap passed: out of bounds table access: table.get at 1 >= max value 1
-out/test/spec/table_grow.wast:34: assert_trap passed: out of bounds table access: table.set at 5 >= max value 5
-out/test/spec/table_grow.wast:35: assert_trap passed: out of bounds table access: table.get at 5 >= max value 5
-out/test/spec/table_grow.wast:111: assert_invalid passed:
+out/test/spec/table_grow.wast:17: assert_trap passed: out of bounds table access: table.set at 0 >= max value 0
+out/test/spec/table_grow.wast:18: assert_trap passed: out of bounds table access: table.get at 0 >= max value 0
+out/test/spec/table_grow.wast:25: assert_trap passed: out of bounds table access: table.set at 1 >= max value 1
+out/test/spec/table_grow.wast:26: assert_trap passed: out of bounds table access: table.get at 1 >= max value 1
+out/test/spec/table_grow.wast:37: assert_trap passed: out of bounds table access: table.set at 5 >= max value 5
+out/test/spec/table_grow.wast:38: assert_trap passed: out of bounds table access: table.get at 5 >= max value 5
+out/test/spec/table_grow.wast:114: assert_invalid passed:
   out/test/spec/table_grow/table_grow.5.wasm:0000021: error: type mismatch in table.grow, expected [externref, i32] but got []
   0000021: error: OnTableGrowExpr callback failed
-out/test/spec/table_grow.wast:120: assert_invalid passed:
+out/test/spec/table_grow.wast:123: assert_invalid passed:
   out/test/spec/table_grow/table_grow.6.wasm:0000023: error: type mismatch in table.grow, expected [externref, i32] but got [externref]
   0000023: error: OnTableGrowExpr callback failed
-out/test/spec/table_grow.wast:129: assert_invalid passed:
+out/test/spec/table_grow.wast:132: assert_invalid passed:
   out/test/spec/table_grow/table_grow.7.wasm:0000023: error: type mismatch in table.grow, expected [externref, i32] but got [i32]
   0000023: error: OnTableGrowExpr callback failed
-out/test/spec/table_grow.wast:138: assert_invalid passed:
+out/test/spec/table_grow.wast:141: assert_invalid passed:
   out/test/spec/table_grow/table_grow.8.wasm:0000028: error: type mismatch in table.grow, expected [externref, i32] but got [externref, f32]
   0000028: error: OnTableGrowExpr callback failed
-out/test/spec/table_grow.wast:147: assert_invalid passed:
+out/test/spec/table_grow.wast:150: assert_invalid passed:
   out/test/spec/table_grow/table_grow.9.wasm:0000026: error: type mismatch in table.grow, expected [funcref, i32] but got [externref, i32]
   0000026: error: OnTableGrowExpr callback failed
-out/test/spec/table_grow.wast:157: assert_invalid passed:
+out/test/spec/table_grow.wast:160: assert_invalid passed:
   out/test/spec/table_grow/table_grow.10.wasm:0000025: error: type mismatch at end of function, expected [] but got [i32]
   0000025: error: EndFunctionBody callback failed
-out/test/spec/table_grow.wast:166: assert_invalid passed:
+out/test/spec/table_grow.wast:169: assert_invalid passed:
   out/test/spec/table_grow/table_grow.11.wasm:0000026: error: type mismatch in implicit return, expected [f32] but got [i32]
   0000026: error: EndFunctionBody callback failed
 50/50 tests passed.

--- a/test/wasm2c/spec/elem.txt
+++ b/test/wasm2c/spec/elem.txt
@@ -1,5 +1,5 @@
 ;;; TOOL: run-spec-wasm2c
 ;;; STDIN_FILE: third_party/testsuite/elem.wast
 (;; STDOUT ;;;
-35/35 tests passed.
+37/37 tests passed.
 ;;; STDOUT ;;)

--- a/test/wasm2c/spec/extended-const/elem.txt
+++ b/test/wasm2c/spec/extended-const/elem.txt
@@ -2,5 +2,5 @@
 ;;; STDIN_FILE: third_party/testsuite/proposals/extended-const/elem.wast
 ;;; ARGS*: --enable-extended-const
 (;; STDOUT ;;;
-35/35 tests passed.
+37/37 tests passed.
 ;;; STDOUT ;;)


### PR DESCRIPTION
WastParser now handles the abbreviated (no tableidx) forms of table.{get,set,size,grow,fill} (needed after
https://github.com/WebAssembly/spec/pull/1582).