### PR TITLE
BinaryReader/BinaryReaderIR: add safety checks for missing end markers in init expressions

### DIFF
--- a/src/binary-reader-ir.cc
+++ b/src/binary-reader-ir.cc
@@ -449,6 +449,10 @@ Result BinaryReaderIR::TopLabelExpr(LabelNode** label, Expr** expr) {
   CHECK_RESULT(TopLabel(label));
   LabelNode* parent_label;
   CHECK_RESULT(GetLabelAt(&parent_label, 1));
+  if (parent_label->exprs->empty()) {
+    PrintError("TopLabelExpr: parent label has empty expr list");
+    return Result::Error;
+  }
   *expr = &parent_label->exprs->back();
   return Result::Ok;
 }
@@ -1217,6 +1221,10 @@ Result BinaryReaderIR::OnUnreachableExpr() {
 
 Result BinaryReaderIR::EndFunctionBody(Index index) {
   current_func_ = nullptr;
+  if (!label_stack_.empty()) {
+    PrintError("function %" PRIindex " missing end marker", index);
+    return Result::Error;
+  }
   return Result::Ok;
 }
 
@@ -1297,6 +1305,10 @@ Result BinaryReaderIR::BeginElemSegmentInitExpr(Index index) {
 }
 
 Result BinaryReaderIR::EndInitExpr() {
+  if (!label_stack_.empty()) {
+    PrintError("init expression missing end marker");
+    return Result::Error;
+  }
   return Result::Ok;
 }
 

--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -560,7 +560,14 @@ Index BinaryReader::NumTotalFuncs() {
 
 Result BinaryReader::ReadInitExpr(Index index) {
   // Read instructions until END opcode is reached.
-  return ReadInstructions(/*stop_on_end=*/true, read_end_, NULL);
+  Opcode final_opcode(Opcode::Invalid);
+  CHECK_RESULT(
+      ReadInstructions(/*stop_on_end=*/true, read_end_, &final_opcode));
+  ERROR_UNLESS(state_.offset <= read_end_,
+               "init expression longer than given size");
+  ERROR_UNLESS(final_opcode == Opcode::End,
+               "init expression must end with END opcode");
+  return Result::Ok;
 }
 
 Result BinaryReader::ReadTable(Type* out_elem_type, Limits* out_elem_limits) {

--- a/test/regress/bad-missing-end.txt
+++ b/test/regress/bad-missing-end.txt
@@ -1,0 +1,11 @@
+;;; TOOL: run-gen-wasm-bad
+magic
+version
+section(TYPE) { count[1] function params[0] results[0] }
+section(FUNCTION) { count[1] type[0] }
+section(GLOBAL) { count[1] i32 mut[0] init_expr[] }
+section(CODE) { count[1] func { locals[0] } }
+(;; STDERR ;;;
+0000017: error: init expression must end with END opcode
+0000017: error: init expression must end with END opcode
+;;; STDERR ;;)

--- a/test/spec/binary.txt
+++ b/test/spec/binary.txt
@@ -265,7 +265,7 @@ out/test/spec/binary.wast:1653: assert_malformed passed:
 out/test/spec/binary.wast:1687: assert_malformed passed:
   0000021: error: unable to read u32 leb128: elem segment flags
 out/test/spec/binary.wast:1703: assert_malformed passed:
-  0000024: error: unable to read u32 leb128: elem count
+  0000024: error: init expression must end with END opcode
 out/test/spec/binary.wast:1720: assert_malformed passed:
   0000021: error: unfinished section (expected end: 0x27)
 out/test/spec/binary.wast:1746: assert_malformed passed:

--- a/test/spec/exception-handling/binary.txt
+++ b/test/spec/exception-handling/binary.txt
@@ -266,7 +266,7 @@ out/test/spec/exception-handling/binary.wast:1653: assert_malformed passed:
 out/test/spec/exception-handling/binary.wast:1687: assert_malformed passed:
   0000021: error: unable to read u32 leb128: elem segment flags
 out/test/spec/exception-handling/binary.wast:1703: assert_malformed passed:
-  0000024: error: unable to read u32 leb128: elem count
+  0000024: error: init expression must end with END opcode
 out/test/spec/exception-handling/binary.wast:1720: assert_malformed passed:
   0000021: error: unfinished section (expected end: 0x27)
 out/test/spec/exception-handling/binary.wast:1746: assert_malformed passed:

--- a/test/spec/multi-memory/binary.txt
+++ b/test/spec/multi-memory/binary.txt
@@ -246,7 +246,7 @@ out/test/spec/multi-memory/binary.wast:1462: assert_malformed passed:
 out/test/spec/multi-memory/binary.wast:1496: assert_malformed passed:
   0000021: error: unable to read u32 leb128: elem segment flags
 out/test/spec/multi-memory/binary.wast:1512: assert_malformed passed:
-  0000024: error: unable to read u32 leb128: elem count
+  0000024: error: init expression must end with END opcode
 out/test/spec/multi-memory/binary.wast:1529: assert_malformed passed:
   0000021: error: unfinished section (expected end: 0x27)
 out/test/spec/multi-memory/binary.wast:1555: assert_malformed passed:


### PR DESCRIPTION
Fixes #2199. (Possibly related to #1771)

This adds some safety checks in BinaryReader & BinaryReaderIR to prevent crashing on some "missing end marker" situations.

1. Add a check in BinaryReader that init expressions end with an "end" opcode (matching the pre-existing check for function bodies).
2. Add checks in BinaryReaderIR that the label stack is empty at the end of an init expression or function body. (This isn't enforced in validation or typechecking because the end markers don't make it into the IR.)
3. The test (regress/bad-missing-end.txt) triggers the same assertion failure as #2199 before applying this PR.