### PR TITLE
wasm2c: reduce the max exceptions size

### DIFF
--- a/wasm2c/wasm-rt-impl.c
+++ b/wasm2c/wasm-rt-impl.c
@@ -42,7 +42,7 @@
 #endif
 
 #define PAGE_SIZE 65536
-#define MAX_EXCEPTION_SIZE PAGE_SIZE
+#define MAX_EXCEPTION_SIZE 256
 
 #if WASM_RT_INSTALL_SIGNAL_HANDLER
 static bool g_signal_handler_installed = false;


### PR DESCRIPTION
Per suggestion of @sbc100 in https://github.com/WebAssembly/wabt/pull/2222#discussion_r1181155780, reducing the size of maximum exceptions