### PR TITLE
Silence warnings on GCC 12

### DIFF
--- a/src/c-writer.cc
+++ b/src/c-writer.cc
@@ -773,7 +773,7 @@ void CWriter::DefineImportName(const Import* import,
                                std::string_view module,
                                std::string_view field_name) {
   std::string name;
-  ModuleFieldType type;
+  ModuleFieldType type{};
 
   switch (import->kind()) {
     case ExternalKind::Func:

--- a/src/tools/spectest-interp.cc
+++ b/src/tools/spectest-interp.cc
@@ -189,9 +189,8 @@ int LaneCountFromType(Type type) {
 }
 
 ExpectedValue GetLane(const ExpectedValue& ev, int lane) {
-  int lane_count = LaneCountFromType(ev.lane_type);
   assert(ev.value.type == Type::V128);
-  assert(lane < lane_count);
+  assert(lane < LaneCountFromType(ev.lane_type));
 
   ExpectedValue result;
   result.value.type = ev.lane_type;
@@ -236,9 +235,8 @@ ExpectedValue GetLane(const ExpectedValue& ev, int lane) {
 }
 
 TypedValue GetLane(const TypedValue& tv, Type lane_type, int lane) {
-  int lane_count = LaneCountFromType(lane_type);
   assert(tv.type == Type::V128);
-  assert(lane < lane_count);
+  assert(lane < LaneCountFromType(lane_type));
 
   TypedValue result;
   result.type = lane_type;

--- a/src/type-checker.cc
+++ b/src/type-checker.cc
@@ -513,12 +513,11 @@ Result TypeChecker::OnCallIndirect(const TypeVector& param_types,
 
 Result TypeChecker::OnIndexedFuncRef(Index* out_index) {
   Type type;
-  Result result = PeekType(0, &type);
+  CHECK_RESULT(PeekType(0, &type));
+  Result result = Result::Ok;
   if (!(type == Type::Any || type.IsReferenceWithIndex())) {
     TypeVector actual;
-    if (Succeeded(result)) {
-      actual.push_back(type);
-    }
+    actual.push_back(type);
     std::string message =
         "type mismatch in call_ref, expected reference but got " +
         TypesToString(actual);

--- a/src/wat-writer.cc
+++ b/src/wat-writer.cc
@@ -1722,7 +1722,7 @@ void WatWriter::WriteInlineExports(ExternalKind kind, Index index) {
 }
 
 bool WatWriter::IsInlineExport(const Export& export_) {
-  Index index;
+  Index index{};
   switch (export_.kind) {
     case ExternalKind::Func:
       index = module.GetFuncIndex(export_.var);


### PR DESCRIPTION
These changes allow the build to succeed with `-DWERROR=ON` on GCC 12.

Fixes #2020