### PR TITLE
Track use of SIMD and exceptions in IR, and CWriter includes support only if used

### DIFF
--- a/include/wabt/c-writer.h
+++ b/include/wabt/c-writer.h
@@ -29,8 +29,6 @@ class Stream;
 
 struct WriteCOptions {
   std::string_view module_name;
-  /* Set of wasm features enabled for wasm2c */
-  Features* features;
   /*
    * name_to_output_file_index takes const iterators to begin and end of a list
    * of all functions in the module, number of imported functions, and number of

--- a/include/wabt/ir.h
+++ b/include/wabt/ir.h
@@ -1245,6 +1245,12 @@ struct Module {
   BindingHash memory_bindings;
   BindingHash data_segment_bindings;
   BindingHash elem_segment_bindings;
+
+  // Feature tracking for a subset of supported features
+  struct {
+    bool simd = false;
+    bool exceptions = false;
+  } features;
 };
 
 enum class ScriptModuleType {

--- a/include/wabt/ir.h
+++ b/include/wabt/ir.h
@@ -1246,11 +1246,13 @@ struct Module {
   BindingHash data_segment_bindings;
   BindingHash elem_segment_bindings;
 
-  // Feature tracking for a subset of supported features
+  // For a subset of features, the BinaryReaderIR tracks whether they are
+  // actually used by the module. wasm2c (CWriter) uses this information to
+  // limit its output in some cases.
   struct {
     bool simd = false;
     bool exceptions = false;
-  } features;
+  } features_used;
 };
 
 enum class ScriptModuleType {

--- a/src/binary-reader-ir.cc
+++ b/src/binary-reader-ir.cc
@@ -526,6 +526,15 @@ Result BinaryReaderIR::OnFuncType(Index index,
   auto func_type = std::make_unique<FuncType>();
   func_type->sig.param_types.assign(param_types, param_types + param_count);
   func_type->sig.result_types.assign(result_types, result_types + result_count);
+
+  module_->features.simd |=
+      std::any_of(func_type->sig.param_types.begin(),
+                  func_type->sig.param_types.end(),
+                  [](auto x) { return x == Type::V128; }) |
+      std::any_of(func_type->sig.result_types.begin(),
+                  func_type->sig.result_types.end(),
+                  [](auto x) { return x == Type::V128; });
+
   field->type = std::move(func_type);
   module_->AppendField(std::move(field));
   return Result::Ok;
@@ -540,6 +549,7 @@ Result BinaryReaderIR::OnStructType(Index index,
   for (Index i = 0; i < field_count; ++i) {
     struct_type->fields[i].type = fields[i].type;
     struct_type->fields[i].mutable_ = fields[i].mutable_;
+    module_->features.simd |= (fields[i].type == Type::V128);
   }
   field->type = std::move(struct_type);
   module_->AppendField(std::move(field));
@@ -551,6 +561,7 @@ Result BinaryReaderIR::OnArrayType(Index index, TypeMut type_mut) {
   auto array_type = std::make_unique<ArrayType>();
   array_type->field.type = type_mut.type;
   array_type->field.mutable_ = type_mut.mutable_;
+  module_->features.simd |= (type_mut.type == Type::V128);
   field->type = std::move(array_type);
   module_->AppendField(std::move(field));
   return Result::Ok;
@@ -620,6 +631,7 @@ Result BinaryReaderIR::OnImportGlobal(Index import_index,
   import->global.mutable_ = mutable_;
   module_->AppendField(
       std::make_unique<ImportModuleField>(std::move(import), GetLocation()));
+  module_->features.simd |= (type == Type::V128);
   return Result::Ok;
 }
 
@@ -634,6 +646,7 @@ Result BinaryReaderIR::OnImportTag(Index import_index,
   SetFuncDeclaration(&import->tag.decl, Var(sig_index, GetLocation()));
   module_->AppendField(
       std::make_unique<ImportModuleField>(std::move(import), GetLocation()));
+  module_->features.exceptions = true;
   return Result::Ok;
 }
 
@@ -698,6 +711,7 @@ Result BinaryReaderIR::BeginGlobal(Index index, Type type, bool mutable_) {
   global.type = type;
   global.mutable_ = mutable_;
   module_->AppendField(std::move(field));
+  module_->features.simd |= (type == Type::V128);
   return Result::Ok;
 }
 
@@ -763,6 +777,7 @@ Result BinaryReaderIR::OnLocalDecl(Index decl_index, Index count, Type type) {
     return Result::Error;
   }
 
+  module_->features.simd |= (type == Type::V128);
   return Result::Ok;
 }
 
@@ -772,6 +787,7 @@ Result BinaryReaderIR::OnOpcode(Opcode opcode) {
   if (metadata) {
     return AppendExpr(std::move(metadata));
   }
+  module_->features.simd |= (opcode.GetResultType() == Type::V128);
   return Result::Ok;
 }
 
@@ -1143,6 +1159,7 @@ Result BinaryReaderIR::OnTryExpr(Type sig_type) {
   ExprList* expr_list = &expr->block.exprs;
   SetBlockDeclaration(&expr->block.decl, sig_type);
   CHECK_RESULT(AppendExpr(std::move(expr_ptr)));
+  module_->features.exceptions = true;
   return PushLabel(LabelType::Try, expr_list, expr);
 }
 
@@ -1647,6 +1664,7 @@ Result BinaryReaderIR::OnTagType(Index index, Index sig_index) {
   Tag& tag = field->tag;
   SetFuncDeclaration(&tag.decl, Var(sig_index, GetLocation()));
   module_->AppendField(std::move(field));
+  module_->features.exceptions = true;
   return Result::Ok;
 }
 

--- a/src/c-writer.cc
+++ b/src/c-writer.cc
@@ -1791,10 +1791,10 @@ void CWriter::WriteCallIndirectFuncDeclaration(const FuncDeclaration& decl,
 }
 
 void CWriter::WriteFeatureMacros() {
-  if (module_->features.exceptions) {
+  if (module_->features_used.exceptions) {
     Write("#define WASM_RT_ENABLE_EXCEPTION_HANDLING", Newline(), Newline());
   }
-  if (module_->features.simd) {
+  if (module_->features_used.simd) {
     Write("#define WASM_RT_ENABLE_SIMD", Newline(), Newline());
   }
 }

--- a/src/c-writer.cc
+++ b/src/c-writer.cc
@@ -1791,10 +1791,10 @@ void CWriter::WriteCallIndirectFuncDeclaration(const FuncDeclaration& decl,
 }
 
 void CWriter::WriteFeatureMacros() {
-  if (options_.features->exceptions_enabled()) {
+  if (module_->features.exceptions) {
     Write("#define WASM_RT_ENABLE_EXCEPTION_HANDLING", Newline(), Newline());
   }
-  if (options_.features->simd_enabled()) {
+  if (module_->features.simd) {
     Write("#define WASM_RT_ENABLE_SIMD", Newline(), Newline());
   }
 }

--- a/src/tools/wasm2c.cc
+++ b/src/tools/wasm2c.cc
@@ -100,7 +100,6 @@ static void ParseOptions(int argc, char** argv) {
                        ConvertBackslashToSlash(&s_infile);
                      });
   parser.Parse(argc, argv);
-  s_write_c_options.features = &s_features;
 
   bool any_non_supported_feature = false;
 #define WABT_FEATURE(variable, flag, default_, help)   \

--- a/test/wasm2c/add.txt
+++ b/test/wasm2c/add.txt
@@ -8,8 +8,6 @@
 #ifndef WASM_H_GENERATED_
 #define WASM_H_GENERATED_
 
-#define WASM_RT_ENABLE_SIMD
-
 #include <stdint.h>
 
 #include "wasm-rt.h"

--- a/test/wasm2c/check-imports.txt
+++ b/test/wasm2c/check-imports.txt
@@ -21,8 +21,6 @@
 #ifndef WASM_H_GENERATED_
 #define WASM_H_GENERATED_
 
-#define WASM_RT_ENABLE_SIMD
-
 #include <stdint.h>
 
 #include "wasm-rt.h"

--- a/test/wasm2c/export-names.txt
+++ b/test/wasm2c/export-names.txt
@@ -11,8 +11,6 @@
 #ifndef WASM_H_GENERATED_
 #define WASM_H_GENERATED_
 
-#define WASM_RT_ENABLE_SIMD
-
 #include <stdint.h>
 
 #include "wasm-rt.h"

--- a/test/wasm2c/hello.txt
+++ b/test/wasm2c/hello.txt
@@ -26,8 +26,6 @@
 #ifndef WASM_H_GENERATED_
 #define WASM_H_GENERATED_
 
-#define WASM_RT_ENABLE_SIMD
-
 #include <stdint.h>
 
 #include "wasm-rt.h"

--- a/test/wasm2c/minimal.txt
+++ b/test/wasm2c/minimal.txt
@@ -5,8 +5,6 @@
 #ifndef WASM_H_GENERATED_
 #define WASM_H_GENERATED_
 
-#define WASM_RT_ENABLE_SIMD
-
 #include <stdint.h>
 
 #include "wasm-rt.h"


### PR DESCRIPTION
This is tasks 4 and 5 from #2224.