### PR TITLE
Don't include windows.h for color printing if !HAVE_WIN32_VT100

### DIFF
--- a/src/color.cc
+++ b/src/color.cc
@@ -21,8 +21,10 @@
 #include "wabt/common.h"
 
 #if _WIN32
+#if HAVE_WIN32_VT100
 #include <io.h>
 #include <windows.h>
+#endif
 #elif HAVE_UNISTD_H
 #include <unistd.h>
 #endif


### PR DESCRIPTION
We don't need windows.h if color printing is disabled i.e., HAVE_WIN32_VT100 is not defined

@keithw @sbc100 Unfortunately a blocking bug for use in Firefox as we temporarily need to build wasm2c without relying on windows.h