### PR TITLE
wasm2c: Separate the macros for allocation and bounds checks strategies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,7 +109,7 @@ jobs:
     env:
       USE_NINJA: "1"
       CC: "clang" # used by the wasm2c tests
-      WASM2C_CFLAGS: "-march=x86-64-v2 -fsanitize=address -DWASM_RT_MEMCHECK_SIGNAL_HANDLER=0"
+      WASM2C_CFLAGS: "-march=x86-64-v2 -fsanitize=address -DWASM_RT_USE_MMAP=0"
     steps:
     - uses: actions/setup-python@v1
       with:

--- a/src/prebuilt/wasm2c_source_declarations.cc
+++ b/src/prebuilt/wasm2c_source_declarations.cc
@@ -75,7 +75,7 @@ R"w2c_template(    TRAP(OOB);
 R"w2c_template(#endif
 )w2c_template"
 R"w2c_template(
-#if WASM_RT_MEMCHECK_SIGNAL_HANDLER
+#if WASM_RT_MEMCHECK_GUARD_PAGES
 )w2c_template"
 R"w2c_template(#define MEMCHECK(mem, a, t)
 )w2c_template"

--- a/src/template/wasm2c.declarations.c
+++ b/src/template/wasm2c.declarations.c
@@ -41,7 +41,7 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
     TRAP(OOB);
 #endif
 
-#if WASM_RT_MEMCHECK_SIGNAL_HANDLER
+#if WASM_RT_MEMCHECK_GUARD_PAGES
 #define MEMCHECK(mem, a, t)
 #else
 #define MEMCHECK(mem, a, t) RANGE_CHECK(mem, a, sizeof(t))

--- a/test/wasm2c/add.txt
+++ b/test/wasm2c/add.txt
@@ -114,7 +114,7 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
     TRAP(OOB);
 #endif
 
-#if WASM_RT_MEMCHECK_SIGNAL_HANDLER
+#if WASM_RT_MEMCHECK_GUARD_PAGES
 #define MEMCHECK(mem, a, t)
 #else
 #define MEMCHECK(mem, a, t) RANGE_CHECK(mem, a, sizeof(t))

--- a/test/wasm2c/check-imports.txt
+++ b/test/wasm2c/check-imports.txt
@@ -137,7 +137,7 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
     TRAP(OOB);
 #endif
 
-#if WASM_RT_MEMCHECK_SIGNAL_HANDLER
+#if WASM_RT_MEMCHECK_GUARD_PAGES
 #define MEMCHECK(mem, a, t)
 #else
 #define MEMCHECK(mem, a, t) RANGE_CHECK(mem, a, sizeof(t))

--- a/test/wasm2c/export-names.txt
+++ b/test/wasm2c/export-names.txt
@@ -137,7 +137,7 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
     TRAP(OOB);
 #endif
 
-#if WASM_RT_MEMCHECK_SIGNAL_HANDLER
+#if WASM_RT_MEMCHECK_GUARD_PAGES
 #define MEMCHECK(mem, a, t)
 #else
 #define MEMCHECK(mem, a, t) RANGE_CHECK(mem, a, sizeof(t))

--- a/test/wasm2c/hello.txt
+++ b/test/wasm2c/hello.txt
@@ -145,7 +145,7 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
     TRAP(OOB);
 #endif
 
-#if WASM_RT_MEMCHECK_SIGNAL_HANDLER
+#if WASM_RT_MEMCHECK_GUARD_PAGES
 #define MEMCHECK(mem, a, t)
 #else
 #define MEMCHECK(mem, a, t) RANGE_CHECK(mem, a, sizeof(t))

--- a/test/wasm2c/minimal.txt
+++ b/test/wasm2c/minimal.txt
@@ -108,7 +108,7 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
     TRAP(OOB);
 #endif
 
-#if WASM_RT_MEMCHECK_SIGNAL_HANDLER
+#if WASM_RT_MEMCHECK_GUARD_PAGES
 #define MEMCHECK(mem, a, t)
 #else
 #define MEMCHECK(mem, a, t) RANGE_CHECK(mem, a, sizeof(t))

--- a/wasm2c/examples/fac/fac.c
+++ b/wasm2c/examples/fac/fac.c
@@ -56,7 +56,7 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
     TRAP(OOB);
 #endif
 
-#if WASM_RT_MEMCHECK_SIGNAL_HANDLER
+#if WASM_RT_MEMCHECK_GUARD_PAGES
 #define MEMCHECK(mem, a, t)
 #else
 #define MEMCHECK(mem, a, t) RANGE_CHECK(mem, a, sizeof(t))

--- a/wasm2c/wasm-rt-impl.h
+++ b/wasm2c/wasm-rt-impl.h
@@ -30,7 +30,7 @@ extern "C" {
 /** A setjmp buffer used for handling traps. */
 extern WASM_RT_THREAD_LOCAL wasm_rt_jmp_buf g_wasm_rt_jmp_buf;
 
-#if WASM_RT_MEMCHECK_SIGNAL_HANDLER && !defined(_WIN32)
+#if WASM_RT_INSTALL_SIGNAL_HANDLER && !defined(_WIN32)
 #define WASM_RT_LONGJMP_UNCHECKED(buf, val) siglongjmp(buf, val)
 #else
 #define WASM_RT_LONGJMP_UNCHECKED(buf, val) longjmp(buf, val)


### PR DESCRIPTION
(Edited for the latest push)

The wasm2c runtime implementation today blends a couple of concepts together that make it hard to use in 32-bit environment. These are the
1. The memory allocation/growth strategy - **mmap** (memories supporting in-place growth) vs **malloc** (memories that may be moved to grow)
2. The OOB prevention strategy - **Guardpages** (which requires **mmap** memory, 64-bit platforms and WasmMemory32) vs **Boundschecks**. I am planing to add other strategies in the future. 

When using wasm2c in Firefox with RLBox, we want the following configurations
1. **mmap** always as RLBox does not support moveable memories
2. **Guardpages** on 64-bit and **BoundsChecks** on 32-bit (as guard pages are not supported in 32-bit)

Since wasm2c blends this concepts together these attributes are currently controlled by one macro `WASM_RT_MEMCHECK_SIGNAL_HANDLER` which says either use (**mmap** and **Guardpages**, supported only on a 64-bit platform) or (**malloc** and **BoundsChecks**)

This means we cannot get the 32-bit config we are using in Firefox with our wasm2c fork: **mmap** and **BoundsChecks** 

I want to propose decoupling these concepts each controllable with their own macros. We can do sanity checks to ensure disallowed combinations don't go through  (e.g., **malloc** with **Guardpages**). We can then eliminate the `WASM_RT_MEMCHECK_SIGNAL_HANDLER` altogether.  

I have also added some optional code to translate WASM_RT_MEMCHECK_SIGNAL_HANDLER to use the new macros we have added. We can add this if we want to preserve compat with this previous macro, but I am happy to remove this.

@keithw Heads up on this one, as this changes the `wasm-rt.h` header (But the optional compat code can preserve the old behavior if we want this)