### PR TITLE
wasm-rt-impl.c: wasm_rt_free() should reset g_signal_handler_installed

### DIFF
--- a/wasm2c/wasm-rt-impl.c
+++ b/wasm2c/wasm-rt-impl.c
@@ -294,6 +294,7 @@ bool wasm_rt_is_initialized(void) {
 void wasm_rt_free(void) {
 #if WASM_RT_INSTALL_SIGNAL_HANDLER
   os_cleanup_signal_handler();
+  g_signal_handler_installed = false;
 #endif
 }
 


### PR DESCRIPTION
Fixes #2206 