### PR TITLE
wasm2c: provide option to disable exception handling in the runtime

### DIFF
--- a/wasm2c/wasm-rt-impl.c
+++ b/wasm2c/wasm-rt-impl.c
@@ -60,11 +60,13 @@ WASM_RT_THREAD_LOCAL uint32_t wasm_rt_saved_call_stack_depth;
 
 WASM_RT_THREAD_LOCAL wasm_rt_jmp_buf g_wasm_rt_jmp_buf;
 
+#if !WASM_RT_SKIP_EXCEPTION_HANDLING
 static WASM_RT_THREAD_LOCAL wasm_rt_tag_t g_active_exception_tag;
 static WASM_RT_THREAD_LOCAL uint8_t g_active_exception[MAX_EXCEPTION_SIZE];
 static WASM_RT_THREAD_LOCAL uint32_t g_active_exception_size;
 
 static WASM_RT_THREAD_LOCAL wasm_rt_jmp_buf* g_unwind_target;
+#endif
 
 #ifdef WASM_RT_TRAP_HANDLER
 extern void WASM_RT_TRAP_HANDLER(wasm_rt_trap_t code);
@@ -87,6 +89,8 @@ void wasm_rt_trap(wasm_rt_trap_t code) {
   WASM_RT_LONGJMP(g_wasm_rt_jmp_buf, code);
 #endif
 }
+
+#if !WASM_RT_SKIP_EXCEPTION_HANDLING
 
 void wasm_rt_load_exception(const wasm_rt_tag_t tag,
                             uint32_t size,
@@ -126,6 +130,8 @@ uint32_t wasm_rt_exception_size(void) {
 void* wasm_rt_exception(void) {
   return g_active_exception;
 }
+
+#endif
 
 #ifdef _WIN32
 static void* os_mmap(size_t size) {


### PR DESCRIPTION
In some of the audits prior to landing wasm2c in upstream Firefox, we saw that exception and tag handling for Wasm is implemented with globals, longjmp etc. While we don't use/plan to use `--enable-exceptions` at the moment, and I can't see anything immediately wrong with the runtime exception code, I think we need the ability to disable this code altogether in the runtime to safely say we aren't exposed to any bugs in this and to ensure other bugs in the application don't use this code as gadgets. This commit adds a macro to disable exception support in the wasm2c runtime. Naturally the support is still enabled by default so existing/new users are not confused, but for the Firefox case, I think we would need something like this macro to land this upstream.