### PR TITLE
fix relaxed-simd link

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Wabt has been compiled to JavaScript via emscripten. Some of the functionality i
 | [memory64][]          | `--enable-memory64`         |   | ✓ | ✓ | ✓ | ✓ | ✓ |
 | [multi-memory][]      | `--enable-multi-memory`     |   | ✓ | ✓ | ✓ | ✓ | ✓ |
 | [extended-const][]    | `--enable-extended-const`   |   | ✓ | ✓ | ✓ | ✓ | ✓ |
-| [relaxed-simd*][]     | `--enable-relaxed-simd`     |   | ✓ | ✓ | ✓ | ✓ |   |
+| [relaxed-simd][]      | `--enable-relaxed-simd`     |   | ✓ | ✓ | ✓ | ✓ |   |
 
 [exception handling]: https://github.com/WebAssembly/exception-handling
 [mutable globals]: https://github.com/WebAssembly/mutable-global


### PR DESCRIPTION
The footnote was removed in https://github.com/WebAssembly/wabt/commit/463b54d39fdc86f41875d185a450173cf236f1f9