### PR TITLE
implementation of --run-export and --argument

### DIFF
--- a/src/tools/wasm-interp.cc
+++ b/src/tools/wasm-interp.cc
@@ -217,11 +217,12 @@ Result RunSpecificExports(const Instance::Ptr& instance,
   auto&& module_desc = module->desc();
 
   for (auto&& export_ : module_desc.exports) {
-    if (export_.type.type->kind != ExternalKind::Func) {
-      continue;
-    }
     for (auto& call_ : calls) {
       if (export_.type.name == call_.name) {
+        ERROR_EXIT_UNLESS(export_.type.type->kind == ExternalKind::Func,
+                          "Export '%s' is not a function\n",
+                          export_.type.name.c_str());
+
         if (s_trace_stream) {
           s_trace_stream->Writef(">>> running export \"%s\":\n",
                                  call_.name.c_str());

--- a/src/tools/wasm-interp.cc
+++ b/src/tools/wasm-interp.cc
@@ -110,14 +110,14 @@ Result ParseArgument(std::string argument, Value& val) {
 
   if (strcmp(ptype, "i32") == 0) {
     uint32_t parsed_value;
-    result |= ParseInt32(pval, pval_end, &parsed_value,
-                         ParseIntType::SignedAndUnsigned);
+    result |=
+        ParseInt32(pval, pval_end, &parsed_value, ParseIntType::UnsignedOnly);
     val.Set(parsed_value);
   }
   if (strcmp(ptype, "i64") == 0) {
     uint64_t parsed_value;
-    result |= ParseInt64(pval, pval_end, &parsed_value,
-                         ParseIntType::SignedAndUnsigned);
+    result |=
+        ParseInt64(pval, pval_end, &parsed_value, ParseIntType::UnsignedOnly);
     val.Set(parsed_value);
   }
   if (strcmp(ptype, "f32") == 0) {

--- a/src/tools/wasm-interp.cc
+++ b/src/tools/wasm-interp.cc
@@ -99,7 +99,7 @@ Result ParseArgument(std::string argument, Value& val) {
   Result result = Result::Ok;
 
   size_t cindex;
-  if (argument.empty() || (cindex = argument.find(':')) == -1u) {
+  if (argument.empty() || (cindex = argument.find(':')) == std::string::npos) {
     return wabt::Result::Error;
   }
 
@@ -110,14 +110,14 @@ Result ParseArgument(std::string argument, Value& val) {
 
   if (strcmp(ptype, "i32") == 0) {
     uint32_t parsed_value;
-    result |=
-        ParseInt32(pval, pval_end, &parsed_value, ParseIntType::UnsignedOnly);
+    result |= ParseInt32(pval, pval_end, &parsed_value,
+                         ParseIntType::SignedAndUnsigned);
     val.Set(parsed_value);
   }
   if (strcmp(ptype, "i64") == 0) {
     uint64_t parsed_value;
-    result |=
-        ParseInt64(pval, pval_end, &parsed_value, ParseIntType::UnsignedOnly);
+    result |= ParseInt64(pval, pval_end, &parsed_value,
+                         ParseIntType::SignedAndUnsigned);
     val.Set(parsed_value);
   }
   if (strcmp(ptype, "f32") == 0) {

--- a/src/tools/wasm-interp.cc
+++ b/src/tools/wasm-interp.cc
@@ -29,6 +29,7 @@
 #include "wabt/interp/interp-util.h"
 #include "wabt/interp/interp-wasi.h"
 #include "wabt/interp/interp.h"
+#include "wabt/literal.h"
 #include "wabt/option-parser.h"
 #include "wabt/stream.h"
 
@@ -39,6 +40,19 @@
 using namespace wabt;
 using namespace wabt::interp;
 
+struct FunctionCallee {
+  std::string name;
+  Values args;
+};
+
+#define ERROR_EXIT_UNLESS(cond, ...) \
+  do {                               \
+    if (!(cond)) {                   \
+      printf(__VA_ARGS__);           \
+      exit(1);                       \
+    }                                \
+  } while (0);
+
 static int s_verbose;
 static const char* s_infile;
 static Thread::Options s_thread_options;
@@ -48,6 +62,7 @@ static bool s_host_print;
 static bool s_dummy_import_func;
 static Features s_features;
 static bool s_wasi;
+static std::vector<FunctionCallee> s_run_exports;
 static std::vector<std::string> s_wasi_env;
 static std::vector<std::string> s_wasi_argv;
 static std::vector<std::string> s_wasi_dirs;
@@ -75,7 +90,48 @@ examples:
   # parse test.wasm and run all its exported functions, setting the
   # value stack size to 100 elements
   $ wasm-interp test.wasm -V 100 --run-all-exports
+
+  # parse test.wasm, run specific exported function by name with argument
+  $ wasm-interp test.wasm -r "func_sum" -a "i32:8" -a "i32:5"
 )";
+
+Result ParseArgument(std::string argument, Value& val) {
+  Result result = Result::Ok;
+
+  size_t cindex;
+  if (argument.empty() || (cindex = argument.find(':')) == -1u) {
+    return wabt::Result::Error;
+  }
+
+  argument[cindex] = '\0';
+  const char* ptype = argument.c_str();
+  const char* pval = argument.c_str() + cindex + 1;
+  const char* pval_end = ptype + argument.length();
+
+  if (strcmp(ptype, "i32") == 0) {
+    uint32_t parsed_value;
+    result |=
+        ParseInt32(pval, pval_end, &parsed_value, ParseIntType::UnsignedOnly);
+    val.Set(parsed_value);
+  }
+  if (strcmp(ptype, "i64") == 0) {
+    uint64_t parsed_value;
+    result |=
+        ParseInt64(pval, pval_end, &parsed_value, ParseIntType::UnsignedOnly);
+    val.Set(parsed_value);
+  }
+  if (strcmp(ptype, "f32") == 0) {
+    uint32_t parsed_value;
+    result |= ParseFloat(LiteralType::Float, pval, pval_end, &parsed_value);
+    val.Set(parsed_value);
+  }
+  if (strcmp(ptype, "f64") == 0) {
+    uint64_t parsed_value;
+    result |= ParseDouble(LiteralType::Float, pval, pval_end, &parsed_value);
+    val.Set(parsed_value);
+  }
+  return result;
+}
 
 static void ParseOptions(int argc, char** argv) {
   OptionParser parser("wasm-interp", s_description);
@@ -99,6 +155,26 @@ static void ParseOptions(int argc, char** argv) {
                    });
   parser.AddOption('t', "trace", "Trace execution",
                    []() { s_trace_stream = s_stdout_stream.get(); });
+  parser.AddOption('r', "run-export", "FUNCTION",
+                   "Run exported function by name",
+                   [](const std::string& argument) {
+                     FunctionCallee func;
+                     func.name = argument;
+                     s_run_exports.push_back(func);
+                   });
+  parser.AddOption('a', "argument", "ARGUMENT",
+                   "Add argument to an exported function execution",
+                   [](const std::string& argument) {
+                     Value val;
+                     ERROR_EXIT_UNLESS(
+                         !s_run_exports.empty(),
+                         "Cannot find a function execution for argument '%s'\n",
+                         argument.c_str());
+                     ERROR_EXIT_UNLESS(Succeeded(ParseArgument(argument, val)),
+                                       "Failed to parse argument '%s'\n",
+                                       argument.c_str());
+                     s_run_exports.back().args.push_back(val);
+                   });
   parser.AddOption("wasi",
                    "Assume input module is WASI compliant (Export "
                    " WASI API the the module and invoke _start function)",
@@ -130,6 +206,39 @@ static void ParseOptions(int argc, char** argv) {
       "arg", OptionParser::ArgumentCount::ZeroOrMore,
       [](const char* argument) { s_wasi_argv.push_back(argument); });
   parser.Parse(argc, argv);
+}
+
+Result RunSpecificExports(const Instance::Ptr& instance,
+                          Errors* errors,
+                          std::vector<FunctionCallee>& callees) {
+  Result result = Result::Ok;
+
+  auto module = s_store.UnsafeGet<Module>(instance->module());
+  auto&& module_desc = module->desc();
+
+  for (auto&& export_ : module_desc.exports) {
+    if (export_.type.type->kind != ExternalKind::Func) {
+      continue;
+    }
+    for (auto& callee_ : callees) {
+      if (export_.type.name == callee_.name) {
+        if (s_trace_stream) {
+          s_trace_stream->Writef(">>> running export \"%s\":\n",
+                                 callee_.name.c_str());
+        }
+        auto* func_type = cast<FuncType>(export_.type.type.get());
+        auto func = s_store.UnsafeGet<Func>(instance->funcs()[export_.index]);
+        Values results;
+        Trap::Ptr trap;
+        result |=
+            func->Call(s_store, callee_.args, results, &trap, s_trace_stream);
+        WriteCall(s_stdout_stream.get(), export_.type.name, *func_type,
+                  callee_.args, results, trap);
+      }
+    }
+  }
+
+  return result;
 }
 
 Result RunAllExports(const Instance::Ptr& instance, Errors* errors) {
@@ -307,6 +416,10 @@ static Result ReadAndRunModule(const char* module_filename) {
 
   if (s_run_all_exports) {
     RunAllExports(instance, &errors);
+  }
+
+  if (!s_run_exports.empty()) {
+    RunSpecificExports(instance, &errors, s_run_exports);
   }
 #ifdef WITH_WASI
   if (s_wasi) {

--- a/test/help/wasm-interp.txt
+++ b/test/help/wasm-interp.txt
@@ -20,6 +20,9 @@ examples:
   # value stack size to 100 elements
   $ wasm-interp test.wasm -V 100 --run-all-exports
 
+  # parse test.wasm, run specific exported function by name with argument
+  $ wasm-interp test.wasm -r "func_sum" -a "i32:8" -a "i32:5"
+
 options:
       --help                                   Print this help message
       --version                                Print version information
@@ -46,6 +49,8 @@ options:
   -V, --value-stack-size=SIZE                  Size in elements of the value stack
   -C, --call-stack-size=SIZE                   Size in elements of the call stack
   -t, --trace                                  Trace execution
+  -r, --run-export=FUNCTION                    Run exported function by name
+  -a, --argument=ARGUMENT                      Add argument to an exported function execution
       --wasi                                   Assume input module is WASI compliant (Export  WASI API the the module and invoke _start function)
   -e, --env=ENV                                Pass the given environment string in the WASI runtime
   -d, --dir=DIR                                Pass the given directory the the WASI runtime

--- a/test/interp/call-with-argument.txt
+++ b/test/interp/call-with-argument.txt
@@ -1,0 +1,27 @@
+;;; TOOL: run-interp
+;;; ARGS: -r func_fac -a "i32:10"
+(module
+  (func (export "func_fac") (param i32) (result i32)
+    local.get 0
+    call $fac)
+
+  (func $fac (param i32) (result i32)
+    local.get 0
+    i32.const 0
+    i32.gt_s 
+    if (result i32)
+      local.get 0
+      local.get 0
+      i32.const 1
+      i32.sub
+      call $fac
+      i32.mul
+      return
+    else
+      i32.const 1
+      return
+    end) 
+)
+(;; STDOUT ;;;
+fac10(i32:10) => i32:3628800
+;;; STDOUT ;;)

--- a/test/interp/call-with-argument.txt
+++ b/test/interp/call-with-argument.txt
@@ -1,5 +1,5 @@
 ;;; TOOL: run-interp
-;;; ARGS: -r func_fac -a "i32:10"
+;;; ARGS*: -r func_fac -a "i32:10"
 (module
   (func (export "func_fac") (param i32) (result i32)
     local.get 0
@@ -23,5 +23,5 @@
     end) 
 )
 (;; STDOUT ;;;
-fac10(i32:10) => i32:3628800
+func_fac(i32:10) => i32:3628800
 ;;; STDOUT ;;)

--- a/test/interp/run-export-as-global.txt
+++ b/test/interp/run-export-as-global.txt
@@ -1,0 +1,10 @@
+;;; TOOL: run-interp
+;;; ARGS1: --run-export=global_export --argument=i32:10
+;;; ERROR: 1
+(module
+  (global $my_global i32 (i32.const 0))
+  (export "global_export" (global $my_global))
+)
+(;; STDOUT ;;;
+Export 'global_export' is not a function
+;;; STDOUT ;;)

--- a/test/interp/run-export-with-argument.txt
+++ b/test/interp/run-export-with-argument.txt
@@ -1,6 +1,12 @@
 ;;; TOOL: run-interp
-;;; ARGS1: --run-export=func_fac --argument=i32:10
+;;; ARGS1: --run-export=func_sum --argument=i64:8 --argument=i64:5 --run-export=func_fac --argument=i32:10
 (module
+  (func (export "func_sum") (param i64) (param i64) (result i64)
+    local.get 0
+    local.get 1
+    i64.add
+    return)
+
   (func (export "func_fac") (param i32) (result i32)
     local.get 0
     call $fac)
@@ -23,5 +29,6 @@
     end) 
 )
 (;; STDOUT ;;;
+func_sum(i64:8, i64:5) => i64:13
 func_fac(i32:10) => i32:3628800
 ;;; STDOUT ;;)

--- a/test/interp/run-export-with-argument.txt
+++ b/test/interp/run-export-with-argument.txt
@@ -1,5 +1,5 @@
 ;;; TOOL: run-interp
-;;; ARGS*: -r func_fac -a "i32:10"
+;;; ARGS1: --run-export=func_fac --argument=i32:10
 (module
   (func (export "func_fac") (param i32) (result i32)
     local.get 0


### PR DESCRIPTION
Reference: https://github.com/WebAssembly/wabt/pull/1167 cc @keithw 
Closes: https://github.com/WebAssembly/wabt/issues/198

Allows `wasm-interp` to be execute specific exported wasm functions by name.

Quick example:

```lisp
(module (func (export "func_sum") (param i32) (param i32) (result i32)
  local.get 0
  local.get 1
  i32.add
  return))
```

```bash
$ ./wasm-interp sum.wasm -r func_sum -a "i32:8" -a "i32:5" 
func_sum(i32:8, i32:5) => i32:13
```

with `--trace`

```bash
$ ./wasm-interp sum.wasm -r func_sum -a "i32:8" -a "i32:5" --trace
>>> running export "func_sum":
#0.    0: V:2  | local.get $2
#0.    8: V:3  | local.get $2
#0.   16: V:4  | i32.add 8, 5
#0.   20: V:3  | drop_keep $2 $1
#0.   32: V:1  | return
func_sum(i32:8, i32:5) => i32:13
```

Supported types: i32, i64, f32, f64

## Overview

```bash
 ./wasm-interp --help
usage: wasm-interp [options] filename [arg]...

  read a file in the wasm binary format, and run in it a stack-based
  interpreter.

examples:
  # parse binary file test.wasm, and type-check it
  $ wasm-interp test.wasm

  # parse test.wasm and run all its exported functions
  $ wasm-interp test.wasm --run-all-exports

  # parse test.wasm, run the exported functions and trace the output
  $ wasm-interp test.wasm --run-all-exports --trace

  # parse test.wasm and run all its exported functions, setting the
  # value stack size to 100 elements
  $ wasm-interp test.wasm -V 100 --run-all-exports

  # parse test.wasm, run specific exported function by name with argument
  $ wasm-interp test.wasm -r "func_sum" -a "i32:8" -a "i32:5"

options:
      --help                                   Print this help message
      --version                                Print version information
  -v, --verbose                                Use multiple times for more info
      --enable-exceptions                      Enable Experimental exception handling
      --disable-mutable-globals                Disable Import/export mutable globals
      --disable-saturating-float-to-int        Disable Saturating float-to-int operators
      --disable-sign-extension                 Disable Sign-extension operators
      --disable-simd                           Disable SIMD support
      --enable-threads                         Enable Threading support
      --enable-function-references             Enable Typed function references
      --disable-multi-value                    Disable Multi-value
      --enable-tail-call                       Enable Tail-call support
      --disable-bulk-memory                    Disable Bulk-memory operations
      --disable-reference-types                Disable Reference types (externref)
      --enable-annotations                     Enable Custom annotation syntax
      --enable-code-metadata                   Enable Code metadata
      --enable-gc                              Enable Garbage collection
      --enable-memory64                        Enable 64-bit memory
      --enable-multi-memory                    Enable Multi-memory
      --enable-extended-const                  Enable Extended constant expressions
      --enable-relaxed-simd                    Enable Relaxed SIMD
      --enable-all                             Enable all features
  -V, --value-stack-size=SIZE                  Size in elements of the value stack
  -C, --call-stack-size=SIZE                   Size in elements of the call stack
  -t, --trace                                  Trace execution
  -r, --run-export=FUNCTION                    Run exported function by name
  -a, --argument=ARGUMENT                      Add argument to a exported function execution
      --wasi                                   Assume input module is WASI compliant (Export  WASI API the the module and invoke _start function)
  -e, --env=ENV                                Pass the given environment string in the WASI runtime
  -d, --dir=DIR                                Pass the given directory the the WASI runtime
      --run-all-exports                        Run all the exported functions, in order. Useful for testing
      --host-print                             Include an importable function named "host.print" for printing to stdout
      --dummy-import-func                      Provide a dummy implementation of all imported functions. The function will log the call and return an appropriate zero value.
```

```bash

```