### PR TITLE
alloca() lives in <stdlib.h> on OpenBSD too (fixes #2216)

### DIFF
--- a/src/prebuilt/wasm2c_source_includes.cc
+++ b/src/prebuilt/wasm2c_source_includes.cc
@@ -20,7 +20,7 @@ R"w2c_template(#include <malloc.h>
 )w2c_template"
 R"w2c_template(#define alloca _alloca
 )w2c_template"
-R"w2c_template(#elif defined(__FreeBSD__)
+R"w2c_template(#elif defined(__FreeBSD__) || defined(__OpenBSD__)
 )w2c_template"
 R"w2c_template(#include <stdlib.h>
 )w2c_template"

--- a/src/template/wasm2c.includes.c
+++ b/src/template/wasm2c.includes.c
@@ -9,7 +9,7 @@
 #include <intrin.h>
 #include <malloc.h>
 #define alloca _alloca
-#elif defined(__FreeBSD__)
+#elif defined(__FreeBSD__) || defined(__OpenBSD__)
 #include <stdlib.h>
 #else
 #include <alloca.h>

--- a/test/wasm2c/add.txt
+++ b/test/wasm2c/add.txt
@@ -68,7 +68,7 @@ u32 w2c_test_add(w2c_test*, u32, u32);
 #include <intrin.h>
 #include <malloc.h>
 #define alloca _alloca
-#elif defined(__FreeBSD__)
+#elif defined(__FreeBSD__) || defined(__OpenBSD__)
 #include <stdlib.h>
 #else
 #include <alloca.h>

--- a/test/wasm2c/check-imports.txt
+++ b/test/wasm2c/check-imports.txt
@@ -91,7 +91,7 @@ extern const u8 wasm2c_test_is64_env_0x5F_linear_memory;
 #include <intrin.h>
 #include <malloc.h>
 #define alloca _alloca
-#elif defined(__FreeBSD__)
+#elif defined(__FreeBSD__) || defined(__OpenBSD__)
 #include <stdlib.h>
 #else
 #include <alloca.h>

--- a/test/wasm2c/export-names.txt
+++ b/test/wasm2c/export-names.txt
@@ -91,7 +91,7 @@ void w2c_test_0xE20x9D0xA40xEF0xB80x8F(w2c_test*);
 #include <intrin.h>
 #include <malloc.h>
 #define alloca _alloca
-#elif defined(__FreeBSD__)
+#elif defined(__FreeBSD__) || defined(__OpenBSD__)
 #include <stdlib.h>
 #else
 #include <alloca.h>

--- a/test/wasm2c/hello.txt
+++ b/test/wasm2c/hello.txt
@@ -99,7 +99,7 @@ void w2c_test_0x5Fstart(w2c_test*);
 #include <intrin.h>
 #include <malloc.h>
 #define alloca _alloca
-#elif defined(__FreeBSD__)
+#elif defined(__FreeBSD__) || defined(__OpenBSD__)
 #include <stdlib.h>
 #else
 #include <alloca.h>

--- a/test/wasm2c/minimal.txt
+++ b/test/wasm2c/minimal.txt
@@ -62,7 +62,7 @@ wasm_rt_func_type_t wasm2c_test_get_func_type(uint32_t param_count, uint32_t res
 #include <intrin.h>
 #include <malloc.h>
 #define alloca _alloca
-#elif defined(__FreeBSD__)
+#elif defined(__FreeBSD__) || defined(__OpenBSD__)
 #include <stdlib.h>
 #else
 #include <alloca.h>


### PR DESCRIPTION
per http://man.openbsd.org/alloca.3

totally untested in wabt itself, but fixes mozilla-central build for me.