### PR TITLE
Make sure Validator and BinaryReaderInterp agree re: validity

### DIFF
--- a/src/validator.cc
+++ b/src/validator.cc
@@ -820,7 +820,7 @@ Result Validator::CheckModule() {
                                                   f->elem_segment.elem_type);
 
       // Init expr.
-      if (f->elem_segment.offset.size()) {
+      if (f->elem_segment.kind == SegmentKind::Active) {
         result_ |= validator_.BeginInitExpr(field.loc, Type::I32);
         ExprVisitor visitor(this);
         result_ |= visitor.VisitExprList(
@@ -881,7 +881,7 @@ Result Validator::CheckModule() {
                                           f->data_segment.kind);
 
       // Init expr.
-      if (f->data_segment.offset.size()) {
+      if (f->data_segment.kind == SegmentKind::Active) {
         Type offset_type = Type::I32;
         Index memory_index = module->GetMemoryIndex(f->data_segment.memory_var);
         if (memory_index < module->memories.size() &&


### PR DESCRIPTION
Right now we're running the spec tests against the BinaryReaderInterp, and the BinaryReaderIR and Validator are sometimes only tested in the wasm2c tests (which don't run the `assert_malformed`, `assert_invalid`, or `assert_unlinkable` tests yet).

This PR makes spectest-interp compare both readers/validators and bombs out when they disagree about module validity. This caught one issue where the Validator was mistakenly accepting some malformed modules from the (post bulk-memory) spec tests.

Fixes #2220 