### PR TITLE
Cleanup use of HAVE_WIN32_VT100 in color.cc

### DIFF
--- a/src/color.cc
+++ b/src/color.cc
@@ -20,11 +20,9 @@
 
 #include "wabt/common.h"
 
-#if _WIN32
 #if HAVE_WIN32_VT100
 #include <io.h>
 #include <windows.h>
-#endif
 #elif HAVE_UNISTD_H
 #include <unistd.h>
 #endif
@@ -42,29 +40,23 @@ bool Color::SupportsColor(FILE* file) {
     return atoi(force) != 0;
   }
 
-#if _WIN32
-
-  {
 #if HAVE_WIN32_VT100
-    HANDLE handle;
-    if (file == stdout) {
-      handle = GetStdHandle(STD_OUTPUT_HANDLE);
-    } else if (file == stderr) {
-      handle = GetStdHandle(STD_ERROR_HANDLE);
-    } else {
-      return false;
-    }
-    DWORD mode;
-    if (!_isatty(_fileno(file)) || !GetConsoleMode(handle, &mode) ||
-        !SetConsoleMode(handle, mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING)) {
-      return false;
-    }
-    return true;
-#else
-    // TODO(binji): Support older Windows by using SetConsoleTextAttribute?
+
+  HANDLE handle;
+  if (file == stdout) {
+    handle = GetStdHandle(STD_OUTPUT_HANDLE);
+  } else if (file == stderr) {
+    handle = GetStdHandle(STD_ERROR_HANDLE);
+  } else {
     return false;
-#endif
   }
+  DWORD mode;
+  if (!_isatty(_fileno(file)) || !GetConsoleMode(handle, &mode) ||
+      !SetConsoleMode(handle, mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING)) {
+    return false;
+  }
+  return true;
+  // TODO(binji): Support older Windows by using SetConsoleTextAttribute?
 
 #elif HAVE_UNISTD_H
 


### PR DESCRIPTION
@sbc100 Addressing the comment https://github.com/WebAssembly/wabt/pull/2228/files/9ede8fe37999d10ecda449afe43312d04133718d#r1187855033 from https://github.com/WebAssembly/wabt/pull/2228

**Edit:** Unfortunately, i think we can't make this change as HAVE_WIN32_VT100 is defined only in win32 platforms
https://github.com/WebAssembly/wabt/blob/main/CMakeLists.txt#L121

If you prefer I can change the CMAKE to define it always, or we could leave the nested _WIN32 and HAVE_WIN32_VT100 in place. Happy to go either way