### PR TITLE
BinaryReaderIR: increase kMaxNestingDepth to 16,384

### DIFF
--- a/src/binary-reader-ir.cc
+++ b/src/binary-reader-ir.cc
@@ -91,7 +91,7 @@ class CodeMetadataExprQueue {
 };
 
 class BinaryReaderIR : public BinaryReaderNop {
-  static constexpr size_t kMaxNestingDepth = 1024;  // max depth of label stack
+  static constexpr size_t kMaxNestingDepth = 16384;  // max depth of label stack
 
  public:
   BinaryReaderIR(Module* out_module, const char* filename, Errors* errors);


### PR DESCRIPTION
It turns out that clang (compiled to Wasm) uses a label nesting depth of >1400, which is greater than the limit of 1024 created in PR #2169. So we were failing to be able to run wasm2wat (etc.) on clang.wasm with this limit.

In practice, with a debug build, values up to about 40,000 appear sufficient to keep the stack within an 8 MiB limit. On release builds it's more frugal and we could probably afford an even bigger limit. But, "16384 ought to be enough nesting depth for anybody."

I wonder if we want to have a test for "extremely large modules" in general...