### PR TITLE
binary-reader.cc: expand max local count and fix error message

### DIFF
--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -2770,8 +2770,8 @@ Result BinaryReader::ReadCodeSection(Offset section_size) {
       Index num_local_types;
       CHECK_RESULT(ReadIndex(&num_local_types, "local type count"));
       total_locals += num_local_types;
-      ERROR_UNLESS(total_locals < UINT32_MAX,
-                   "local count must be < 0x10000000");
+      ERROR_UNLESS(total_locals <= UINT32_MAX,
+                   "local count must be < 0x100000000");
       Type local_type;
       CHECK_RESULT(ReadType(&local_type, "local type"));
       ERROR_UNLESS(IsConcreteType(local_type), "expected valid local type");

--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -2770,8 +2770,8 @@ Result BinaryReader::ReadCodeSection(Offset section_size) {
       Index num_local_types;
       CHECK_RESULT(ReadIndex(&num_local_types, "local type count"));
       total_locals += num_local_types;
-      ERROR_UNLESS(total_locals <= UINT32_MAX,
-                   "local count must be < 0x100000000");
+      ERROR_UNLESS(total_locals <= UINT32_MAX, "local count must be <= 0x%x",
+                   UINT32_MAX);
       Type local_type;
       CHECK_RESULT(ReadType(&local_type, "local type"));
       ERROR_UNLESS(IsConcreteType(local_type), "expected valid local type");

--- a/test/binary/bad-too-many-locals.txt
+++ b/test/binary/bad-too-many-locals.txt
@@ -16,7 +16,7 @@ section(CODE) {
   }
 }
 (;; STDERR ;;;
-000001e: error: local count must be < 0x100000000
+000001e: error: local count must be <= 0xffffffff
 ;;; STDERR ;;)
 (;; STDOUT ;;;
 

--- a/test/binary/bad-too-many-locals.txt
+++ b/test/binary/bad-too-many-locals.txt
@@ -16,7 +16,7 @@ section(CODE) {
   }
 }
 (;; STDERR ;;;
-000001c: error: local count must be < 0x10000000
+000001e: error: local count must be < 0x100000000
 ;;; STDERR ;;)
 (;; STDOUT ;;;
 
@@ -34,4 +34,5 @@ Code[1]:
 Code Disassembly:
 
 000016 func[0]:
+ 000017: ff ff ff ff 0f 7f          | local[0..4294967294] type=i32
 ;;; STDOUT ;;)

--- a/test/spec/binary.txt
+++ b/test/spec/binary.txt
@@ -192,9 +192,9 @@ out/test/spec/binary.wast:1048: assert_malformed passed:
 out/test/spec/binary.wast:1065: assert_malformed passed:
   0000017: error: unable to read u32 leb128: local type count
 out/test/spec/binary.wast:1082: assert_malformed passed:
-  000001e: error: local count must be < 0x100000000
+  000001e: error: local count must be <= 0xffffffff
 out/test/spec/binary.wast:1098: assert_malformed passed:
-  0000030: error: local count must be < 0x100000000
+  0000030: error: local count must be <= 0xffffffff
 out/test/spec/binary.wast:1132: assert_malformed passed:
   0000013: error: function signature count != function body count
 out/test/spec/binary.wast:1142: assert_malformed passed:

--- a/test/spec/binary.txt
+++ b/test/spec/binary.txt
@@ -192,9 +192,9 @@ out/test/spec/binary.wast:1048: assert_malformed passed:
 out/test/spec/binary.wast:1065: assert_malformed passed:
   0000017: error: unable to read u32 leb128: local type count
 out/test/spec/binary.wast:1082: assert_malformed passed:
-  000001c: error: local count must be < 0x10000000
+  000001e: error: local count must be < 0x100000000
 out/test/spec/binary.wast:1098: assert_malformed passed:
-  0000030: error: local count must be < 0x10000000
+  0000030: error: local count must be < 0x100000000
 out/test/spec/binary.wast:1132: assert_malformed passed:
   0000013: error: function signature count != function body count
 out/test/spec/binary.wast:1142: assert_malformed passed:

--- a/test/spec/exception-handling/binary.txt
+++ b/test/spec/exception-handling/binary.txt
@@ -193,9 +193,9 @@ out/test/spec/exception-handling/binary.wast:1048: assert_malformed passed:
 out/test/spec/exception-handling/binary.wast:1065: assert_malformed passed:
   0000017: error: unable to read u32 leb128: local type count
 out/test/spec/exception-handling/binary.wast:1082: assert_malformed passed:
-  000001c: error: local count must be < 0x10000000
+  000001e: error: local count must be < 0x100000000
 out/test/spec/exception-handling/binary.wast:1098: assert_malformed passed:
-  0000030: error: local count must be < 0x10000000
+  0000030: error: local count must be < 0x100000000
 out/test/spec/exception-handling/binary.wast:1132: assert_malformed passed:
   0000013: error: function signature count != function body count
 out/test/spec/exception-handling/binary.wast:1142: assert_malformed passed:

--- a/test/spec/exception-handling/binary.txt
+++ b/test/spec/exception-handling/binary.txt
@@ -193,9 +193,9 @@ out/test/spec/exception-handling/binary.wast:1048: assert_malformed passed:
 out/test/spec/exception-handling/binary.wast:1065: assert_malformed passed:
   0000017: error: unable to read u32 leb128: local type count
 out/test/spec/exception-handling/binary.wast:1082: assert_malformed passed:
-  000001e: error: local count must be < 0x100000000
+  000001e: error: local count must be <= 0xffffffff
 out/test/spec/exception-handling/binary.wast:1098: assert_malformed passed:
-  0000030: error: local count must be < 0x100000000
+  0000030: error: local count must be <= 0xffffffff
 out/test/spec/exception-handling/binary.wast:1132: assert_malformed passed:
   0000013: error: function signature count != function body count
 out/test/spec/exception-handling/binary.wast:1142: assert_malformed passed:

--- a/test/spec/memory64/binary.txt
+++ b/test/spec/memory64/binary.txt
@@ -103,9 +103,9 @@ out/test/spec/memory64/binary.wast:336: assert_malformed passed:
 out/test/spec/memory64/binary.wast:355: assert_malformed passed:
   0000017: error: unable to read u32 leb128: local type count
 out/test/spec/memory64/binary.wast:372: assert_malformed passed:
-  000001c: error: local count must be < 0x10000000
+  000001e: error: local count must be < 0x100000000
 out/test/spec/memory64/binary.wast:388: assert_malformed passed:
-  0000030: error: local count must be < 0x10000000
+  0000030: error: local count must be < 0x100000000
 out/test/spec/memory64/binary.wast:422: assert_malformed passed:
   0000013: error: function signature count != function body count
 out/test/spec/memory64/binary.wast:432: assert_malformed passed:

--- a/test/spec/memory64/binary.txt
+++ b/test/spec/memory64/binary.txt
@@ -103,9 +103,9 @@ out/test/spec/memory64/binary.wast:336: assert_malformed passed:
 out/test/spec/memory64/binary.wast:355: assert_malformed passed:
   0000017: error: unable to read u32 leb128: local type count
 out/test/spec/memory64/binary.wast:372: assert_malformed passed:
-  000001e: error: local count must be < 0x100000000
+  000001e: error: local count must be <= 0xffffffff
 out/test/spec/memory64/binary.wast:388: assert_malformed passed:
-  0000030: error: local count must be < 0x100000000
+  0000030: error: local count must be <= 0xffffffff
 out/test/spec/memory64/binary.wast:422: assert_malformed passed:
   0000013: error: function signature count != function body count
 out/test/spec/memory64/binary.wast:432: assert_malformed passed:

--- a/test/spec/multi-memory/binary.txt
+++ b/test/spec/multi-memory/binary.txt
@@ -173,9 +173,9 @@ out/test/spec/multi-memory/binary.wast:857: assert_malformed passed:
 out/test/spec/multi-memory/binary.wast:874: assert_malformed passed:
   0000017: error: unable to read u32 leb128: local type count
 out/test/spec/multi-memory/binary.wast:891: assert_malformed passed:
-  000001c: error: local count must be < 0x10000000
+  000001e: error: local count must be < 0x100000000
 out/test/spec/multi-memory/binary.wast:907: assert_malformed passed:
-  0000030: error: local count must be < 0x10000000
+  0000030: error: local count must be < 0x100000000
 out/test/spec/multi-memory/binary.wast:941: assert_malformed passed:
   0000013: error: function signature count != function body count
 out/test/spec/multi-memory/binary.wast:951: assert_malformed passed:

--- a/test/spec/multi-memory/binary.txt
+++ b/test/spec/multi-memory/binary.txt
@@ -173,9 +173,9 @@ out/test/spec/multi-memory/binary.wast:857: assert_malformed passed:
 out/test/spec/multi-memory/binary.wast:874: assert_malformed passed:
   0000017: error: unable to read u32 leb128: local type count
 out/test/spec/multi-memory/binary.wast:891: assert_malformed passed:
-  000001e: error: local count must be < 0x100000000
+  000001e: error: local count must be <= 0xffffffff
 out/test/spec/multi-memory/binary.wast:907: assert_malformed passed:
-  0000030: error: local count must be < 0x100000000
+  0000030: error: local count must be <= 0xffffffff
 out/test/spec/multi-memory/binary.wast:941: assert_malformed passed:
   0000013: error: function signature count != function body count
 out/test/spec/multi-memory/binary.wast:951: assert_malformed passed:


### PR DESCRIPTION
On the tour of cleaning up what look like relatively easy old issues. (The error message was missing one '0'.)

Fixes #1593