### PR TITLE
wasm2c: update simde submodule to 0.7.4-rc4 and add remaining tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Wabt has been compiled to JavaScript via emscripten. Some of the functionality i
 | [mutable globals][]   | `--disable-mutable-globals` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | [nontrapping float-to-int conversions][] | `--disable-saturating-float-to-int` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | [sign extension][]    | `--disable-sign-extension`  | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| [simd][]              | `--disable-simd`            | ✓ | ✓ | ✓ | ✓ | ✓ | 🚧 |
+| [simd][]              | `--disable-simd`            | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | [threads][]           | `--enable-threads`          |   | ✓ | ✓ | ✓ | ✓ |   |
 | [multi-value][]       | `--disable-multi-value`     | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | [tail-call][]         | `--enable-tail-call`        |   | ✓ | ✓ | ✓ | ✓ |   |

--- a/test/wasm2c/spec/simd_f32x4.txt
+++ b/test/wasm2c/spec/simd_f32x4.txt
@@ -1,0 +1,5 @@
+;;; TOOL: run-spec-wasm2c
+;;; STDIN_FILE: third_party/testsuite/simd_f32x4.wast
+(;; STDOUT ;;;
+772/772 tests passed.
+;;; STDOUT ;;)

--- a/test/wasm2c/spec/simd_f32x4_rounding.txt
+++ b/test/wasm2c/spec/simd_f32x4_rounding.txt
@@ -1,0 +1,5 @@
+;;; TOOL: run-spec-wasm2c
+;;; STDIN_FILE: third_party/testsuite/simd_f32x4_rounding.wast
+(;; STDOUT ;;;
+176/176 tests passed.
+;;; STDOUT ;;)

--- a/test/wasm2c/spec/simd_f64x2.txt
+++ b/test/wasm2c/spec/simd_f64x2.txt
@@ -1,0 +1,5 @@
+;;; TOOL: run-spec-wasm2c
+;;; STDIN_FILE: third_party/testsuite/simd_f64x2.wast
+(;; STDOUT ;;;
+793/793 tests passed.
+;;; STDOUT ;;)

--- a/test/wasm2c/spec/simd_f64x2_rounding.txt
+++ b/test/wasm2c/spec/simd_f64x2_rounding.txt
@@ -1,0 +1,5 @@
+;;; TOOL: run-spec-wasm2c
+;;; STDIN_FILE: third_party/testsuite/simd_f64x2_rounding.wast
+(;; STDOUT ;;;
+176/176 tests passed.
+;;; STDOUT ;;)

--- a/test/wasm2c/spec/simd_i16x8_q15mulr_sat_s.txt
+++ b/test/wasm2c/spec/simd_i16x8_q15mulr_sat_s.txt
@@ -1,0 +1,5 @@
+;;; TOOL: run-spec-wasm2c
+;;; STDIN_FILE: third_party/testsuite/simd_i16x8_q15mulr_sat_s.wast
+(;; STDOUT ;;;
+26/26 tests passed.
+;;; STDOUT ;;)


### PR DESCRIPTION
This completes support for the SIMD proposal that was mostly done in #2021 / #2119.

Will check first three boxes in #2224.