### PR TITLE
 wasm2c: Enable exceptions and simd according to command line flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -415,7 +415,9 @@ if (WABT_INSTALL_RULES)
   )
 endif ()
 
-add_library(wasm-rt-impl STATIC wasm2c/wasm-rt-impl.c wasm2c/wasm-rt-impl.h)
+set(WASM_RT_FILES "wasm2c/wasm-rt-impl.h" "wasm2c/wasm-rt-impl.c" "wasm2c/wasm-rt-exceptions-impl.c")
+
+add_library(wasm-rt-impl STATIC ${WASM_RT_FILES})
 add_library(wabt::wasm-rt-impl ALIAS wasm-rt-impl)
 if (WABT_BIG_ENDIAN)
   target_compile_definitions(wasm-rt-impl PUBLIC WABT_BIG_ENDIAN=1)
@@ -429,12 +431,12 @@ if (WABT_INSTALL_RULES)
     INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
   )
   install(
-    FILES "wasm2c/wasm-rt.h"
+    FILES "wasm2c/wasm-rt.h" "wasm2c/wasm-rt-exceptions.h"
     TYPE INCLUDE
     COMPONENT wabt-development
   )
   install(
-    FILES "wasm2c/wasm-rt-impl.h" "wasm2c/wasm-rt-impl.c"
+    FILES ${WASM_RT_FILES}
     DESTINATION "${CMAKE_INSTALL_DATADIR}/wabt/wasm2c"
     COMPONENT wabt-development
   )

--- a/include/wabt/c-writer.h
+++ b/include/wabt/c-writer.h
@@ -19,6 +19,7 @@
 
 #include <functional>
 #include "wabt/common.h"
