### PR TITLE
c-writer.cc: Add local symbol prefix.

### DIFF
--- a/src/c-writer.cc
+++ b/src/c-writer.cc
@@ -828,7 +828,7 @@ std::string CWriter::DefineGlobalScopeName(ModuleFieldType type,
                          ExportName(StripLeadingDollar(name)));
 }
 
-/* Names for params, locals, and stack vars are formatted as "w2c_" + name. */
+/* Names for params, locals, and stack vars are formatted as "var_" + name. */
 std::string CWriter::DefineLocalScopeName(std::string_view name,
                                           bool is_label) {
   return ClaimUniqueName(

--- a/src/c-writer.cc
+++ b/src/c-writer.cc
@@ -428,6 +428,7 @@ static constexpr char kParamSuffix =
 static constexpr char kLabelSuffix = kParamSuffix + 1;
 
 static constexpr char kSymbolPrefix[] = "w2c_";
+static constexpr char kLocalSymbolPrefix[] = "var_";
 static constexpr char kAdminSymbolPrefix[] = "wasm2c_";
 
 size_t CWriter::MarkTypeStack() const {
@@ -830,9 +831,9 @@ std::string CWriter::DefineGlobalScopeName(ModuleFieldType type,
 /* Names for params, locals, and stack vars are formatted as "w2c_" + name. */
 std::string CWriter::DefineLocalScopeName(std::string_view name,
                                           bool is_label) {
-  return ClaimUniqueName(local_syms_, local_sym_map_,
-                         is_label ? kLabelSuffix : kParamSuffix, name,
-                         kSymbolPrefix + MangleName(StripLeadingDollar(name)));
+  return ClaimUniqueName(
+      local_syms_, local_sym_map_, is_label ? kLabelSuffix : kParamSuffix, name,
+      kLocalSymbolPrefix + MangleName(StripLeadingDollar(name)));
 }
 
 std::string CWriter::DefineParamName(std::string_view name) {
@@ -847,7 +848,7 @@ std::string CWriter::DefineStackVarName(Index index,
                                         Type type,
                                         std::string_view name) {
   std::string unique =
-      FindUniqueName(local_syms_, kSymbolPrefix + MangleName(name));
+      FindUniqueName(local_syms_, kLocalSymbolPrefix + MangleName(name));
   StackTypePair stp = {index, type};
   [[maybe_unused]] bool success =
       stack_var_sym_map_.emplace(stp, unique).second;
@@ -2360,7 +2361,7 @@ void CWriter::PushFuncSection(std::string_view include_condition) {
 void CWriter::Write(const Func& func) {
   func_ = &func;
   // Copy symbols from global symbol table so we don't shadow them.
-  local_syms_ = global_syms_;
+  local_syms_.clear();
   local_sym_map_.clear();
   stack_var_sym_map_.clear();
   func_sections_.clear();

--- a/src/c-writer.cc
+++ b/src/c-writer.cc
@@ -427,7 +427,7 @@ static constexpr char kParamSuffix =
     'a' + static_cast<char>(ModuleFieldType::Tag) + 1;
 static constexpr char kLabelSuffix = kParamSuffix + 1;
 
-static constexpr char kSymbolPrefix[] = "w2c_";
+static constexpr char kGlobalSymbolPrefix[] = "w2c_";
 static constexpr char kLocalSymbolPrefix[] = "var_";
 static constexpr char kAdminSymbolPrefix[] = "wasm2c_";
 
@@ -568,26 +568,26 @@ std::string CWriter::MangleTagTypes(const TypeVector& types) {
 
 /* The C symbol for an export from this module. */
 std::string CWriter::ExportName(std::string_view export_name) {
-  return kSymbolPrefix + module_prefix_ + '_' + MangleName(export_name);
+  return kGlobalSymbolPrefix + module_prefix_ + '_' + MangleName(export_name);
 }
 
 /* The C symbol for an export from an arbitrary module. */
 // static
 std::string CWriter::ExportName(std::string_view module_name,
                                 std::string_view export_name) {
-  return kSymbolPrefix + MangleModuleName(module_name) + '_' +
+  return kGlobalSymbolPrefix + MangleModuleName(module_name) + '_' +
          MangleName(export_name);
 }
 
 /* The type name of an instance of this module. */
 std::string CWriter::ModuleInstanceTypeName() const {
-  return kSymbolPrefix + module_prefix_;
+  return kGlobalSymbolPrefix + module_prefix_;
 }
 
 /* The type name of an instance of an arbitrary module. */
 // static
 std::string CWriter::ModuleInstanceTypeName(std::string_view module_name) {
-  return kSymbolPrefix + MangleModuleName(module_name);
+  return kGlobalSymbolPrefix + MangleModuleName(module_name);
 }
 
 /*
@@ -862,8 +862,9 @@ std::string CWriter::DefineStackVarName(Index index,
  */
 std::string CWriter::DefineInstanceMemberName(ModuleFieldType type,
                                               std::string_view name) {
-  return ClaimUniqueName(global_syms_, global_sym_map_, MangleField(type), name,
-                         kSymbolPrefix + MangleName(StripLeadingDollar(name)));
+  return ClaimUniqueName(
+      global_syms_, global_sym_map_, MangleField(type), name,
+      kGlobalSymbolPrefix + MangleName(StripLeadingDollar(name)));
 }
 
 /*
@@ -2360,7 +2361,6 @@ void CWriter::PushFuncSection(std::string_view include_condition) {
 
 void CWriter::Write(const Func& func) {
   func_ = &func;
-  // Copy symbols from global symbol table so we don't shadow them.
   local_syms_.clear();
   local_sym_map_.clear();
   stack_var_sym_map_.clear();

--- a/test/wasm2c/add.txt
+++ b/test/wasm2c/add.txt
@@ -786,19 +786,19 @@ FUNC_TYPE_T(w2c_test_t0) = "\x92\xfb\x6a\xdf\x49\x07\x0a\x83\xbe\x08\x02\x68\xcd
 
 static u32 w2c_test_add_0(w2c_test*, u32, u32);
 
-static u32 w2c_test_add_0(w2c_test* instance, u32 w2c_p0, u32 w2c_p1) {
+static u32 w2c_test_add_0(w2c_test* instance, u32 var_p0, u32 var_p1) {
   FUNC_PROLOGUE;
-  u32 w2c_i0, w2c_i1;
-  w2c_i0 = w2c_p0;
-  w2c_i1 = w2c_p1;
-  w2c_i0 += w2c_i1;
+  u32 var_i0, var_i1;
+  var_i0 = var_p0;
+  var_i1 = var_p1;
+  var_i0 += var_i1;
   FUNC_EPILOGUE;
-  return w2c_i0;
+  return var_i0;
 }
 
 /* export: 'add' */
-u32 w2c_test_add(w2c_test* instance, u32 w2c_p0, u32 w2c_p1) {
-  return w2c_test_add_0(instance, w2c_p0, w2c_p1);
+u32 w2c_test_add(w2c_test* instance, u32 var_p0, u32 var_p1) {
+  return w2c_test_add_0(instance, var_p0, var_p1);
 }
 
 void wasm2c_test_instantiate(w2c_test* instance) {

--- a/test/wasm2c/hello.txt
+++ b/test/wasm2c/hello.txt
@@ -846,20 +846,20 @@ static void init_elem_instances(w2c_test *instance) {
 
 static void w2c_test_0x5Fstart_0(w2c_test* instance) {
   FUNC_PROLOGUE;
-  u32 w2c_i0, w2c_i1, w2c_i2, w2c_i3, w2c_i4;
-  w2c_i0 = 0u;
-  w2c_i1 = 8u;
-  i32_store(&instance->w2c_memory, (u64)(w2c_i0), w2c_i1);
-  w2c_i0 = 4u;
-  w2c_i1 = 14u;
-  i32_store(&instance->w2c_memory, (u64)(w2c_i0), w2c_i1);
-  w2c_i0 = 1u;
-  w2c_i1 = 0u;
-  w2c_i2 = 1u;
-  w2c_i3 = 0u;
-  w2c_i4 = 0u;
-  w2c_i0 = CALL_INDIRECT(instance->w2c_T0, u32 (*)(void*, u32, u32, u32, u32), w2c_test_t0, w2c_i4, instance->w2c_T0.data[w2c_i4].module_instance, w2c_i0, w2c_i1, w2c_i2, w2c_i3);
-  (*w2c_wasi__snapshot__preview1_proc_exit)(instance->w2c_wasi__snapshot__preview1_instance, w2c_i0);
+  u32 var_i0, var_i1, var_i2, var_i3, var_i4;
+  var_i0 = 0u;
+  var_i1 = 8u;
+  i32_store(&instance->w2c_memory, (u64)(var_i0), var_i1);
+  var_i0 = 4u;
+  var_i1 = 14u;
+  i32_store(&instance->w2c_memory, (u64)(var_i0), var_i1);
+  var_i0 = 1u;
+  var_i1 = 0u;
+  var_i2 = 1u;
+  var_i3 = 0u;
+  var_i4 = 0u;
+  var_i0 = CALL_INDIRECT(instance->w2c_T0, u32 (*)(void*, u32, u32, u32, u32), w2c_test_t0, var_i4, instance->w2c_T0.data[var_i4].module_instance, var_i0, var_i1, var_i2, var_i3);
+  (*w2c_wasi__snapshot__preview1_proc_exit)(instance->w2c_wasi__snapshot__preview1_instance, var_i0);
   FUNC_EPILOGUE;
 }
 

--- a/wasm2c/README.md
+++ b/wasm2c/README.md
@@ -458,24 +458,24 @@ module doesn't use any globals, memory or tables.
 The most interesting part is the definition of the function `fac`:
 
 ```c
-static u32 w2c_fac_fac_0(w2c_fac* instance, u32 w2c_p0) {
+static u32 w2c_fac_fac_0(w2c_fac* instance, u32 var_p0) {
   FUNC_PROLOGUE;
-  u32 w2c_i0, w2c_i1, w2c_i2;
-  w2c_i0 = w2c_p0;
-  w2c_i1 = 0u;
-  w2c_i0 = w2c_i0 == w2c_i1;
-  if (w2c_i0) {
-    w2c_i0 = 1u;
+  u32 var_i0, var_i1, var_i2;
+  var_i0 = var_p0;
+  var_i1 = 0u;
+  var_i0 = var_i0 == var_i1;
+  if (var_i0) {
+    var_i0 = 1u;
   } else {
-    w2c_i0 = w2c_p0;
-    w2c_i1 = w2c_p0;
-    w2c_i2 = 1u;
-    w2c_i1 -= w2c_i2;
-    w2c_i1 = w2c_fac_fac_0(instance, w2c_i1);
-    w2c_i0 *= w2c_i1;
+    var_i0 = var_p0;
+    var_i1 = var_p0;
+    var_i2 = 1u;
+    var_i1 -= var_i2;
+    var_i1 = w2c_fac_fac_0(instance, var_i1);
+    var_i0 *= var_i1;
   }
   FUNC_EPILOGUE;
-  return w2c_i0;
+  return var_i0;
 }
 ```
 

--- a/wasm2c/examples/fac/fac.c
+++ b/wasm2c/examples/fac/fac.c
@@ -728,29 +728,29 @@ FUNC_TYPE_T(w2c_fac_t0) = "\x07\x80\x96\x7a\x42\xf7\x3e\xe6\x70\x5c\x2f\xac\x83\
 
 static u32 w2c_fac_fac_0(w2c_fac*, u32);
 
-static u32 w2c_fac_fac_0(w2c_fac* instance, u32 w2c_p0) {
+static u32 w2c_fac_fac_0(w2c_fac* instance, u32 var_p0) {
   FUNC_PROLOGUE;
-  u32 w2c_i0, w2c_i1, w2c_i2;
-  w2c_i0 = w2c_p0;
-  w2c_i1 = 0u;
-  w2c_i0 = w2c_i0 == w2c_i1;
-  if (w2c_i0) {
-    w2c_i0 = 1u;
+  u32 var_i0, var_i1, var_i2;
+  var_i0 = var_p0;
+  var_i1 = 0u;
+  var_i0 = var_i0 == var_i1;
+  if (var_i0) {
+    var_i0 = 1u;
   } else {
-    w2c_i0 = w2c_p0;
-    w2c_i1 = w2c_p0;
-    w2c_i2 = 1u;
-    w2c_i1 -= w2c_i2;
-    w2c_i1 = w2c_fac_fac_0(instance, w2c_i1);
-    w2c_i0 *= w2c_i1;
+    var_i0 = var_p0;
+    var_i1 = var_p0;
+    var_i2 = 1u;
+    var_i1 -= var_i2;
+    var_i1 = w2c_fac_fac_0(instance, var_i1);
+    var_i0 *= var_i1;
   }
   FUNC_EPILOGUE;
-  return w2c_i0;
+  return var_i0;
 }
 
 /* export: 'fac' */
-u32 w2c_fac_fac(w2c_fac* instance, u32 w2c_p0) {
-  return w2c_fac_fac_0(instance, w2c_p0);
+u32 w2c_fac_fac(w2c_fac* instance, u32 var_p0) {
+  return w2c_fac_fac_0(instance, var_p0);
 }
 
 void wasm2c_fac_instantiate(w2c_fac* instance) {


### PR DESCRIPTION
This adds `kLocalSymbolPrefix` which is used for names of params, locals and stack vars. This allows c-writer to not assign `global_syms_` to `local_syms_` for writing each individual function, since local names can't duplicate global names.

This speeds up the execution of `wasm2c` on large inputs. `clang.wasm` is a 75M WASM module. Before this PR, `wasm2c` on `clang.wasm` would take ~63 minutes.
```
time ./build/wasm2c clang.wasm -o clang.c --enable-multi-memory
real    63m42.780s
user    63m15.818s
sys     0m24.107s
```
After this PR, it takes ~2 minutes.
```
time ./build/wasm2c clang.wasm -o clang.c --enable-multi-memory
real    2m12.889s
user    2m8.853s
sys     0m3.983s
```