### PR TITLE
wasm2c: use standard C type names in headers

### DIFF
--- a/src/c-writer.cc
+++ b/src/c-writer.cc
@@ -315,6 +315,7 @@ class CWriter {
   static const char* GetReferenceTypeName(const Type& type);
   static const char* GetReferenceNullValue(const Type& type);
   static const char* GetCTypeName(const Type& type);
+  static const char* GetImplTypeName(const Type& type);
 
   const char* InternalSymbolScope() const;
 
@@ -1142,6 +1143,23 @@ void CWriter::Write(const StackVar& sv) {
 const char* CWriter::GetCTypeName(const Type& type) {
   // clang-format off
   switch (type) {
+  case Type::I32: return "uint32_t";
+  case Type::I64: return "uint64_t";
+  case Type::F32: return "float";
+  case Type::F64: return "double";
+  case Type::V128: return "simde_v128_t";
+  case Type::FuncRef: return "wasm_rt_funcref_t";
+  case Type::ExternRef: return "wasm_rt_externref_t";
+  default:
+    WABT_UNREACHABLE;
+  }
+  // clang-format on
+}
+
+// static
+const char* CWriter::GetImplTypeName(const Type& type) {
+  // clang-format off
+  switch (type) {
   case Type::I32: return "u32";
   case Type::I64: return "u64";
   case Type::F32: return "f32";
@@ -1149,14 +1167,15 @@ const char* CWriter::GetCTypeName(const Type& type) {
   case Type::V128: return "v128";
   case Type::FuncRef: return "wasm_rt_funcref_t";
   case Type::ExternRef: return "wasm_rt_externref_t";
-    default:
-      WABT_UNREACHABLE;
+  default:
+    WABT_UNREACHABLE;
   }
   // clang-format on
 }
 
 void CWriter::Write(Type type) {
-  Write(GetCTypeName(type));
+  const bool is_header = stream_ == h_stream_;
+  Write((is_header ? GetCTypeName : GetImplTypeName)(type));
 }
 
 void CWriter::Write(TypeEnum type) {
@@ -2494,15 +2513,15 @@ void CWriter::WriteImportProperties(CWriterPhase kind) {
       const uint64_t default_max = limits->is_64
                                        ? (static_cast<uint64_t>(1) << 48)
                                        : (static_cast<uint64_t>(1) << 16);
-      write_import_prop(import, "min", "u64", limits->initial);
-      write_import_prop(import, "max", "u64",
+      write_import_prop(import, "min", "uint64_t", limits->initial);
+      write_import_prop(import, "max", "uint64_t",
                         limits->has_max ? limits->max : default_max);
-      write_import_prop(import, "is64", "u8", limits->is_64);
+      write_import_prop(import, "is64", "bool", limits->is_64);
     } else if (import->kind() == ExternalKind::Table) {
       const Limits* limits = &(cast<TableImport>(import)->table.elem_limits);
       const uint64_t default_max = std::numeric_limits<uint32_t>::max();
-      write_import_prop(import, "min", "u32", limits->initial);
-      write_import_prop(import, "max", "u32",
+      write_import_prop(import, "min", "uint32_t", limits->initial);
+      write_import_prop(import, "max", "uint32_t",
                         limits->has_max ? limits->max : default_max);
     } else {
       continue;

--- a/src/prebuilt/wasm2c_header_top.cc
+++ b/src/prebuilt/wasm2c_header_top.cc
@@ -1,7 +1,4 @@
-const char* s_header_top = R"w2c_template(#include <stdint.h>
-)w2c_template"
-R"w2c_template(
-#include "wasm-rt.h"
+const char* s_header_top = R"w2c_template(#include "wasm-rt.h"
 )w2c_template"
 R"w2c_template(
 #if defined(WASM_RT_ENABLE_EXCEPTION_HANDLING)
@@ -16,43 +13,6 @@ R"w2c_template(
 R"w2c_template(#include "simde/wasm/simd128.h"
 )w2c_template"
 R"w2c_template(#endif
-)w2c_template"
-R"w2c_template(
-/* TODO(binji): only use stdint.h types in header */
-)w2c_template"
-R"w2c_template(#ifndef WASM_RT_CORE_TYPES_DEFINED
-)w2c_template"
-R"w2c_template(#define WASM_RT_CORE_TYPES_DEFINED
-)w2c_template"
-R"w2c_template(typedef uint8_t u8;
-)w2c_template"
-R"w2c_template(typedef int8_t s8;
-)w2c_template"
-R"w2c_template(typedef uint16_t u16;
-)w2c_template"
-R"w2c_template(typedef int16_t s16;
-)w2c_template"
-R"w2c_template(typedef uint32_t u32;
-)w2c_template"
-R"w2c_template(typedef int32_t s32;
-)w2c_template"
-R"w2c_template(typedef uint64_t u64;
-)w2c_template"
-R"w2c_template(typedef int64_t s64;
-)w2c_template"
-R"w2c_template(typedef float f32;
-)w2c_template"
-R"w2c_template(typedef double f64;
-)w2c_template"
-R"w2c_template(
-#if defined(WASM_RT_ENABLE_SIMD)
-)w2c_template"
-R"w2c_template(typedef simde_v128_t v128;
-)w2c_template"
-R"w2c_template(#endif
-)w2c_template"
-R"w2c_template(
-#endif
 )w2c_template"
 R"w2c_template(
 #ifdef __cplusplus