+#include "wabt/feature.h"
 #include "wabt/ir.h"
 
 namespace wabt {
@@ -28,6 +29,8 @@ class Stream;
 
 struct WriteCOptions {
   std::string_view module_name;
+  /* Set of wasm features enabled for wasm2c */
+  Features* features;
   /*
    * name_to_output_file_index takes const iterators to begin and end of a list
    * of all functions in the module, number of imported functions, and number of

--- a/src/c-writer.cc
+++ b/src/c-writer.cc
@@ -368,6 +368,7 @@ class CWriter {
                                   const std::string&);
   void WriteCallIndirectFuncDeclaration(const FuncDeclaration&,
                                         const std::string&);
+  void WriteFeatureMacros();
   void WriteModuleInstance();
   void WriteGlobals();
   void WriteGlobal(const Global&, const std::string&);
@@ -1787,6 +1788,15 @@ void CWriter::WriteCallIndirectFuncDeclaration(const FuncDeclaration& decl,
   Write(ResultType(decl.sig.result_types), " ", name, "(void*");
   WriteParamTypes(decl);
   Write(")");
+}
+
+void CWriter::WriteFeatureMacros() {
+  if (options_.features->exceptions_enabled()) {
+    Write("#define WASM_RT_ENABLE_EXCEPTION_HANDLING", Newline(), Newline());
+  }
+  if (options_.features->simd_enabled()) {
+    Write("#define WASM_RT_ENABLE_SIMD", Newline(), Newline());
+  }
 }
 
 void CWriter::WriteModuleInstance() {
@@ -5122,6 +5132,7 @@ void CWriter::WriteCHeader() {
   Write("#ifndef ", guard, Newline());
   Write("#define ", guard, Newline());
   Write(Newline());
+  WriteFeatureMacros();
   Write(s_header_top);
   Write(Newline());
   WriteModuleInstance();

--- a/src/prebuilt/wasm2c_header_top.cc
+++ b/src/prebuilt/wasm2c_header_top.cc
@@ -4,6 +4,13 @@ R"w2c_template(
 #include "wasm-rt.h"
 )w2c_template"
 R"w2c_template(
+#if defined(WASM_RT_ENABLE_EXCEPTION_HANDLING)
+)w2c_template"
+R"w2c_template(#include "wasm-rt-exceptions.h"
+)w2c_template"
+R"w2c_template(#endif
+)w2c_template"
+R"w2c_template(
 #if defined(WASM_RT_ENABLE_SIMD)
 )w2c_template"
 R"w2c_template(#include "simde/wasm/simd128.h"

--- a/src/template/wasm2c.top.h
+++ b/src/template/wasm2c.top.h
@@ -2,6 +2,10 @@
 
 #include "wasm-rt.h"
 
+#if defined(WASM_RT_ENABLE_EXCEPTION_HANDLING)
+#include "wasm-rt-exceptions.h"
+#endif
+
 #if defined(WASM_RT_ENABLE_SIMD)
 #include "simde/wasm/simd128.h"
 #endif

--- a/src/tools/wasm2c.cc
+++ b/src/tools/wasm2c.cc
@@ -60,7 +60,7 @@ examples:
 
 static const std::string supported_features[] = {
     "multi-memory", "multi-value", "sign-extension", "saturating-float-to-int",
-    "exceptions",   "memory64",    "extended-const"};
+    "exceptions",   "memory64",    "extended-const", "simd"};
 
 static bool IsFeatureSupported(const std::string& feature) {
   return std::find(std::begin(supported_features), std::end(supported_features),
@@ -100,12 +100,13 @@ static void ParseOptions(int argc, char** argv) {
                        ConvertBackslashToSlash(&s_infile);
                      });
   parser.Parse(argc, argv);
+  s_write_c_options.features = &s_features;
 
   bool any_non_supported_feature = false;
 #define WABT_FEATURE(variable, flag, default_, help)   \
   any_non_supported_feature |=                         \
       (s_features.variable##_enabled() != default_) && \
-      !IsFeatureSupported(flag);
+      s_features.variable##_enabled() && !IsFeatureSupported(flag);
 #include "wabt/feature.def"
 #undef WABT_FEATURE
 

--- a/test/run-spec-wasm2c.py
+++ b/test/run-spec-wasm2c.py
@@ -452,15 +452,13 @@ def Compile(cc, c_filename, out_dir, *cflags):
     o_filename = utils.ChangeDir(utils.ChangeExt(c_filename, ext), out_dir)
     args = list(cflags)
     if IS_WINDOWS:
-        args += ['/nologo', '/DWASM_RT_ENABLE_SIMD',
-                 '/MDd', '/c', c_filename, '/Fo' + o_filename]
+        args += ['/nologo', '/MDd', '/c', c_filename, '/Fo' + o_filename]
     else:
         # See "Compiling the wasm2c output" section of wasm2c/README.md
         # When compiling with -O2, GCC and clang require '-fno-optimize-sibling-calls'
         # and '-frounding-math' to maintain conformance with the spec tests
         # (GCC also requires '-fsignaling-nans')
         args += ['-c', c_filename, '-o', o_filename, '-O2',
-                 '-DWASM_RT_ENABLE_SIMD',
                  '-Wall', '-Werror', '-Wno-unused',
                  '-Wno-ignored-optimization-argument',
                  '-Wno-tautological-constant-out-of-range-compare',
@@ -621,6 +619,10 @@ def main(args):
             # Compile wasm-rt-impl.
             wasm_rt_impl_c = os.path.join(options.wasmrt_dir, 'wasm-rt-impl.c')
             o_filenames.append(Compile(cc, wasm_rt_impl_c, out_dir, *cflags))
+
+            # Compile wasm-rt-exceptions.
+            wasm_rt_exceptions_c = os.path.join(options.wasmrt_dir, 'wasm-rt-exceptions-impl.c')
+            o_filenames.append(Compile(cc, wasm_rt_exceptions_c, out_dir, *cflags))
 
             # Compile and link -main test run entry point
             o_filenames.append(Compile(cc, main_filename, out_dir, *cflags))

--- a/test/spec-wasm2c-prefix.c
+++ b/test/spec-wasm2c-prefix.c
@@ -11,6 +11,7 @@
 
 #include "wasm-rt.h"
 #include "wasm-rt-impl.h"
+#include "wasm-rt-exceptions.h"
 
 static int g_tests_run;
 static int g_tests_passed;

--- a/test/wasm2c/add.txt
+++ b/test/wasm2c/add.txt
@@ -8,9 +8,15 @@
 #ifndef WASM_H_GENERATED_
 #define WASM_H_GENERATED_
 
+#define WASM_RT_ENABLE_SIMD
+
 #include <stdint.h>
 
 #include "wasm-rt.h"
+
+#if defined(WASM_RT_ENABLE_EXCEPTION_HANDLING)
+#include "wasm-rt-exceptions.h"
+#endif
 
 #if defined(WASM_RT_ENABLE_SIMD)
 #include "simde/wasm/simd128.h"

--- a/test/wasm2c/check-imports.txt
+++ b/test/wasm2c/check-imports.txt
@@ -21,9 +21,15 @@
 #ifndef WASM_H_GENERATED_
 #define WASM_H_GENERATED_
 
+#define WASM_RT_ENABLE_SIMD
+
 #include <stdint.h>
 
 #include "wasm-rt.h"
+
+#if defined(WASM_RT_ENABLE_EXCEPTION_HANDLING)
+#include "wasm-rt-exceptions.h"
+#endif
 
 #if defined(WASM_RT_ENABLE_SIMD)
 #include "simde/wasm/simd128.h"

--- a/test/wasm2c/export-names.txt
+++ b/test/wasm2c/export-names.txt
@@ -11,9 +11,15 @@
 #ifndef WASM_H_GENERATED_
 #define WASM_H_GENERATED_
 
+#define WASM_RT_ENABLE_SIMD
+
 #include <stdint.h>
 
 #include "wasm-rt.h"
+
+#if defined(WASM_RT_ENABLE_EXCEPTION_HANDLING)
+#include "wasm-rt-exceptions.h"
+#endif
 
 #if defined(WASM_RT_ENABLE_SIMD)
 #include "simde/wasm/simd128.h"

--- a/test/wasm2c/hello.txt
+++ b/test/wasm2c/hello.txt
@@ -26,9 +26,15 @@
 #ifndef WASM_H_GENERATED_
 #define WASM_H_GENERATED_
 
+#define WASM_RT_ENABLE_SIMD
+
 #include <stdint.h>
 
 #include "wasm-rt.h"
+
+#if defined(WASM_RT_ENABLE_EXCEPTION_HANDLING)
+#include "wasm-rt-exceptions.h"
+#endif
 
 #if defined(WASM_RT_ENABLE_SIMD)
 #include "simde/wasm/simd128.h"

--- a/test/wasm2c/minimal.txt
+++ b/test/wasm2c/minimal.txt
@@ -5,9 +5,15 @@
 #ifndef WASM_H_GENERATED_
 #define WASM_H_GENERATED_
 
+#define WASM_RT_ENABLE_SIMD
+
 #include <stdint.h>
 
 #include "wasm-rt.h"
+
+#if defined(WASM_RT_ENABLE_EXCEPTION_HANDLING)
+#include "wasm-rt-exceptions.h"
+#endif
 
 #if defined(WASM_RT_ENABLE_SIMD)
 #include "simde/wasm/simd128.h"

--- a/wasm2c/README.md
+++ b/wasm2c/README.md
@@ -341,8 +341,9 @@ exhaustion.
 
 ### Runtime support for exception handling
 
-Several additional symbols must be defined if wasm2c is being run with
-support for exceptions (`--enable-exceptions`):
+Several additional symbols must be defined if wasm2c is being run with support
+for exceptions (`--enable-exceptions`). These are defined in
+`wasm-rt-exceptions.h`. These symbols are:
 
 ```c
 void wasm_rt_load_exception(const char* tag, uint32_t size, const void* values);
@@ -357,7 +358,7 @@ wasm_rt_try(target)
 ```
 
 A C implementation of these functions is also available in
-[`wasm-rt-impl.h`](wasm-rt-impl.h) and [`wasm-rt-impl.c`](wasm-rt-impl.c).
+[`wasm-rt-exceptions-impl.c`](wasm-rt-exceptions-impl.c).
 
 `wasm_rt_load_exception` sets the active exception to a given tag, size, and contents.
 

--- a/wasm2c/examples/callback/Makefile
+++ b/wasm2c/examples/callback/Makefile
@@ -14,6 +14,6 @@ callback.wasm: callback.wat ../../../bin/wat2wasm
 	../../../bin/wat2wasm --debug-names $< -o $@
 
 callback.c: callback.wasm ../../../bin/wasm2c
-	../../../bin/wasm2c $< -o $@
+	../../../bin/wasm2c $< -o $@ --disable-simd
 
 .PHONY: all clean

--- a/wasm2c/examples/fac/Makefile
+++ b/wasm2c/examples/fac/Makefile
@@ -12,6 +12,6 @@ fac.wasm: fac.wat ../../../bin/wat2wasm
 	../../../bin/wat2wasm $< -o $@
 
 fac.c: fac.wasm ../../../bin/wasm2c
-	../../../bin/wasm2c $< -o $@
+	../../../bin/wasm2c $< -o $@ --disable-simd
 
 .PHONY: all clean

--- a/wasm2c/examples/fac/fac.c
+++ b/wasm2c/examples/fac/fac.c
@@ -4,10 +4,14 @@
 #include <stdarg.h>
 #include <stddef.h>
 #include <string.h>
-#if defined(_MSC_VER)
+#if defined(__MINGW32__)
+#include <malloc.h>
+#elif defined(_MSC_VER)
 #include <intrin.h>
 #include <malloc.h>
 #define alloca _alloca
+#elif defined(__FreeBSD__) || defined(__OpenBSD__)
+#include <stdlib.h>
 #else
 #include <alloca.h>
 #endif

--- a/wasm2c/examples/fac/fac.h
+++ b/wasm2c/examples/fac/fac.h
@@ -6,6 +6,10 @@
 
 #include "wasm-rt.h"
 
+#if defined(WASM_RT_ENABLE_EXCEPTION_HANDLING)
+#include "wasm-rt-exceptions.h"
+#endif
+
 #if defined(WASM_RT_ENABLE_SIMD)
 #include "simde/wasm/simd128.h"
 #endif

--- a/wasm2c/examples/rot13/Makefile
+++ b/wasm2c/examples/rot13/Makefile
@@ -14,6 +14,6 @@ rot13.wasm: rot13.wat ../../../bin/wat2wasm
 	../../../bin/wat2wasm $< -o $@
 
 rot13.c: rot13.wasm ../../../bin/wasm2c
-	../../../bin/wasm2c $< -o $@
+	../../../bin/wasm2c $< -o $@ --disable-simd
 
 .PHONY: all clean

--- a/wasm2c/wasm-rt-exceptions-impl.c
+++ b/wasm2c/wasm-rt-exceptions-impl.c
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2018 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "wasm-rt.h"
+
+#include "wasm-rt-exceptions.h"
+
+#include <string.h>
+
+#define MAX_EXCEPTION_SIZE 256
+
+static WASM_RT_THREAD_LOCAL wasm_rt_tag_t g_active_exception_tag;
+static WASM_RT_THREAD_LOCAL uint8_t g_active_exception[MAX_EXCEPTION_SIZE];
+static WASM_RT_THREAD_LOCAL uint32_t g_active_exception_size;
+
+static WASM_RT_THREAD_LOCAL wasm_rt_jmp_buf* g_unwind_target;
+
+void wasm_rt_load_exception(const wasm_rt_tag_t tag,
+                            uint32_t size,
+                            const void* values) {
+  if (size > MAX_EXCEPTION_SIZE) {
+    wasm_rt_trap(WASM_RT_TRAP_EXHAUSTION);
+  }
+
+  g_active_exception_tag = tag;
+  g_active_exception_size = size;
+
+  if (size) {
+    memcpy(g_active_exception, values, size);
+  }
+}
+
+WASM_RT_NO_RETURN void wasm_rt_throw(void) {
+  WASM_RT_LONGJMP(*g_unwind_target, WASM_RT_TRAP_UNCAUGHT_EXCEPTION);
+}
+
+WASM_RT_UNWIND_TARGET* wasm_rt_get_unwind_target(void) {
+  return g_unwind_target;
+}
+
+void wasm_rt_set_unwind_target(WASM_RT_UNWIND_TARGET* target) {
+  g_unwind_target = target;
+}
+
+wasm_rt_tag_t wasm_rt_exception_tag(void) {
+  return g_active_exception_tag;
+}
+
+uint32_t wasm_rt_exception_size(void) {
+  return g_active_exception_size;
+}
+
+void* wasm_rt_exception(void) {
+  return g_active_exception;
+}

--- a/wasm2c/wasm-rt-exceptions.h
+++ b/wasm2c/wasm-rt-exceptions.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2018 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef WASM_RT_EXCEPTIONS_H_
+#define WASM_RT_EXCEPTIONS_H_
+
+#include "wasm-rt.h"
+
+/**
+ * A tag is represented as an arbitrary pointer.
+ */
+typedef const void* wasm_rt_tag_t;
+
+/**
+ * Set the active exception to given tag, size, and contents.
+ */
+void wasm_rt_load_exception(const wasm_rt_tag_t tag,
+                            uint32_t size,
+                            const void* values);
+
+/**
+ * Throw the active exception.
+ */
+WASM_RT_NO_RETURN void wasm_rt_throw(void);
+
+/**
+ * The type of an unwind target if an exception is thrown and caught.
+ */
+#define WASM_RT_UNWIND_TARGET wasm_rt_jmp_buf
+
+/**
+ * Get the current unwind target if an exception is thrown.
+ */
+WASM_RT_UNWIND_TARGET* wasm_rt_get_unwind_target(void);
+
+/**
+ * Set the unwind target if an exception is thrown.
+ */
+void wasm_rt_set_unwind_target(WASM_RT_UNWIND_TARGET* target);
+
+/**
+ * Tag of the active exception.
+ */
+wasm_rt_tag_t wasm_rt_exception_tag(void);
+
+/**
+ * Size of the active exception.
+ */
+uint32_t wasm_rt_exception_size(void);
+
+/**
+ * Contents of the active exception.
+ */
+void* wasm_rt_exception(void);
+
+#endif

--- a/wasm2c/wasm-rt-impl.h
+++ b/wasm2c/wasm-rt-impl.h
@@ -30,19 +30,6 @@ extern "C" {
 /** A setjmp buffer used for handling traps. */
 extern WASM_RT_THREAD_LOCAL wasm_rt_jmp_buf g_wasm_rt_jmp_buf;
 
-#if WASM_RT_INSTALL_SIGNAL_HANDLER && !defined(_WIN32)
-#define WASM_RT_LONGJMP_UNCHECKED(buf, val) siglongjmp(buf, val)
-#else
-#define WASM_RT_LONGJMP_UNCHECKED(buf, val) longjmp(buf, val)
-#endif
-
-#define WASM_RT_LONGJMP(buf, val)                                  \
-  /* Abort on failure as this may be called in the trap handler */ \
-  if (!((buf).initialized))                                        \
-    abort();                                                       \
-  (buf).initialized = false;                                       \
-  WASM_RT_LONGJMP_UNCHECKED((buf).buffer, val)
-
 #if WASM_RT_USE_STACK_DEPTH_COUNT
 /** Saved call stack depth that will be restored in case a trap occurs. */
 extern WASM_RT_THREAD_LOCAL uint32_t wasm_rt_saved_call_stack_depth;


### PR DESCRIPTION
Ensure exceptions and simd are enabled according the feature flags exposed in the command line of wasm2c

@sbc100 Would this be close to what you were suggesting in https://github.com/WebAssembly/wabt/pull/2221#issuecomment-1527752792
Happy to bikeshed some more