### PR TITLE
c-writer.cc: Correctly handle label names when branching out of try block

### DIFF
--- a/src/c-writer.cc
+++ b/src/c-writer.cc
@@ -2837,7 +2837,9 @@ void CWriter::WriteTryCatch(const TryExpr& tryexpr) {
   Write(CloseBrace(), Newline()); /* end of try-catch */
 
   ResetTypeStack(mark);
-  Write(LabelDecl(label_stack_.back().name));
+  assert(!label_stack_.empty());
+  assert(label_stack_.back().name == tryexpr.block.label);
+  Write(LabelDecl(GetLocalName(tryexpr.block.label, true)));
   PopLabel();
   PushTypes(tryexpr.block.decl.sig.result_types);
 }
@@ -2939,7 +2941,9 @@ void CWriter::WriteTryDelegate(const TryExpr& tryexpr) {
 
   PopTryCatch();
   ResetTypeStack(mark);
-  Write(LabelDecl(label_stack_.back().name));
+  assert(!label_stack_.empty());
+  assert(label_stack_.back().name == tryexpr.block.label);
+  Write(LabelDecl(GetLocalName(tryexpr.block.label, true)));
   PopLabel();
   PushTypes(tryexpr.block.decl.sig.result_types);
 }

--- a/test/regress/wasm2c-try-br.txt
+++ b/test/regress/wasm2c-try-br.txt
@@ -1,0 +1,12 @@
+;;; TOOL: run-spec-wasm2c
+;;; ARGS: --debug-names --enable-exceptions
+(module
+  (func (export "break-try")
+    (try (do (br 0)) (delegate 0))
+  )
+)
+
+(assert_return (invoke "break-try"))
+(;; STDOUT ;;;
+1/1 tests passed.
+;;; STDOUT ;;)


### PR DESCRIPTION
~Sequenced behind #2207.~ Fixes #2205. wasm2c was making a LabelDecl with the raw Wasm name instead of the safe/unique C name. Because the label's C name is generated in `BeginTry` but the LabelDecl doesn't come until later, it's probably easiest just to re-retrieve the C name at that point. Or we could have `BeginTry` actually return the generated C name (along with the mark)...

The exception-handling proposal could benefit from better test coverage here (https://github.com/WebAssembly/exception-handling/issues/210) but this is definitely our bug!