--- a/src/prebuilt/wasm2c_source_declarations.cc
+++ b/src/prebuilt/wasm2c_source_declarations.cc
@@ -26,6 +26,27 @@ R"w2c_template(
 #define UNREACHABLE TRAP(UNREACHABLE)
 )w2c_template"
 R"w2c_template(
+typedef uint8_t u8;
+)w2c_template"
+R"w2c_template(typedef int8_t s8;
+)w2c_template"
+R"w2c_template(typedef uint16_t u16;
+)w2c_template"
+R"w2c_template(typedef int16_t s16;
+)w2c_template"
+R"w2c_template(typedef uint32_t u32;
+)w2c_template"
+R"w2c_template(typedef int32_t s32;
+)w2c_template"
+R"w2c_template(typedef uint64_t u64;
+)w2c_template"
+R"w2c_template(typedef int64_t s64;
+)w2c_template"
+R"w2c_template(typedef float f32;
+)w2c_template"
+R"w2c_template(typedef double f64;
+)w2c_template"
+R"w2c_template(
 static inline bool func_types_eq(const wasm_rt_func_type_t a,
 )w2c_template"
 R"w2c_template(                                 const wasm_rt_func_type_t b) {
@@ -272,6 +293,8 @@ R"w2c_template(DEFINE_STORE(i64_store32, u32, u64)
 )w2c_template"
 R"w2c_template(
 #if defined(WASM_RT_ENABLE_SIMD)
+)w2c_template"
+R"w2c_template(typedef simde_v128_t v128;
 )w2c_template"
 R"w2c_template(
 #ifdef __x86_64__

--- a/src/template/wasm2c.declarations.c
+++ b/src/template/wasm2c.declarations.c
@@ -15,6 +15,17 @@
 
 #define UNREACHABLE TRAP(UNREACHABLE)
 
+typedef uint8_t u8;
+typedef int8_t s8;
+typedef uint16_t u16;
+typedef int16_t s16;
+typedef uint32_t u32;
+typedef int32_t s32;
+typedef uint64_t u64;
+typedef int64_t s64;
+typedef float f32;
+typedef double f64;
+
 static inline bool func_types_eq(const wasm_rt_func_type_t a,
                                  const wasm_rt_func_type_t b) {
   return (a == b) || LIKELY(a && b && !memcmp(a, b, 32));
@@ -143,6 +154,7 @@ DEFINE_STORE(i64_store16, u16, u64)
 DEFINE_STORE(i64_store32, u32, u64)
 
 #if defined(WASM_RT_ENABLE_SIMD)
+typedef simde_v128_t v128;
 
 #ifdef __x86_64__
 #define SIMD_FORCE_READ(var) wasm_asm("" ::"x"(var));

--- a/src/template/wasm2c.top.h
+++ b/src/template/wasm2c.top.h
@@ -1,5 +1,3 @@
-#include <stdint.h>
-
 #include "wasm-rt.h"
 
 #if defined(WASM_RT_ENABLE_EXCEPTION_HANDLING)
@@ -8,26 +6,6 @@
 
 #if defined(WASM_RT_ENABLE_SIMD)
 #include "simde/wasm/simd128.h"
-#endif
-
-/* TODO(binji): only use stdint.h types in header */
-#ifndef WASM_RT_CORE_TYPES_DEFINED
-#define WASM_RT_CORE_TYPES_DEFINED
-typedef uint8_t u8;
-typedef int8_t s8;
-typedef uint16_t u16;
-typedef int16_t s16;
-typedef uint32_t u32;
-typedef int32_t s32;
-typedef uint64_t u64;
-typedef int64_t s64;
-typedef float f32;
-typedef double f64;
-
-#if defined(WASM_RT_ENABLE_SIMD)
-typedef simde_v128_t v128;
-#endif
-
 #endif
 
 #ifdef __cplusplus

--- a/test/run-spec-wasm2c.py
+++ b/test/run-spec-wasm2c.py
@@ -292,7 +292,7 @@ class CWriter(object):
                 lane_count = len(expected[0]['value'])
                 # type, fmt_expected, fmt_got, f, compare, expected, found
                 self.out_file.write('ASSERT_RETURN_MULTI_T(%s, %s, %s, %s, %s, (%s), (%s));\n' %
-                                    ("v128",
+                                    ("simde_v128_t",
                                      " ".join("MULTI_" + ("str" if val in ('nan:canonical', 'nan:arithmetic') else lane_type) for val in value),
                                      " ".join("MULTI_" + lane_type for _ in value),
                                      self._Action(command),

--- a/test/spec-wasm2c-prefix.c
+++ b/test/spec-wasm2c-prefix.c
@@ -170,6 +170,16 @@ static void error(const char* file, int line, const char* format, ...) {
     }                                                                         \
   } while (0)
 
+typedef uint8_t u8;
+typedef int8_t s8;
+typedef uint16_t u16;
+typedef int16_t s16;
+typedef uint32_t u32;
+typedef int32_t s32;
+typedef uint64_t u64;
+typedef int64_t s64;
+typedef float f32;
+typedef double f64;
 
 #define ASSERT_RETURN_I32(f, expected) ASSERT_RETURN_T(u32, "u", f, expected)
 #define ASSERT_RETURN_I64(f, expected) ASSERT_RETURN_T(u64, PRIu64, f, expected)

--- a/test/wasm2c/add.txt
+++ b/test/wasm2c/add.txt
@@ -8,8 +8,6 @@
 #ifndef WASM_H_GENERATED_
 #define WASM_H_GENERATED_
 
-#include <stdint.h>
-
 #include "wasm-rt.h"
 
 #if defined(WASM_RT_ENABLE_EXCEPTION_HANDLING)
@@ -18,26 +16,6 @@
 
 #if defined(WASM_RT_ENABLE_SIMD)
 #include "simde/wasm/simd128.h"
-#endif
-
-/* TODO(binji): only use stdint.h types in header */
-#ifndef WASM_RT_CORE_TYPES_DEFINED
-#define WASM_RT_CORE_TYPES_DEFINED
-typedef uint8_t u8;
-typedef int8_t s8;
-typedef uint16_t u16;
-typedef int16_t s16;
-typedef uint32_t u32;
-typedef int32_t s32;
-typedef uint64_t u64;
-typedef int64_t s64;
-typedef float f32;
-typedef double f64;
-
-#if defined(WASM_RT_ENABLE_SIMD)
-typedef simde_v128_t v128;
-#endif
-
 #endif
 
 #ifdef __cplusplus
@@ -53,7 +31,7 @@ void wasm2c_test_free(w2c_test*);
 wasm_rt_func_type_t wasm2c_test_get_func_type(uint32_t param_count, uint32_t result_count, ...);
 
 /* export: 'add' */
-u32 w2c_test_add(w2c_test*, u32, u32);
+uint32_t w2c_test_add(w2c_test*, uint32_t, uint32_t);
 
 #ifdef __cplusplus
 }
@@ -95,6 +73,17 @@ u32 w2c_test_add(w2c_test*, u32, u32);
 #endif
 
 #define UNREACHABLE TRAP(UNREACHABLE)
+
+typedef uint8_t u8;
+typedef int8_t s8;
+typedef uint16_t u16;
+typedef int16_t s16;
+typedef uint32_t u32;
+typedef int32_t s32;
+typedef uint64_t u64;
+typedef int64_t s64;
+typedef float f32;
+typedef double f64;
 
 static inline bool func_types_eq(const wasm_rt_func_type_t a,
                                  const wasm_rt_func_type_t b) {
@@ -224,6 +213,7 @@ DEFINE_STORE(i64_store16, u16, u64)
 DEFINE_STORE(i64_store32, u32, u64)
 
 #if defined(WASM_RT_ENABLE_SIMD)
+typedef simde_v128_t v128;
 
 #ifdef __x86_64__
 #define SIMD_FORCE_READ(var) wasm_asm("" ::"x"(var));
@@ -794,12 +784,12 @@ DEFINE_TABLE_FILL(externref)
 #define FUNC_TYPE_T(x) static const char x[]
 #endif
 
-static u32 w2c_test_add_0(w2c_test*, u32, u32);
+static uint32_t w2c_test_add_0(w2c_test*, uint32_t, uint32_t);
 
 FUNC_TYPE_T(w2c_test_t0) = "\x92\xfb\x6a\xdf\x49\x07\x0a\x83\xbe\x08\x02\x68\xcd\xf6\x95\x27\x4a\xc2\xf3\xe5\xe4\x7d\x29\x49\xe8\xed\x42\x92\x6a\x9d\xda\xf0";
 
 /* export: 'add' */
-u32 w2c_test_add(w2c_test* instance, u32 var_p0, u32 var_p1) {
+uint32_t w2c_test_add(w2c_test* instance, uint32_t var_p0, uint32_t var_p1) {
   return w2c_test_add_0(instance, var_p0, var_p1);
 }
 
@@ -827,7 +817,7 @@ wasm_rt_func_type_t wasm2c_test_get_func_type(uint32_t param_count, uint32_t res
 
 u32 w2c_test_add_0(w2c_test* instance, u32 var_p0, u32 var_p1) {
   FUNC_PROLOGUE;
-  u32 var_i0, var_i1;
+  uint32_t var_i0, var_i1;
   var_i0 = var_p0;
   var_i1 = var_p1;
   var_i0 += var_i1;

--- a/test/wasm2c/check-imports.txt
+++ b/test/wasm2c/check-imports.txt
@@ -21,8 +21,6 @@
 #ifndef WASM_H_GENERATED_
 #define WASM_H_GENERATED_
 
-#include <stdint.h>
-
 #include "wasm-rt.h"
 
 #if defined(WASM_RT_ENABLE_EXCEPTION_HANDLING)
@@ -31,26 +29,6 @@
 
 #if defined(WASM_RT_ENABLE_SIMD)
 #include "simde/wasm/simd128.h"
-#endif
-
-/* TODO(binji): only use stdint.h types in header */
-#ifndef WASM_RT_CORE_TYPES_DEFINED
-#define WASM_RT_CORE_TYPES_DEFINED
-typedef uint8_t u8;
-typedef int8_t s8;
-typedef uint16_t u16;
-typedef int16_t s16;
-typedef uint32_t u32;
-typedef int32_t s32;
-typedef uint64_t u64;
-typedef int64_t s64;
-typedef float f32;
-typedef double f64;
-
-#if defined(WASM_RT_ENABLE_SIMD)
-typedef simde_v128_t v128;
-#endif
-
 #endif
 
 #ifdef __cplusplus
@@ -72,11 +50,11 @@ void wasm2c_test_instantiate(w2c_test*, struct w2c_env*);
 void wasm2c_test_free(w2c_test*);
 wasm_rt_func_type_t wasm2c_test_get_func_type(uint32_t param_count, uint32_t result_count, ...);
 
-extern const u32 wasm2c_test_min_env_0x5F_indirect_function_table;
-extern const u32 wasm2c_test_max_env_0x5F_indirect_function_table;
-extern const u64 wasm2c_test_min_env_0x5F_linear_memory;
-extern const u64 wasm2c_test_max_env_0x5F_linear_memory;
-extern const u8 wasm2c_test_is64_env_0x5F_linear_memory;
+extern const uint32_t wasm2c_test_min_env_0x5F_indirect_function_table;
+extern const uint32_t wasm2c_test_max_env_0x5F_indirect_function_table;
+extern const uint64_t wasm2c_test_min_env_0x5F_linear_memory;
+extern const uint64_t wasm2c_test_max_env_0x5F_linear_memory;
+extern const bool wasm2c_test_is64_env_0x5F_linear_memory;
 
 #ifdef __cplusplus
 }
@@ -118,6 +96,17 @@ extern const u8 wasm2c_test_is64_env_0x5F_linear_memory;
 #endif
 
 #define UNREACHABLE TRAP(UNREACHABLE)
+
+typedef uint8_t u8;
+typedef int8_t s8;
+typedef uint16_t u16;
+typedef int16_t s16;
+typedef uint32_t u32;
+typedef int32_t s32;
+typedef uint64_t u64;
+typedef int64_t s64;
+typedef float f32;
+typedef double f64;
 
 static inline bool func_types_eq(const wasm_rt_func_type_t a,
                                  const wasm_rt_func_type_t b) {
@@ -247,6 +236,7 @@ DEFINE_STORE(i64_store16, u16, u64)
 DEFINE_STORE(i64_store32, u32, u64)
 
 #if defined(WASM_RT_ENABLE_SIMD)
+typedef simde_v128_t v128;
 
 #ifdef __x86_64__
 #define SIMD_FORCE_READ(var) wasm_asm("" ::"x"(var));
@@ -817,9 +807,9 @@ DEFINE_TABLE_FILL(externref)
 #define FUNC_TYPE_T(x) static const char x[]
 #endif
 
-static u32 w2c_test_f0(w2c_test*, u32);
-static u32 w2c_test_f1(w2c_test*);
-static u32 w2c_test_f2(w2c_test*, u32, u32);
+static uint32_t w2c_test_f0(w2c_test*, uint32_t);
+static uint32_t w2c_test_f1(w2c_test*);
+static uint32_t w2c_test_f2(w2c_test*, uint32_t, uint32_t);
 
 FUNC_TYPE_T(w2c_test_t0) = "\x07\x80\x96\x7a\x42\xf7\x3e\xe6\x70\x5c\x2f\xac\x83\xf5\x67\xd2\xa2\xa0\x69\x41\x5f\xf8\xe7\x96\x7f\x23\xab\x00\x03\x5f\x4a\x3c";
 FUNC_TYPE_T(w2c_test_t1) = "\x72\xab\x00\xdf\x20\x3d\xce\xa1\xf2\x29\xc7\x9d\x13\x40\x7e\x98\xac\x7d\x41\x4a\x53\x2e\x42\x42\x61\x55\x2e\xaa\xeb\xbe\xc6\x35";
@@ -844,11 +834,11 @@ static void init_instance_import(w2c_test* instance, struct w2c_env* w2c_env_ins
   instance->w2c_env_0x5F_linear_memory = w2c_env_0x5F_linear_memory(w2c_env_instance);
 }
 
-const u32 wasm2c_test_min_env_0x5F_indirect_function_table = 1;
-const u32 wasm2c_test_max_env_0x5F_indirect_function_table = 4294967295;
-const u64 wasm2c_test_min_env_0x5F_linear_memory = 0;
-const u64 wasm2c_test_max_env_0x5F_linear_memory = 65536;
-const u8 wasm2c_test_is64_env_0x5F_linear_memory = 0;
+const uint32_t wasm2c_test_min_env_0x5F_indirect_function_table = 1;
+const uint32_t wasm2c_test_max_env_0x5F_indirect_function_table = 4294967295;
+const uint64_t wasm2c_test_min_env_0x5F_linear_memory = 0;
+const uint64_t wasm2c_test_max_env_0x5F_linear_memory = 65536;
+const bool wasm2c_test_is64_env_0x5F_linear_memory = 0;
 
 void wasm2c_test_instantiate(w2c_test* instance, struct w2c_env* w2c_env_instance) {
   assert(wasm_rt_is_initialized());
@@ -896,7 +886,7 @@ wasm_rt_func_type_t wasm2c_test_get_func_type(uint32_t param_count, uint32_t res
 
 u32 w2c_test_f0(w2c_test* instance, u32 var_p0) {
   FUNC_PROLOGUE;
-  u32 var_i0;
+  uint32_t var_i0;
   var_i0 = var_p0;
   var_i0 = CALL_INDIRECT((*instance->w2c_env_0x5F_indirect_function_table), u32 (*)(void*), w2c_test_t1, var_i0, (*instance->w2c_env_0x5F_indirect_function_table).data[var_i0].module_instance);
   FUNC_EPILOGUE;
@@ -905,7 +895,7 @@ u32 w2c_test_f0(w2c_test* instance, u32 var_p0) {
 
 u32 w2c_test_f1(w2c_test* instance) {
   FUNC_PROLOGUE;
-  u32 var_i0;
+  uint32_t var_i0;
   var_i0 = 16u;
   var_i0 = i32_load(instance->w2c_env_0x5F_linear_memory, (u64)(var_i0));
   FUNC_EPILOGUE;
@@ -914,7 +904,7 @@ u32 w2c_test_f1(w2c_test* instance) {
 
 u32 w2c_test_f2(w2c_test* instance, u32 var_p0, u32 var_p1) {
   FUNC_PROLOGUE;
-  u32 var_i0;
+  uint32_t var_i0;
   var_i0 = 1u;
   var_i0 = w2c_test_f0(instance, var_i0);
   FUNC_EPILOGUE;

--- a/test/wasm2c/export-names.txt
+++ b/test/wasm2c/export-names.txt
@@ -11,8 +11,6 @@
 #ifndef WASM_H_GENERATED_
 #define WASM_H_GENERATED_
 
-#include <stdint.h>
-
 #include "wasm-rt.h"
 
 #if defined(WASM_RT_ENABLE_EXCEPTION_HANDLING)
@@ -21,26 +19,6 @@
 
 #if defined(WASM_RT_ENABLE_SIMD)
 #include "simde/wasm/simd128.h"
-#endif
-
-/* TODO(binji): only use stdint.h types in header */
-#ifndef WASM_RT_CORE_TYPES_DEFINED
-#define WASM_RT_CORE_TYPES_DEFINED
-typedef uint8_t u8;
-typedef int8_t s8;
-typedef uint16_t u16;
-typedef int16_t s16;
-typedef uint32_t u32;
-typedef int32_t s32;
-typedef uint64_t u64;
-typedef int64_t s64;
-typedef float f32;
-typedef double f64;
-
-#if defined(WASM_RT_ENABLE_SIMD)
-typedef simde_v128_t v128;
-#endif
-
 #endif
 
 #ifdef __cplusplus
@@ -59,9 +37,9 @@ void wasm2c_test_instantiate(w2c_test*, struct w2c_0x5Cmodule*);
 void wasm2c_test_free(w2c_test*);
 wasm_rt_func_type_t wasm2c_test_get_func_type(uint32_t param_count, uint32_t result_count, ...);
 
-extern const u64 wasm2c_test_min_0x5Cmodule_import0x200x2A0x2F;
-extern const u64 wasm2c_test_max_0x5Cmodule_import0x200x2A0x2F;
-extern const u8 wasm2c_test_is64_0x5Cmodule_import0x200x2A0x2F;
+extern const uint64_t wasm2c_test_min_0x5Cmodule_import0x200x2A0x2F;
+extern const uint64_t wasm2c_test_max_0x5Cmodule_import0x200x2A0x2F;
+extern const bool wasm2c_test_is64_0x5Cmodule_import0x200x2A0x2F;
 
 /* export: '' */
 void w2c_test_(w2c_test*);
@@ -118,6 +96,17 @@ void w2c_test_0xE20x9D0xA40xEF0xB80x8F(w2c_test*);
 #endif
 
 #define UNREACHABLE TRAP(UNREACHABLE)
+
+typedef uint8_t u8;
+typedef int8_t s8;
+typedef uint16_t u16;
+typedef int16_t s16;
+typedef uint32_t u32;
+typedef int32_t s32;
+typedef uint64_t u64;
+typedef int64_t s64;
+typedef float f32;
+typedef double f64;
 
 static inline bool func_types_eq(const wasm_rt_func_type_t a,
                                  const wasm_rt_func_type_t b) {
@@ -247,6 +236,7 @@ DEFINE_STORE(i64_store16, u16, u64)
 DEFINE_STORE(i64_store32, u32, u64)
 
 #if defined(WASM_RT_ENABLE_SIMD)
+typedef simde_v128_t v128;
 
 #ifdef __x86_64__
 #define SIMD_FORCE_READ(var) wasm_asm("" ::"x"(var));
@@ -853,9 +843,9 @@ static void init_instance_import(w2c_test* instance, struct w2c_0x5Cmodule* w2c_
   instance->w2c_0x5Cmodule_import0x200x2A0x2F = w2c_0x5Cmodule_import0x200x2A0x2F(w2c_0x5Cmodule_instance);
 }
 
-const u64 wasm2c_test_min_0x5Cmodule_import0x200x2A0x2F = 0;
-const u64 wasm2c_test_max_0x5Cmodule_import0x200x2A0x2F = 65536;
-const u8 wasm2c_test_is64_0x5Cmodule_import0x200x2A0x2F = 0;
+const uint64_t wasm2c_test_min_0x5Cmodule_import0x200x2A0x2F = 0;
+const uint64_t wasm2c_test_max_0x5Cmodule_import0x200x2A0x2F = 65536;
+const bool wasm2c_test_is64_0x5Cmodule_import0x200x2A0x2F = 0;
 
 void wasm2c_test_instantiate(w2c_test* instance, struct w2c_0x5Cmodule* w2c_0x5Cmodule_instance) {
   assert(wasm_rt_is_initialized());

--- a/test/wasm2c/hello.txt
+++ b/test/wasm2c/hello.txt
@@ -26,8 +26,6 @@
 #ifndef WASM_H_GENERATED_
 #define WASM_H_GENERATED_
 
-#include <stdint.h>
-
 #include "wasm-rt.h"
 
 #if defined(WASM_RT_ENABLE_EXCEPTION_HANDLING)
@@ -36,26 +34,6 @@
 
 #if defined(WASM_RT_ENABLE_SIMD)
 #include "simde/wasm/simd128.h"
-#endif
-
-/* TODO(binji): only use stdint.h types in header */
-#ifndef WASM_RT_CORE_TYPES_DEFINED
-#define WASM_RT_CORE_TYPES_DEFINED
-typedef uint8_t u8;
-typedef int8_t s8;
-typedef uint16_t u16;
-typedef int16_t s16;
-typedef uint32_t u32;
-typedef int32_t s32;
-typedef uint64_t u64;
-typedef int64_t s64;
-typedef float f32;
-typedef double f64;
-
-#if defined(WASM_RT_ENABLE_SIMD)
-typedef simde_v128_t v128;
-#endif
-
 #endif
 
 #ifdef __cplusplus
@@ -75,10 +53,10 @@ void wasm2c_test_free(w2c_test*);
 wasm_rt_func_type_t wasm2c_test_get_func_type(uint32_t param_count, uint32_t result_count, ...);
 
 /* import: 'wasi_snapshot_preview1' 'fd_write' */
-u32 w2c_wasi__snapshot__preview1_fd_write(struct w2c_wasi__snapshot__preview1*, u32, u32, u32, u32);
+uint32_t w2c_wasi__snapshot__preview1_fd_write(struct w2c_wasi__snapshot__preview1*, uint32_t, uint32_t, uint32_t, uint32_t);
 
 /* import: 'wasi_snapshot_preview1' 'proc_exit' */
-void w2c_wasi__snapshot__preview1_proc_exit(struct w2c_wasi__snapshot__preview1*, u32);
+void w2c_wasi__snapshot__preview1_proc_exit(struct w2c_wasi__snapshot__preview1*, uint32_t);
 
 /* export: 'memory' */
 wasm_rt_memory_t* w2c_test_memory(w2c_test* instance);
@@ -126,6 +104,17 @@ void w2c_test_0x5Fstart(w2c_test*);
 #endif
 
 #define UNREACHABLE TRAP(UNREACHABLE)
+
+typedef uint8_t u8;
+typedef int8_t s8;
+typedef uint16_t u16;
+typedef int16_t s16;
+typedef uint32_t u32;
+typedef int32_t s32;
+typedef uint64_t u64;
+typedef int64_t s64;
+typedef float f32;
+typedef double f64;
 
 static inline bool func_types_eq(const wasm_rt_func_type_t a,
                                  const wasm_rt_func_type_t b) {
@@ -255,6 +244,7 @@ DEFINE_STORE(i64_store16, u16, u64)
 DEFINE_STORE(i64_store32, u32, u64)
 
 #if defined(WASM_RT_ENABLE_SIMD)
+typedef simde_v128_t v128;
 
 #ifdef __x86_64__
 #define SIMD_FORCE_READ(var) wasm_asm("" ::"x"(var));
@@ -919,7 +909,7 @@ wasm_rt_func_type_t wasm2c_test_get_func_type(uint32_t param_count, uint32_t res
 
 void w2c_test_0x5Fstart_0(w2c_test* instance) {
   FUNC_PROLOGUE;
-  u32 var_i0, var_i1, var_i2, var_i3, var_i4;
+  uint32_t var_i0, var_i1, var_i2, var_i3, var_i4;
   var_i0 = 0u;
   var_i1 = 8u;
   i32_store(&instance->w2c_memory, (u64)(var_i0), var_i1);

--- a/test/wasm2c/minimal.txt
+++ b/test/wasm2c/minimal.txt
@@ -5,8 +5,6 @@
 #ifndef WASM_H_GENERATED_
 #define WASM_H_GENERATED_
 
-#include <stdint.h>
-
 #include "wasm-rt.h"
 
 #if defined(WASM_RT_ENABLE_EXCEPTION_HANDLING)
@@ -15,26 +13,6 @@
 
 #if defined(WASM_RT_ENABLE_SIMD)
 #include "simde/wasm/simd128.h"
-#endif
-
-/* TODO(binji): only use stdint.h types in header */
-#ifndef WASM_RT_CORE_TYPES_DEFINED
-#define WASM_RT_CORE_TYPES_DEFINED
-typedef uint8_t u8;
-typedef int8_t s8;
-typedef uint16_t u16;
-typedef int16_t s16;
-typedef uint32_t u32;
-typedef int32_t s32;
-typedef uint64_t u64;
-typedef int64_t s64;
-typedef float f32;
-typedef double f64;
-
-#if defined(WASM_RT_ENABLE_SIMD)
-typedef simde_v128_t v128;
-#endif
-
 #endif
 
 #ifdef __cplusplus
@@ -89,6 +67,17 @@ wasm_rt_func_type_t wasm2c_test_get_func_type(uint32_t param_count, uint32_t res
 #endif
 
 #define UNREACHABLE TRAP(UNREACHABLE)
+
+typedef uint8_t u8;
+typedef int8_t s8;
+typedef uint16_t u16;
+typedef int16_t s16;
+typedef uint32_t u32;
+typedef int32_t s32;
+typedef uint64_t u64;
+typedef int64_t s64;
+typedef float f32;
+typedef double f64;
 
 static inline bool func_types_eq(const wasm_rt_func_type_t a,
                                  const wasm_rt_func_type_t b) {
@@ -218,6 +207,7 @@ DEFINE_STORE(i64_store16, u16, u64)
 DEFINE_STORE(i64_store32, u32, u64)
 
 #if defined(WASM_RT_ENABLE_SIMD)
+typedef simde_v128_t v128;
 
 #ifdef __x86_64__
 #define SIMD_FORCE_READ(var) wasm_asm("" ::"x"(var));

--- a/wasm2c/README.md
+++ b/wasm2c/README.md
@@ -74,8 +74,8 @@ int main(int argc, char** argv) {
   }
 
   /* Convert the argument from a string to an int. We'll implicitly cast the int
-  to a `u32`, which is what `fac` expects. */
-  u32 x = atoi(argv[1]);
+  to a `uint32_t`, which is what `fac` expects. */
+  uint32_t x = atoi(argv[1]);
 
   /* Initialize the Wasm runtime. */
   wasm_rt_init();
@@ -87,7 +87,7 @@ int main(int argc, char** argv) {
   wasm2c_fac_instantiate(&fac);
 
   /* Call `fac`, using the mangled name. */
-  u32 result = w2c_fac_fac(&fac, x);
+  uint32_t result = w2c_fac_fac(&fac, x);
 
   /* Print the result. */
   printf("fac(%u) -> %u\n", x, result);
@@ -152,12 +152,6 @@ The generated header file looks something like this:
 #include "wasm-rt.h"
 
 ...
-#ifndef WASM_RT_CORE_TYPES_DEFINED
-#define WASM_RT_CORE_TYPES_DEFINED
-
-...
-
-#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -172,7 +166,7 @@ void wasm2c_fac_free(w2c_fac*);
 wasm_rt_func_type_t wasm2c_fac_get_func_type(uint32_t param_count, uint32_t result_count, ...);
 
 /* export: 'fac' */
-u32 w2c_fac_fac(w2c_fac*, u32);
+uint32_t w2c_fac_fac(w2c_fac*, uint32_t);
 
 #ifdef __cplusplus
 }
@@ -183,9 +177,7 @@ u32 w2c_fac_fac(w2c_fac*, u32);
 ```
 
 Let's look at each section. The outer `#ifndef` is standard C
-boilerplate for a header. This `WASM_RT_CORE_TYPES_DEFINED` section
-contains a number of definitions required for all WebAssembly
-modules. The `extern "C"` part makes sure to not mangle the symbols if
+boilerplate for a header. The `extern "C"` part makes sure to not mangle the symbols if
 using this header in C++.
 
 The included `wasm-rt.h` file also includes a number of relevant definitions.
@@ -231,7 +223,7 @@ Next is the definition for a function reference (in WebAssembly 1.0,
 this was the type of all table elements, but funcrefs can now also be
 used as ordinary values, and tables can alternately be declared as
 type externref). In this structure, `wasm_rt_func_type_t` is an opaque
-256-bit ID that can be looked up via the `Z_[modname]_get_func_type`
+256-bit ID that can be looked up via the `wasm2c_[modname]_get_func_type`
 function. (A demonstration of this can be found in the `callback`
 example.) `module_instance` is the pointer to the function's
 originating module instance, which will be passed in when the func is
@@ -406,7 +398,7 @@ void wasm2c_fac_free(w2c_fac*);
 wasm_rt_func_type_t wasm2c_fac_get_func_type(uint32_t param_count, uint32_t result_count, ...);
 
 /* export: 'fac' */
-u32 w2c_fac_fac(w2c_fac*, u32);
+uint32_t w2c_fac_fac(w2c_fac*, uint32_t);
 ```
 
 ## Handling other kinds of imports and exports of modules
@@ -460,7 +452,7 @@ module doesn't use any globals, memory or tables.
 The most interesting part is the definition of the function `fac`:
 
 ```c
-static u32 w2c_fac_fac_0(w2c_fac* instance, u32 var_p0) {
+u32 w2c_fac_fac_0(w2c_fac* instance, u32 var_p0) {
   FUNC_PROLOGUE;
   u32 var_i0, var_i1, var_i2;
   var_i0 = var_p0;
@@ -606,7 +598,7 @@ int main(int argc, char** argv) {
  * result:
  *   The number of bytes filled into the buffer. (Must be <= size).
  */
-u32 w2c_host_fill_buf(w2c_host* instance, u32 ptr, u32 size) {
+uint32_t w2c_host_fill_buf(w2c_host* instance, uint32_t ptr, uint32_t size) {
   for (size_t i = 0; i < size; ++i) {
     if (instance->input[i] == 0) {
       return i;
@@ -623,7 +615,7 @@ u32 w2c_host_fill_buf(w2c_host* instance, u32 ptr, u32 size) {
  *   ptr: The wasm memory address of the buffer.
  *   size: The size of the buffer in wasm memory.
  */
-void w2c_host_buf_done(w2c_host* instance, u32 ptr, u32 size) {
+void w2c_host_buf_done(w2c_host* instance, uint32_t ptr, uint32_t size) {
   /* The output buffer is not necessarily null-terminated, so use the %*.s
    * printf format to limit the number of characters printed. */
   printf("%s -> %.*s\n", instance->input, (int)size, &instance->memory.data[ptr]);

--- a/wasm2c/examples/fac/fac.c
+++ b/wasm2c/examples/fac/fac.c
@@ -34,6 +34,17 @@
 
 #define UNREACHABLE TRAP(UNREACHABLE)
 
+typedef uint8_t u8;
+typedef int8_t s8;
+typedef uint16_t u16;
+typedef int16_t s16;
+typedef uint32_t u32;
+typedef int32_t s32;
+typedef uint64_t u64;
+typedef int64_t s64;
+typedef float f32;
+typedef double f64;
+
 static inline bool func_types_eq(const wasm_rt_func_type_t a,
                                  const wasm_rt_func_type_t b) {
   return (a == b) || LIKELY(a && b && !memcmp(a, b, 32));
@@ -162,6 +173,7 @@ DEFINE_STORE(i64_store16, u16, u64)
 DEFINE_STORE(i64_store32, u32, u64)
 
 #if defined(WASM_RT_ENABLE_SIMD)
+typedef simde_v128_t v128;
 
 #ifdef __x86_64__
 #define SIMD_FORCE_READ(var) wasm_asm("" ::"x"(var));

--- a/wasm2c/examples/fac/fac.h
+++ b/wasm2c/examples/fac/fac.h
@@ -2,8 +2,6 @@
 #ifndef FAC_H_GENERATED_
 #define FAC_H_GENERATED_
 
-#include <stdint.h>
-
 #include "wasm-rt.h"
 
 #if defined(WASM_RT_ENABLE_EXCEPTION_HANDLING)
@@ -12,26 +10,6 @@
 
 #if defined(WASM_RT_ENABLE_SIMD)
 #include "simde/wasm/simd128.h"
-#endif
-
-/* TODO(binji): only use stdint.h types in header */
-#ifndef WASM_RT_CORE_TYPES_DEFINED
-#define WASM_RT_CORE_TYPES_DEFINED
-typedef uint8_t u8;
-typedef int8_t s8;
-typedef uint16_t u16;
-typedef int16_t s16;
-typedef uint32_t u32;
-typedef int32_t s32;
-typedef uint64_t u64;
-typedef int64_t s64;
-typedef float f32;
-typedef double f64;
-
-#if defined(WASM_RT_ENABLE_SIMD)
-typedef simde_v128_t v128;
-#endif
-
 #endif
 
 #ifdef __cplusplus
@@ -47,7 +25,7 @@ void wasm2c_fac_free(w2c_fac*);
 wasm_rt_func_type_t wasm2c_fac_get_func_type(uint32_t param_count, uint32_t result_count, ...);
 
 /* export: 'fac' */
-u32 w2c_fac_fac(w2c_fac*, u32);
+uint32_t w2c_fac_fac(w2c_fac*, uint32_t);
 
 #ifdef __cplusplus
 }

--- a/wasm2c/examples/fac/main.c
+++ b/wasm2c/examples/fac/main.c
@@ -11,8 +11,8 @@ int main(int argc, char** argv) {
   }
 
   /* Convert the argument from a string to an int. We'll implicitly cast the int
-  to a `u32`, which is what `fac` expects. */
-  u32 x = atoi(argv[1]);
+  to a `uint32_t`, which is what `fac` expects. */
+  uint32_t x = atoi(argv[1]);
 
   /* Initialize the Wasm runtime. */
   wasm_rt_init();
@@ -24,7 +24,7 @@ int main(int argc, char** argv) {
   wasm2c_fac_instantiate(&fac);
 
   /* Call `fac`, using the mangled name. */
-  u32 result = w2c_fac_fac(&fac, x);
+  uint32_t result = w2c_fac_fac(&fac, x);
 
   /* Print the result. */
   printf("fac(%u) -> %u\n", x, result);

--- a/wasm2c/examples/rot13/main.c
+++ b/wasm2c/examples/rot13/main.c
@@ -76,7 +76,9 @@ int main(int argc, char** argv) {
  * result:
  *   The number of bytes filled into the buffer. (Must be <= size).
  */
-u32 w2c_host_fill_buf(struct w2c_host* instance, u32 ptr, u32 size) {
+uint32_t w2c_host_fill_buf(struct w2c_host* instance,
+                           uint32_t ptr,
+                           uint32_t size) {
   for (size_t i = 0; i < size; ++i) {
     if (instance->input[i] == 0) {
       return i;
@@ -93,7 +95,7 @@ u32 w2c_host_fill_buf(struct w2c_host* instance, u32 ptr, u32 size) {
  *   ptr: The wasm memory address of the buffer.
  *   size: The size of the buffer in wasm memory.
  */
-void w2c_host_buf_done(struct w2c_host* instance, u32 ptr, u32 size) {
+void w2c_host_buf_done(struct w2c_host* instance, uint32_t ptr, uint32_t size) {
   /* The output buffer is not necessarily null-terminated, so use the %*.s
    * printf format to limit the number of characters printed. */
   printf("%s -> %.*s\n", instance->input, (int)size,


### PR DESCRIPTION
Fulfills an old TODO. Also a step towards cleaning up/minimizing the wasm2c-generated header to let us include SIMDe in a clean way in one place. (I think it will be possible to eliminate the wasm2c.top.h and wasm2c.bottom.h templates completely, and merge wasm2c.includes.c and wasm2c.declarations.c.)