### PR TITLE
wasm2c: partial support for atomic memory ops

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -261,6 +261,7 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -D out="${WABT_SOURCE_DIR}/src/prebuilt/wasm2c_source_includes.cc" -D in="${WABT_SOURCE_DIR}/src/template/wasm2c.includes.c" -D symbol="s_source_includes" -P ${TEMPLATE_CMAKE}
   COMMAND ${CMAKE_COMMAND} -D out="${WABT_SOURCE_DIR}/src/prebuilt/wasm2c_source_declarations.cc" -D in="${WABT_SOURCE_DIR}/src/template/wasm2c.declarations.c" -D symbol="s_source_declarations" -P ${TEMPLATE_CMAKE}
   COMMAND ${CMAKE_COMMAND} -D out="${WABT_SOURCE_DIR}/src/prebuilt/wasm2c_simd_source_declarations.cc" -D in="${WABT_SOURCE_DIR}/src/template/wasm2c_simd.declarations.c" -D symbol="s_simd_source_declarations" -P ${TEMPLATE_CMAKE}
+  COMMAND ${CMAKE_COMMAND} -D out="${WABT_SOURCE_DIR}/src/prebuilt/wasm2c_atomicops_source_declarations.cc" -D in="${WABT_SOURCE_DIR}/src/template/wasm2c_atomicops.declarations.c" -D symbol="s_atomicops_source_declarations" -P ${TEMPLATE_CMAKE}
   COMMAND ${CMAKE_COMMAND} -E touch gen-wasm2c-prebuilt
 
   DEPENDS ${WABT_SOURCE_DIR}/src/template/wasm2c.top.h
@@ -268,6 +269,7 @@ add_custom_command(
   ${WABT_SOURCE_DIR}/src/template/wasm2c.includes.c
   ${WABT_SOURCE_DIR}/src/template/wasm2c.declarations.c
   ${WABT_SOURCE_DIR}/src/template/wasm2c_simd.declarations.c
+  ${WABT_SOURCE_DIR}/src/template/wasm2c_atomicops.declarations.c
 )
 
 add_custom_target(gen-wasm2c-prebuilt-target DEPENDS gen-wasm2c-prebuilt)
@@ -276,7 +278,8 @@ set(CWRITER_TEMPLATE_SRC ${WABT_SOURCE_DIR}/src/prebuilt/wasm2c_header_top.cc
                          ${WABT_SOURCE_DIR}/src/prebuilt/wasm2c_header_bottom.cc
                          ${WABT_SOURCE_DIR}/src/prebuilt/wasm2c_source_includes.cc
                          ${WABT_SOURCE_DIR}/src/prebuilt/wasm2c_source_declarations.cc
-                         ${WABT_SOURCE_DIR}/src/prebuilt/wasm2c_simd_source_declarations.cc)
+                         ${WABT_SOURCE_DIR}/src/prebuilt/wasm2c_simd_source_declarations.cc
+                         ${WABT_SOURCE_DIR}/src/prebuilt/wasm2c_atomicops_source_declarations.cc)
 
 add_custom_target(everything)
 

--- a/include/wabt/ir.h
+++ b/include/wabt/ir.h
@@ -1252,6 +1252,7 @@ struct Module {
   struct {
     bool simd = false;
     bool exceptions = false;
+    bool threads = false;
   } features_used;
 };
 

--- a/src/binary-reader-ir.cc
+++ b/src/binary-reader-ir.cc
@@ -788,6 +788,7 @@ Result BinaryReaderIR::OnOpcode(Opcode opcode) {
     return AppendExpr(std::move(metadata));
   }
   module_->features_used.simd |= (opcode.GetResultType() == Type::V128);
+  module_->features_used.threads |= (opcode.GetPrefix() == 0xfe);
   return Result::Ok;
 }
 

--- a/src/prebuilt/wasm2c_atomicops_source_declarations.cc
+++ b/src/prebuilt/wasm2c_atomicops_source_declarations.cc
@@ -1,0 +1,438 @@
+const char* s_atomicops_source_declarations = R"w2c_template(#if defined(_MSC_VER)
+)w2c_template"
+R"w2c_template(
+#include <intrin.h>
+)w2c_template"
+R"w2c_template(
+// Use MSVC intrinsics
+)w2c_template"
+R"w2c_template(
+// For loads and stores, its not clear if we can rely on register width loads
+)w2c_template"
+R"w2c_template(// and stores to be atomic as reported here
+)w2c_template"
+R"w2c_template(// https://learn.microsoft.com/en-us/windows/win32/sync/interlocked-variable-access?redirectedfrom=MSDN
+)w2c_template"
+R"w2c_template(// or if we have to reuse other instrinsics
+)w2c_template"
+R"w2c_template(// https://stackoverflow.com/questions/42660091/atomic-load-in-c-with-msvc
+)w2c_template"
+R"w2c_template(// We reuse other intrinsics to be cautious
+)w2c_template"
+R"w2c_template(#define atomic_load_u8(a, v) _InterlockedOr8(a, 0)
+)w2c_template"
+R"w2c_template(#define atomic_load_u16(a, v) _InterlockedOr16(a, 0)
+)w2c_template"
+R"w2c_template(#define atomic_load_u32(a, v) _InterlockedOr(a, 0)
+)w2c_template"
+R"w2c_template(#define atomic_load_u64(a, v) _InterlockedOr64(a, 0)
+)w2c_template"
+R"w2c_template(
+#define atomic_store_u8(a, v) _InterlockedExchange8(a, v)
+)w2c_template"
+R"w2c_template(#define atomic_store_u16(a, v) _InterlockedExchange16(a, v)
+)w2c_template"
+R"w2c_template(#define atomic_store_u32(a, v) _InterlockedExchange(a, v)
+)w2c_template"
+R"w2c_template(#define atomic_store_u64(a, v) _InterlockedExchange64(a, v)
+)w2c_template"
+R"w2c_template(
+#define atomic_add_u8(a, v) _InterlockedExchangeAdd8(a, v)
+)w2c_template"
+R"w2c_template(#define atomic_add_u16(a, v) _InterlockedExchangeAdd16(a, v)
+)w2c_template"
+R"w2c_template(#define atomic_add_u32(a, v) _InterlockedExchangeAdd(a, v)
+)w2c_template"
+R"w2c_template(#define atomic_add_u64(a, v) _InterlockedExchangeAdd64(a, v)
+)w2c_template"
+R"w2c_template(
+#define atomic_sub_u8(a, v) _InterlockedExchangeAdd8(a, -(v))
+)w2c_template"
+R"w2c_template(#define atomic_sub_u16(a, v) _InterlockedExchangeAdd16(a, -(v))
+)w2c_template"
+R"w2c_template(#define atomic_sub_u32(a, v) _InterlockedExchangeAdd(a, -(v))
+)w2c_template"
+R"w2c_template(#define atomic_sub_u64(a, v) _InterlockedExchangeAdd64(a, -(v))
+)w2c_template"
+R"w2c_template(
+#define atomic_and_u8(a, v) _InterlockedAnd8(a, v)
+)w2c_template"
+R"w2c_template(#define atomic_and_u16(a, v) _InterlockedAnd16(a, v)
+)w2c_template"
+R"w2c_template(#define atomic_and_u32(a, v) _InterlockedAnd(a, v)
+)w2c_template"
+R"w2c_template(#define atomic_and_u64(a, v) _InterlockedAnd64(a, v)
+)w2c_template"
+R"w2c_template(
+#define atomic_or_u8(a, v) _InterlockedOr8(a, v)
+)w2c_template"
+R"w2c_template(#define atomic_or_u16(a, v) _InterlockedOr16(a, v)
+)w2c_template"
+R"w2c_template(#define atomic_or_u32(a, v) _InterlockedOr(a, v)
+)w2c_template"
+R"w2c_template(#define atomic_or_u64(a, v) _InterlockedOr64(a, v)
+)w2c_template"
+R"w2c_template(
+#define atomic_xor_u8(a, v) _InterlockedXor8(a, v)
+)w2c_template"
+R"w2c_template(#define atomic_xor_u16(a, v) _InterlockedXor16(a, v)
+)w2c_template"
+R"w2c_template(#define atomic_xor_u32(a, v) _InterlockedXor(a, v)
+)w2c_template"
+R"w2c_template(#define atomic_xor_u64(a, v) _InterlockedXor64(a, v)
+)w2c_template"
+R"w2c_template(
+#define atomic_exchange_u8(a, v) _InterlockedExchange8(a, v)
+)w2c_template"
+R"w2c_template(#define atomic_exchange_u16(a, v) _InterlockedExchange16(a, v)
+)w2c_template"
+R"w2c_template(#define atomic_exchange_u32(a, v) _InterlockedExchange(a, v)
+)w2c_template"
+R"w2c_template(#define atomic_exchange_u64(a, v) _InterlockedExchange64(a, v)
+)w2c_template"
+R"w2c_template(
+// clang-format off
+)w2c_template"
+R"w2c_template(#define atomic_compare_exchange_u8(a, expected_ptr, desired) _InterlockedCompareExchange8(a, desired, *(expected_ptr))
+)w2c_template"
+R"w2c_template(#define atomic_compare_exchange_u16(a, expected_ptr, desired) _InterlockedCompareExchange16(a, desired, *(expected_ptr))
+)w2c_template"
+R"w2c_template(#define atomic_compare_exchange_u32(a, expected_ptr, desired) _InterlockedCompareExchange(a, desired, *(expected_ptr))
+)w2c_template"
+R"w2c_template(#define atomic_compare_exchange_u64(a, expected_ptr, desired) _InterlockedCompareExchange64(a, desired, *(expected_ptr))
+)w2c_template"
+R"w2c_template(// clang-format on
+)w2c_template"
+R"w2c_template(
+#define atomic_fence() _ReadWriteBarrier()
+)w2c_template"
+R"w2c_template(
+#else
+)w2c_template"
+R"w2c_template(
+// Use gcc/clang/icc intrinsics
+)w2c_template"
+R"w2c_template(#define atomic_load_u8(a) __atomic_load_n((u8*)(a), __ATOMIC_SEQ_CST)
+)w2c_template"
+R"w2c_template(#define atomic_load_u16(a) __atomic_load_n((u16*)(a), __ATOMIC_SEQ_CST)
+)w2c_template"
+R"w2c_template(#define atomic_load_u32(a) __atomic_load_n((u32*)(a), __ATOMIC_SEQ_CST)
+)w2c_template"
+R"w2c_template(#define atomic_load_u64(a) __atomic_load_n((u64*)(a), __ATOMIC_SEQ_CST)
+)w2c_template"
+R"w2c_template(
+#define atomic_store_u8(a, v) __atomic_store_n((u8*)(a), v, __ATOMIC_SEQ_CST)
+)w2c_template"
+R"w2c_template(#define atomic_store_u16(a, v) __atomic_store_n((u16*)(a), v, __ATOMIC_SEQ_CST)
+)w2c_template"
+R"w2c_template(#define atomic_store_u32(a, v) __atomic_store_n((u32*)(a), v, __ATOMIC_SEQ_CST)
+)w2c_template"
+R"w2c_template(#define atomic_store_u64(a, v) __atomic_store_n((u64*)(a), v, __ATOMIC_SEQ_CST)
+)w2c_template"
+R"w2c_template(
+#define atomic_add_u8(a, v) __atomic_fetch_add((u8*)(a), v, __ATOMIC_SEQ_CST)
+)w2c_template"
+R"w2c_template(#define atomic_add_u16(a, v) __atomic_fetch_add((u16*)(a), v, __ATOMIC_SEQ_CST)
+)w2c_template"
+R"w2c_template(#define atomic_add_u32(a, v) __atomic_fetch_add((u32*)(a), v, __ATOMIC_SEQ_CST)
+)w2c_template"
+R"w2c_template(#define atomic_add_u64(a, v) __atomic_fetch_add((u64*)(a), v, __ATOMIC_SEQ_CST)
+)w2c_template"
+R"w2c_template(
+#define atomic_sub_u8(a, v) __atomic_fetch_sub((u8*)(a), v, __ATOMIC_SEQ_CST)
+)w2c_template"
+R"w2c_template(#define atomic_sub_u16(a, v) __atomic_fetch_sub((u16*)(a), v, __ATOMIC_SEQ_CST)
+)w2c_template"
+R"w2c_template(#define atomic_sub_u32(a, v) __atomic_fetch_sub((u32*)(a), v, __ATOMIC_SEQ_CST)
+)w2c_template"
+R"w2c_template(#define atomic_sub_u64(a, v) __atomic_fetch_sub((u64*)(a), v, __ATOMIC_SEQ_CST)
+)w2c_template"
+R"w2c_template(
+#define atomic_and_u8(a, v) __atomic_fetch_and((u8*)(a), v, __ATOMIC_SEQ_CST)
+)w2c_template"
+R"w2c_template(#define atomic_and_u16(a, v) __atomic_fetch_and((u16*)(a), v, __ATOMIC_SEQ_CST)
+)w2c_template"
+R"w2c_template(#define atomic_and_u32(a, v) __atomic_fetch_and((u32*)(a), v, __ATOMIC_SEQ_CST)
+)w2c_template"
+R"w2c_template(#define atomic_and_u64(a, v) __atomic_fetch_and((u64*)(a), v, __ATOMIC_SEQ_CST)
+)w2c_template"
+R"w2c_template(
+#define atomic_or_u8(a, v) __atomic_fetch_or((u8*)(a), v, __ATOMIC_SEQ_CST)
+)w2c_template"
+R"w2c_template(#define atomic_or_u16(a, v) __atomic_fetch_or((u16*)(a), v, __ATOMIC_SEQ_CST)
+)w2c_template"
+R"w2c_template(#define atomic_or_u32(a, v) __atomic_fetch_or((u32*)(a), v, __ATOMIC_SEQ_CST)
+)w2c_template"
+R"w2c_template(#define atomic_or_u64(a, v) __atomic_fetch_or((u64*)(a), v, __ATOMIC_SEQ_CST)
+)w2c_template"
+R"w2c_template(
+#define atomic_xor_u8(a, v) __atomic_fetch_xor((u8*)(a), v, __ATOMIC_SEQ_CST)
+)w2c_template"
+R"w2c_template(#define atomic_xor_u16(a, v) __atomic_fetch_xor((u16*)(a), v, __ATOMIC_SEQ_CST)
+)w2c_template"
+R"w2c_template(#define atomic_xor_u32(a, v) __atomic_fetch_xor((u32*)(a), v, __ATOMIC_SEQ_CST)
+)w2c_template"
+R"w2c_template(#define atomic_xor_u64(a, v) __atomic_fetch_xor((u64*)(a), v, __ATOMIC_SEQ_CST)
+)w2c_template"
+R"w2c_template(
+// clang-format off
+)w2c_template"
+R"w2c_template(#define atomic_exchange_u8(a, v) __atomic_exchange_n((u8*)(a), v, __ATOMIC_SEQ_CST)
+)w2c_template"
+R"w2c_template(#define atomic_exchange_u16(a, v) __atomic_exchange_n((u16*)(a), v, __ATOMIC_SEQ_CST)
+)w2c_template"
+R"w2c_template(#define atomic_exchange_u32(a, v) __atomic_exchange_n((u32*)(a), v, __ATOMIC_SEQ_CST)
+)w2c_template"
+R"w2c_template(#define atomic_exchange_u64(a, v) __atomic_exchange_n((u64*)(a), v, __ATOMIC_SEQ_CST)
+)w2c_template"
+R"w2c_template(// clang-format on
+)w2c_template"
+R"w2c_template(
+#define __atomic_compare_exchange_helper(a, expected_ptr, desired)        \
+)w2c_template"
+R"w2c_template(  (__atomic_compare_exchange_n(a, expected_ptr, desired, 0 /* is_weak */, \
+)w2c_template"
+R"w2c_template(                               __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST),       \
+)w2c_template"
+R"w2c_template(   *(expected_ptr))
+)w2c_template"
+R"w2c_template(
+// clang-format off
+)w2c_template"
+R"w2c_template(#define atomic_compare_exchange_u8(a, expected_ptr, desired) __atomic_compare_exchange_helper((u8*)(a), expected_ptr, desired)
+)w2c_template"
+R"w2c_template(#define atomic_compare_exchange_u16(a, expected_ptr, desired) __atomic_compare_exchange_helper((u16*)(a), expected_ptr, desired)
+)w2c_template"
+R"w2c_template(#define atomic_compare_exchange_u32(a, expected_ptr, desired) __atomic_compare_exchange_helper((u32*)(a), expected_ptr, desired)
+)w2c_template"
+R"w2c_template(#define atomic_compare_exchange_u64(a, expected_ptr, desired) __atomic_compare_exchange_helper((u64*)(a), expected_ptr, desired)
+)w2c_template"
+R"w2c_template(// clang-format on
+)w2c_template"
+R"w2c_template(
+#define atomic_fence() __atomic_thread_fence(__ATOMIC_SEQ_CST)
+)w2c_template"
+R"w2c_template(
+#endif
+)w2c_template"
+R"w2c_template(
+#define ATOMIC_ALIGNMENT_CHECK(addr, t1) \
+)w2c_template"
+R"w2c_template(  if (UNLIKELY(addr % sizeof(t1))) {     \
+)w2c_template"
+R"w2c_template(    TRAP(UNALIGNED);                     \
+)w2c_template"
+R"w2c_template(  }
+)w2c_template"
+R"w2c_template(
+#define DEFINE_ATOMIC_LOAD(name, t1, t2, t3)               \
+)w2c_template"
+R"w2c_template(  static inline t3 name(wasm_rt_memory_t* mem, u64 addr) { \
+)w2c_template"
+R"w2c_template(    MEMCHECK(mem, addr, t1);                               \
+)w2c_template"
+R"w2c_template(    ATOMIC_ALIGNMENT_CHECK(addr, t1);                      \
+)w2c_template"
+R"w2c_template(    t1 result;                                             \
+)w2c_template"
+R"w2c_template(    wasm_rt_memcpy(&result, &mem->data[addr], sizeof(t1)); \
+)w2c_template"
+R"w2c_template(    result = atomic_load_##t1(&mem->data[addr]);           \
+)w2c_template"
+R"w2c_template(    wasm_asm("" ::"r"(result));                            \
+)w2c_template"
+R"w2c_template(    return (t3)(t2)result;                                 \
+)w2c_template"
+R"w2c_template(  }
+)w2c_template"
+R"w2c_template(
+DEFINE_ATOMIC_LOAD(i32_atomic_load, u32, u32, u32)
+)w2c_template"
+R"w2c_template(DEFINE_ATOMIC_LOAD(i64_atomic_load, u64, u64, u64)
+)w2c_template"
+R"w2c_template(DEFINE_ATOMIC_LOAD(i32_atomic_load8_u, u8, u32, u32)
+)w2c_template"
+R"w2c_template(DEFINE_ATOMIC_LOAD(i64_atomic_load8_u, u8, u64, u64)
+)w2c_template"
+R"w2c_template(DEFINE_ATOMIC_LOAD(i32_atomic_load16_u, u16, u32, u32)
+)w2c_template"
+R"w2c_template(DEFINE_ATOMIC_LOAD(i64_atomic_load16_u, u16, u64, u64)
+)w2c_template"
+R"w2c_template(DEFINE_ATOMIC_LOAD(i64_atomic_load32_u, u32, u64, u64)
+)w2c_template"
+R"w2c_template(
+#define DEFINE_ATOMIC_STORE(name, t1, t2)                              \
+)w2c_template"
+R"w2c_template(  static inline void name(wasm_rt_memory_t* mem, u64 addr, t2 value) { \
+)w2c_template"
+R"w2c_template(    MEMCHECK(mem, addr, t1);                                           \
+)w2c_template"
+R"w2c_template(    ATOMIC_ALIGNMENT_CHECK(addr, t1);                                  \
+)w2c_template"
+R"w2c_template(    t1 wrapped = (t1)value;                                            \
+)w2c_template"
+R"w2c_template(    atomic_store_##t1(&mem->data[addr], wrapped);                      \
+)w2c_template"
+R"w2c_template(  }
+)w2c_template"
+R"w2c_template(
+DEFINE_ATOMIC_STORE(i32_atomic_store, u32, u32)
+)w2c_template"
+R"w2c_template(DEFINE_ATOMIC_STORE(i64_atomic_store, u64, u64)
+)w2c_template"
+R"w2c_template(DEFINE_ATOMIC_STORE(i32_atomic_store8, u8, u32)
+)w2c_template"
+R"w2c_template(DEFINE_ATOMIC_STORE(i32_atomic_store16, u16, u32)
+)w2c_template"
+R"w2c_template(DEFINE_ATOMIC_STORE(i64_atomic_store8, u8, u64)
+)w2c_template"
+R"w2c_template(DEFINE_ATOMIC_STORE(i64_atomic_store16, u16, u64)
+)w2c_template"
+R"w2c_template(DEFINE_ATOMIC_STORE(i64_atomic_store32, u32, u64)
+)w2c_template"
+R"w2c_template(
+#define DEFINE_ATOMIC_RMW(name, op, t1, t2)                          \
+)w2c_template"
+R"w2c_template(  static inline t2 name(wasm_rt_memory_t* mem, u64 addr, t2 value) { \
+)w2c_template"
+R"w2c_template(    MEMCHECK(mem, addr, t1);                                         \
+)w2c_template"
+R"w2c_template(    ATOMIC_ALIGNMENT_CHECK(addr, t1);                                \
+)w2c_template"
+R"w2c_template(    t1 wrapped = (t1)value;                                          \
+)w2c_template"
+R"w2c_template(    t1 ret = atomic_##op##_##t1(&mem->data[addr], wrapped);          \
+)w2c_template"
+R"w2c_template(    return (t2)ret;                                                  \
+)w2c_template"
+R"w2c_template(  }
+)w2c_template"
+R"w2c_template(
+DEFINE_ATOMIC_RMW(i32_atomic_rmw8_add_u, add, u8, u32)
+)w2c_template"
+R"w2c_template(DEFINE_ATOMIC_RMW(i32_atomic_rmw16_add_u, add, u16, u32)
+)w2c_template"
+R"w2c_template(DEFINE_ATOMIC_RMW(i32_atomic_rmw_add, add, u32, u32)
+)w2c_template"
+R"w2c_template(DEFINE_ATOMIC_RMW(i64_atomic_rmw8_add_u, add, u8, u64)
+)w2c_template"
+R"w2c_template(DEFINE_ATOMIC_RMW(i64_atomic_rmw16_add_u, add, u16, u64)
+)w2c_template"
+R"w2c_template(DEFINE_ATOMIC_RMW(i64_atomic_rmw32_add_u, add, u32, u64)
+)w2c_template"
+R"w2c_template(DEFINE_ATOMIC_RMW(i64_atomic_rmw_add, add, u64, u64)
+)w2c_template"
+R"w2c_template(
+DEFINE_ATOMIC_RMW(i32_atomic_rmw8_sub_u, sub, u8, u32)
+)w2c_template"
+R"w2c_template(DEFINE_ATOMIC_RMW(i32_atomic_rmw16_sub_u, sub, u16, u32)
+)w2c_template"
+R"w2c_template(DEFINE_ATOMIC_RMW(i32_atomic_rmw_sub, sub, u32, u32)
+)w2c_template"
+R"w2c_template(DEFINE_ATOMIC_RMW(i64_atomic_rmw8_sub_u, sub, u8, u64)
+)w2c_template"
+R"w2c_template(DEFINE_ATOMIC_RMW(i64_atomic_rmw16_sub_u, sub, u16, u64)
+)w2c_template"
+R"w2c_template(DEFINE_ATOMIC_RMW(i64_atomic_rmw32_sub_u, sub, u32, u64)
+)w2c_template"
+R"w2c_template(DEFINE_ATOMIC_RMW(i64_atomic_rmw_sub, sub, u64, u64)
+)w2c_template"
+R"w2c_template(
+DEFINE_ATOMIC_RMW(i32_atomic_rmw8_and_u, and, u8, u32)
+)w2c_template"
+R"w2c_template(DEFINE_ATOMIC_RMW(i32_atomic_rmw16_and_u, and, u16, u32)
+)w2c_template"
+R"w2c_template(DEFINE_ATOMIC_RMW(i32_atomic_rmw_and, and, u32, u32)
+)w2c_template"
+R"w2c_template(DEFINE_ATOMIC_RMW(i64_atomic_rmw8_and_u, and, u8, u64)
+)w2c_template"
+R"w2c_template(DEFINE_ATOMIC_RMW(i64_atomic_rmw16_and_u, and, u16, u64)
+)w2c_template"
+R"w2c_template(DEFINE_ATOMIC_RMW(i64_atomic_rmw32_and_u, and, u32, u64)
+)w2c_template"
+R"w2c_template(DEFINE_ATOMIC_RMW(i64_atomic_rmw_and, and, u64, u64)
+)w2c_template"
+R"w2c_template(
+DEFINE_ATOMIC_RMW(i32_atomic_rmw8_or_u, or, u8, u32)
+)w2c_template"
+R"w2c_template(DEFINE_ATOMIC_RMW(i32_atomic_rmw16_or_u, or, u16, u32)
+)w2c_template"
+R"w2c_template(DEFINE_ATOMIC_RMW(i32_atomic_rmw_or, or, u32, u32)
+)w2c_template"
+R"w2c_template(DEFINE_ATOMIC_RMW(i64_atomic_rmw8_or_u, or, u8, u64)
+)w2c_template"
+R"w2c_template(DEFINE_ATOMIC_RMW(i64_atomic_rmw16_or_u, or, u16, u64)
+)w2c_template"
+R"w2c_template(DEFINE_ATOMIC_RMW(i64_atomic_rmw32_or_u, or, u32, u64)
+)w2c_template"
+R"w2c_template(DEFINE_ATOMIC_RMW(i64_atomic_rmw_or, or, u64, u64)
+)w2c_template"
+R"w2c_template(
+DEFINE_ATOMIC_RMW(i32_atomic_rmw8_xor_u, xor, u8, u32)
+)w2c_template"
+R"w2c_template(DEFINE_ATOMIC_RMW(i32_atomic_rmw16_xor_u, xor, u16, u32)
+)w2c_template"
+R"w2c_template(DEFINE_ATOMIC_RMW(i32_atomic_rmw_xor, xor, u32, u32)
+)w2c_template"
+R"w2c_template(DEFINE_ATOMIC_RMW(i64_atomic_rmw8_xor_u, xor, u8, u64)
+)w2c_template"
+R"w2c_template(DEFINE_ATOMIC_RMW(i64_atomic_rmw16_xor_u, xor, u16, u64)
+)w2c_template"
+R"w2c_template(DEFINE_ATOMIC_RMW(i64_atomic_rmw32_xor_u, xor, u32, u64)
+)w2c_template"
+R"w2c_template(DEFINE_ATOMIC_RMW(i64_atomic_rmw_xor, xor, u64, u64)
+)w2c_template"
+R"w2c_template(
+DEFINE_ATOMIC_RMW(i32_atomic_rmw8_xchg_u, exchange, u8, u32)
+)w2c_template"
+R"w2c_template(DEFINE_ATOMIC_RMW(i32_atomic_rmw16_xchg_u, exchange, u16, u32)
+)w2c_template"
+R"w2c_template(DEFINE_ATOMIC_RMW(i32_atomic_rmw_xchg, exchange, u32, u32)
+)w2c_template"
+R"w2c_template(DEFINE_ATOMIC_RMW(i64_atomic_rmw8_xchg_u, exchange, u8, u64)
+)w2c_template"
+R"w2c_template(DEFINE_ATOMIC_RMW(i64_atomic_rmw16_xchg_u, exchange, u16, u64)
+)w2c_template"
+R"w2c_template(DEFINE_ATOMIC_RMW(i64_atomic_rmw32_xchg_u, exchange, u32, u64)
+)w2c_template"
+R"w2c_template(DEFINE_ATOMIC_RMW(i64_atomic_rmw_xchg, exchange, u64, u64)
+)w2c_template"
+R"w2c_template(
+#define DEFINE_ATOMIC_CMP_XCHG(name, t1, t2)                                   \
+)w2c_template"
+R"w2c_template(  static inline t1 name(wasm_rt_memory_t* mem, u64 addr, t1 expected,          \
+)w2c_template"
+R"w2c_template(                        t1 replacement) {                                      \
+)w2c_template"
+R"w2c_template(    MEMCHECK(mem, addr, t2);                                                   \
+)w2c_template"
+R"w2c_template(    ATOMIC_ALIGNMENT_CHECK(addr, t2);                                          \
+)w2c_template"
+R"w2c_template(    t2 expected_wrapped = (t2)expected;                                        \
+)w2c_template"
+R"w2c_template(    t2 replacement_wrapped = (t2)replacement;                                  \
+)w2c_template"
+R"w2c_template(    t2 old = atomic_compare_exchange_##t2(&mem->data[addr], &expected_wrapped, \
+)w2c_template"
+R"w2c_template(                                          replacement_wrapped);                \
+)w2c_template"
+R"w2c_template(    return (t1)old;                                                            \
+)w2c_template"
+R"w2c_template(  }
+)w2c_template"
+R"w2c_template(
+DEFINE_ATOMIC_CMP_XCHG(i32_atomic_rmw8_cmpxchg_u, u32, u8);
+)w2c_template"
+R"w2c_template(DEFINE_ATOMIC_CMP_XCHG(i32_atomic_rmw16_cmpxchg_u, u32, u16);
+)w2c_template"
+R"w2c_template(DEFINE_ATOMIC_CMP_XCHG(i32_atomic_rmw_cmpxchg, u32, u32);
+)w2c_template"
+R"w2c_template(DEFINE_ATOMIC_CMP_XCHG(i64_atomic_rmw8_cmpxchg_u, u64, u8);
+)w2c_template"
+R"w2c_template(DEFINE_ATOMIC_CMP_XCHG(i64_atomic_rmw16_cmpxchg_u, u64, u16);
+)w2c_template"
+R"w2c_template(DEFINE_ATOMIC_CMP_XCHG(i64_atomic_rmw32_cmpxchg_u, u64, u32);
+)w2c_template"
+R"w2c_template(DEFINE_ATOMIC_CMP_XCHG(i64_atomic_rmw_cmpxchg, u64, u64);
+)w2c_template"
+;

--- a/src/template/wasm2c_atomicops.declarations.c
+++ b/src/template/wasm2c_atomicops.declarations.c
@@ -1,0 +1,238 @@
+#if defined(_MSC_VER)
+
+#include <intrin.h>
+
+// Use MSVC intrinsics
+
+// For loads and stores, its not clear if we can rely on register width loads
+// and stores to be atomic as reported here
+// https://learn.microsoft.com/en-us/windows/win32/sync/interlocked-variable-access?redirectedfrom=MSDN
+// or if we have to reuse other instrinsics
+// https://stackoverflow.com/questions/42660091/atomic-load-in-c-with-msvc
+// We reuse other intrinsics to be cautious
+#define atomic_load_u8(a, v) _InterlockedOr8(a, 0)
+#define atomic_load_u16(a, v) _InterlockedOr16(a, 0)
+#define atomic_load_u32(a, v) _InterlockedOr(a, 0)
+#define atomic_load_u64(a, v) _InterlockedOr64(a, 0)
+
+#define atomic_store_u8(a, v) _InterlockedExchange8(a, v)
+#define atomic_store_u16(a, v) _InterlockedExchange16(a, v)
+#define atomic_store_u32(a, v) _InterlockedExchange(a, v)
+#define atomic_store_u64(a, v) _InterlockedExchange64(a, v)
+
+#define atomic_add_u8(a, v) _InterlockedExchangeAdd8(a, v)
+#define atomic_add_u16(a, v) _InterlockedExchangeAdd16(a, v)
+#define atomic_add_u32(a, v) _InterlockedExchangeAdd(a, v)
+#define atomic_add_u64(a, v) _InterlockedExchangeAdd64(a, v)
+
+#define atomic_sub_u8(a, v) _InterlockedExchangeAdd8(a, -(v))
+#define atomic_sub_u16(a, v) _InterlockedExchangeAdd16(a, -(v))
+#define atomic_sub_u32(a, v) _InterlockedExchangeAdd(a, -(v))
+#define atomic_sub_u64(a, v) _InterlockedExchangeAdd64(a, -(v))
+
+#define atomic_and_u8(a, v) _InterlockedAnd8(a, v)
+#define atomic_and_u16(a, v) _InterlockedAnd16(a, v)
+#define atomic_and_u32(a, v) _InterlockedAnd(a, v)
+#define atomic_and_u64(a, v) _InterlockedAnd64(a, v)
+
+#define atomic_or_u8(a, v) _InterlockedOr8(a, v)
+#define atomic_or_u16(a, v) _InterlockedOr16(a, v)
+#define atomic_or_u32(a, v) _InterlockedOr(a, v)
+#define atomic_or_u64(a, v) _InterlockedOr64(a, v)
+
+#define atomic_xor_u8(a, v) _InterlockedXor8(a, v)
+#define atomic_xor_u16(a, v) _InterlockedXor16(a, v)
+#define atomic_xor_u32(a, v) _InterlockedXor(a, v)
+#define atomic_xor_u64(a, v) _InterlockedXor64(a, v)
+
+#define atomic_exchange_u8(a, v) _InterlockedExchange8(a, v)
+#define atomic_exchange_u16(a, v) _InterlockedExchange16(a, v)
+#define atomic_exchange_u32(a, v) _InterlockedExchange(a, v)
+#define atomic_exchange_u64(a, v) _InterlockedExchange64(a, v)
+
+// clang-format off
+#define atomic_compare_exchange_u8(a, expected_ptr, desired) _InterlockedCompareExchange8(a, desired, *(expected_ptr))
+#define atomic_compare_exchange_u16(a, expected_ptr, desired) _InterlockedCompareExchange16(a, desired, *(expected_ptr))
+#define atomic_compare_exchange_u32(a, expected_ptr, desired) _InterlockedCompareExchange(a, desired, *(expected_ptr))
+#define atomic_compare_exchange_u64(a, expected_ptr, desired) _InterlockedCompareExchange64(a, desired, *(expected_ptr))
+// clang-format on
+
+#define atomic_fence() _ReadWriteBarrier()
+
+#else
+
+// Use gcc/clang/icc intrinsics
+#define atomic_load_u8(a) __atomic_load_n((u8*)(a), __ATOMIC_SEQ_CST)
+#define atomic_load_u16(a) __atomic_load_n((u16*)(a), __ATOMIC_SEQ_CST)
+#define atomic_load_u32(a) __atomic_load_n((u32*)(a), __ATOMIC_SEQ_CST)
+#define atomic_load_u64(a) __atomic_load_n((u64*)(a), __ATOMIC_SEQ_CST)
+
+#define atomic_store_u8(a, v) __atomic_store_n((u8*)(a), v, __ATOMIC_SEQ_CST)
+#define atomic_store_u16(a, v) __atomic_store_n((u16*)(a), v, __ATOMIC_SEQ_CST)
+#define atomic_store_u32(a, v) __atomic_store_n((u32*)(a), v, __ATOMIC_SEQ_CST)
+#define atomic_store_u64(a, v) __atomic_store_n((u64*)(a), v, __ATOMIC_SEQ_CST)
+
+#define atomic_add_u8(a, v) __atomic_fetch_add((u8*)(a), v, __ATOMIC_SEQ_CST)
+#define atomic_add_u16(a, v) __atomic_fetch_add((u16*)(a), v, __ATOMIC_SEQ_CST)
+#define atomic_add_u32(a, v) __atomic_fetch_add((u32*)(a), v, __ATOMIC_SEQ_CST)
+#define atomic_add_u64(a, v) __atomic_fetch_add((u64*)(a), v, __ATOMIC_SEQ_CST)
+
+#define atomic_sub_u8(a, v) __atomic_fetch_sub((u8*)(a), v, __ATOMIC_SEQ_CST)
+#define atomic_sub_u16(a, v) __atomic_fetch_sub((u16*)(a), v, __ATOMIC_SEQ_CST)
+#define atomic_sub_u32(a, v) __atomic_fetch_sub((u32*)(a), v, __ATOMIC_SEQ_CST)
+#define atomic_sub_u64(a, v) __atomic_fetch_sub((u64*)(a), v, __ATOMIC_SEQ_CST)
+
+#define atomic_and_u8(a, v) __atomic_fetch_and((u8*)(a), v, __ATOMIC_SEQ_CST)
+#define atomic_and_u16(a, v) __atomic_fetch_and((u16*)(a), v, __ATOMIC_SEQ_CST)
+#define atomic_and_u32(a, v) __atomic_fetch_and((u32*)(a), v, __ATOMIC_SEQ_CST)
+#define atomic_and_u64(a, v) __atomic_fetch_and((u64*)(a), v, __ATOMIC_SEQ_CST)
+
+#define atomic_or_u8(a, v) __atomic_fetch_or((u8*)(a), v, __ATOMIC_SEQ_CST)
+#define atomic_or_u16(a, v) __atomic_fetch_or((u16*)(a), v, __ATOMIC_SEQ_CST)
+#define atomic_or_u32(a, v) __atomic_fetch_or((u32*)(a), v, __ATOMIC_SEQ_CST)
+#define atomic_or_u64(a, v) __atomic_fetch_or((u64*)(a), v, __ATOMIC_SEQ_CST)
+
+#define atomic_xor_u8(a, v) __atomic_fetch_xor((u8*)(a), v, __ATOMIC_SEQ_CST)
+#define atomic_xor_u16(a, v) __atomic_fetch_xor((u16*)(a), v, __ATOMIC_SEQ_CST)
+#define atomic_xor_u32(a, v) __atomic_fetch_xor((u32*)(a), v, __ATOMIC_SEQ_CST)
+#define atomic_xor_u64(a, v) __atomic_fetch_xor((u64*)(a), v, __ATOMIC_SEQ_CST)
+
+// clang-format off
+#define atomic_exchange_u8(a, v) __atomic_exchange_n((u8*)(a), v, __ATOMIC_SEQ_CST)
+#define atomic_exchange_u16(a, v) __atomic_exchange_n((u16*)(a), v, __ATOMIC_SEQ_CST)
+#define atomic_exchange_u32(a, v) __atomic_exchange_n((u32*)(a), v, __ATOMIC_SEQ_CST)
+#define atomic_exchange_u64(a, v) __atomic_exchange_n((u64*)(a), v, __ATOMIC_SEQ_CST)
+// clang-format on
+
+#define __atomic_compare_exchange_helper(a, expected_ptr, desired)        \
+  (__atomic_compare_exchange_n(a, expected_ptr, desired, 0 /* is_weak */, \
+                               __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST),       \
+   *(expected_ptr))
+
+// clang-format off
+#define atomic_compare_exchange_u8(a, expected_ptr, desired) __atomic_compare_exchange_helper((u8*)(a), expected_ptr, desired)
+#define atomic_compare_exchange_u16(a, expected_ptr, desired) __atomic_compare_exchange_helper((u16*)(a), expected_ptr, desired)
+#define atomic_compare_exchange_u32(a, expected_ptr, desired) __atomic_compare_exchange_helper((u32*)(a), expected_ptr, desired)
+#define atomic_compare_exchange_u64(a, expected_ptr, desired) __atomic_compare_exchange_helper((u64*)(a), expected_ptr, desired)
+// clang-format on
+
+#define atomic_fence() __atomic_thread_fence(__ATOMIC_SEQ_CST)
+
+#endif
+
+#define ATOMIC_ALIGNMENT_CHECK(addr, t1) \
+  if (UNLIKELY(addr % sizeof(t1))) {     \
+    TRAP(UNALIGNED);                     \
+  }
+
+#define DEFINE_ATOMIC_LOAD(name, t1, t2, t3)               \
+  static inline t3 name(wasm_rt_memory_t* mem, u64 addr) { \
+    MEMCHECK(mem, addr, t1);                               \
+    ATOMIC_ALIGNMENT_CHECK(addr, t1);                      \
+    t1 result;                                             \
+    wasm_rt_memcpy(&result, &mem->data[addr], sizeof(t1)); \
+    result = atomic_load_##t1(&mem->data[addr]);           \
+    wasm_asm("" ::"r"(result));                            \
+    return (t3)(t2)result;                                 \
+  }
+
+DEFINE_ATOMIC_LOAD(i32_atomic_load, u32, u32, u32)
+DEFINE_ATOMIC_LOAD(i64_atomic_load, u64, u64, u64)
+DEFINE_ATOMIC_LOAD(i32_atomic_load8_u, u8, u32, u32)
+DEFINE_ATOMIC_LOAD(i64_atomic_load8_u, u8, u64, u64)
+DEFINE_ATOMIC_LOAD(i32_atomic_load16_u, u16, u32, u32)
+DEFINE_ATOMIC_LOAD(i64_atomic_load16_u, u16, u64, u64)
+DEFINE_ATOMIC_LOAD(i64_atomic_load32_u, u32, u64, u64)
+
+#define DEFINE_ATOMIC_STORE(name, t1, t2)                              \
+  static inline void name(wasm_rt_memory_t* mem, u64 addr, t2 value) { \
+    MEMCHECK(mem, addr, t1);                                           \
+    ATOMIC_ALIGNMENT_CHECK(addr, t1);                                  \
+    t1 wrapped = (t1)value;                                            \
+    atomic_store_##t1(&mem->data[addr], wrapped);                      \
+  }
+
+DEFINE_ATOMIC_STORE(i32_atomic_store, u32, u32)
+DEFINE_ATOMIC_STORE(i64_atomic_store, u64, u64)
+DEFINE_ATOMIC_STORE(i32_atomic_store8, u8, u32)
+DEFINE_ATOMIC_STORE(i32_atomic_store16, u16, u32)
+DEFINE_ATOMIC_STORE(i64_atomic_store8, u8, u64)
+DEFINE_ATOMIC_STORE(i64_atomic_store16, u16, u64)
+DEFINE_ATOMIC_STORE(i64_atomic_store32, u32, u64)
+
+#define DEFINE_ATOMIC_RMW(name, op, t1, t2)                          \
+  static inline t2 name(wasm_rt_memory_t* mem, u64 addr, t2 value) { \
+    MEMCHECK(mem, addr, t1);                                         \
+    ATOMIC_ALIGNMENT_CHECK(addr, t1);                                \
+    t1 wrapped = (t1)value;                                          \
+    t1 ret = atomic_##op##_##t1(&mem->data[addr], wrapped);          \
+    return (t2)ret;                                                  \
+  }
+
+DEFINE_ATOMIC_RMW(i32_atomic_rmw8_add_u, add, u8, u32)
+DEFINE_ATOMIC_RMW(i32_atomic_rmw16_add_u, add, u16, u32)
+DEFINE_ATOMIC_RMW(i32_atomic_rmw_add, add, u32, u32)
+DEFINE_ATOMIC_RMW(i64_atomic_rmw8_add_u, add, u8, u64)
+DEFINE_ATOMIC_RMW(i64_atomic_rmw16_add_u, add, u16, u64)
+DEFINE_ATOMIC_RMW(i64_atomic_rmw32_add_u, add, u32, u64)
+DEFINE_ATOMIC_RMW(i64_atomic_rmw_add, add, u64, u64)
+
+DEFINE_ATOMIC_RMW(i32_atomic_rmw8_sub_u, sub, u8, u32)
+DEFINE_ATOMIC_RMW(i32_atomic_rmw16_sub_u, sub, u16, u32)
+DEFINE_ATOMIC_RMW(i32_atomic_rmw_sub, sub, u32, u32)
+DEFINE_ATOMIC_RMW(i64_atomic_rmw8_sub_u, sub, u8, u64)
+DEFINE_ATOMIC_RMW(i64_atomic_rmw16_sub_u, sub, u16, u64)
+DEFINE_ATOMIC_RMW(i64_atomic_rmw32_sub_u, sub, u32, u64)
+DEFINE_ATOMIC_RMW(i64_atomic_rmw_sub, sub, u64, u64)
+
+DEFINE_ATOMIC_RMW(i32_atomic_rmw8_and_u, and, u8, u32)
+DEFINE_ATOMIC_RMW(i32_atomic_rmw16_and_u, and, u16, u32)
+DEFINE_ATOMIC_RMW(i32_atomic_rmw_and, and, u32, u32)
+DEFINE_ATOMIC_RMW(i64_atomic_rmw8_and_u, and, u8, u64)
+DEFINE_ATOMIC_RMW(i64_atomic_rmw16_and_u, and, u16, u64)
+DEFINE_ATOMIC_RMW(i64_atomic_rmw32_and_u, and, u32, u64)
+DEFINE_ATOMIC_RMW(i64_atomic_rmw_and, and, u64, u64)
+
+DEFINE_ATOMIC_RMW(i32_atomic_rmw8_or_u, or, u8, u32)
+DEFINE_ATOMIC_RMW(i32_atomic_rmw16_or_u, or, u16, u32)
+DEFINE_ATOMIC_RMW(i32_atomic_rmw_or, or, u32, u32)
+DEFINE_ATOMIC_RMW(i64_atomic_rmw8_or_u, or, u8, u64)
+DEFINE_ATOMIC_RMW(i64_atomic_rmw16_or_u, or, u16, u64)
+DEFINE_ATOMIC_RMW(i64_atomic_rmw32_or_u, or, u32, u64)
+DEFINE_ATOMIC_RMW(i64_atomic_rmw_or, or, u64, u64)
+
+DEFINE_ATOMIC_RMW(i32_atomic_rmw8_xor_u, xor, u8, u32)
+DEFINE_ATOMIC_RMW(i32_atomic_rmw16_xor_u, xor, u16, u32)
+DEFINE_ATOMIC_RMW(i32_atomic_rmw_xor, xor, u32, u32)
+DEFINE_ATOMIC_RMW(i64_atomic_rmw8_xor_u, xor, u8, u64)
+DEFINE_ATOMIC_RMW(i64_atomic_rmw16_xor_u, xor, u16, u64)
+DEFINE_ATOMIC_RMW(i64_atomic_rmw32_xor_u, xor, u32, u64)
+DEFINE_ATOMIC_RMW(i64_atomic_rmw_xor, xor, u64, u64)
+
+DEFINE_ATOMIC_RMW(i32_atomic_rmw8_xchg_u, exchange, u8, u32)
+DEFINE_ATOMIC_RMW(i32_atomic_rmw16_xchg_u, exchange, u16, u32)
+DEFINE_ATOMIC_RMW(i32_atomic_rmw_xchg, exchange, u32, u32)
+DEFINE_ATOMIC_RMW(i64_atomic_rmw8_xchg_u, exchange, u8, u64)
+DEFINE_ATOMIC_RMW(i64_atomic_rmw16_xchg_u, exchange, u16, u64)
+DEFINE_ATOMIC_RMW(i64_atomic_rmw32_xchg_u, exchange, u32, u64)
+DEFINE_ATOMIC_RMW(i64_atomic_rmw_xchg, exchange, u64, u64)
+
+#define DEFINE_ATOMIC_CMP_XCHG(name, t1, t2)                                   \
+  static inline t1 name(wasm_rt_memory_t* mem, u64 addr, t1 expected,          \
+                        t1 replacement) {                                      \
+    MEMCHECK(mem, addr, t2);                                                   \
+    ATOMIC_ALIGNMENT_CHECK(addr, t2);                                          \
+    t2 expected_wrapped = (t2)expected;                                        \
+    t2 replacement_wrapped = (t2)replacement;                                  \
+    t2 old = atomic_compare_exchange_##t2(&mem->data[addr], &expected_wrapped, \
+                                          replacement_wrapped);                \
+    return (t1)old;                                                            \
+  }
+
+DEFINE_ATOMIC_CMP_XCHG(i32_atomic_rmw8_cmpxchg_u, u32, u8);
+DEFINE_ATOMIC_CMP_XCHG(i32_atomic_rmw16_cmpxchg_u, u32, u16);
+DEFINE_ATOMIC_CMP_XCHG(i32_atomic_rmw_cmpxchg, u32, u32);
+DEFINE_ATOMIC_CMP_XCHG(i64_atomic_rmw8_cmpxchg_u, u64, u8);
+DEFINE_ATOMIC_CMP_XCHG(i64_atomic_rmw16_cmpxchg_u, u64, u16);
+DEFINE_ATOMIC_CMP_XCHG(i64_atomic_rmw32_cmpxchg_u, u64, u32);
+DEFINE_ATOMIC_CMP_XCHG(i64_atomic_rmw_cmpxchg, u64, u64);

--- a/src/tools/wasm2c.cc
+++ b/src/tools/wasm2c.cc
@@ -60,7 +60,8 @@ examples:
 
 static const std::string supported_features[] = {
     "multi-memory", "multi-value", "sign-extension", "saturating-float-to-int",
-    "exceptions",   "memory64",    "extended-const", "simd"};
+    "exceptions",   "memory64",    "extended-const", "simd",
+    "threads"};
 
 static bool IsFeatureSupported(const std::string& feature) {
   return std::find(std::begin(supported_features), std::end(supported_features),

--- a/test/run-spec-wasm2c.py
+++ b/test/run-spec-wasm2c.py
@@ -532,6 +532,7 @@ def main(args):
     parser.add_argument('--enable-multi-memory', action='store_true')
     parser.add_argument('--enable-memory64', action='store_true')
     parser.add_argument('--enable-extended-const', action='store_true')
+    parser.add_argument('--enable-threads', action='store_true')
     parser.add_argument('--disable-bulk-memory', action='store_true')
     parser.add_argument('--disable-reference-types', action='store_true')
     parser.add_argument('--debug-names', action='store_true')
@@ -551,6 +552,7 @@ def main(args):
             '--enable-exceptions': options.enable_exceptions,
             '--enable-memory64': options.enable_memory64,
             '--enable-extended-const': options.enable_extended_const,
+            '--enable-threads': options.enable_threads,
             '--enable-multi-memory': options.enable_multi_memory,
             '--disable-bulk-memory': options.disable_bulk_memory,
             '--disable-reference-types': options.disable_reference_types,
@@ -568,6 +570,7 @@ def main(args):
             '--enable-exceptions': options.enable_exceptions,
             '--enable-memory64': options.enable_memory64,
             '--enable-extended-const': options.enable_extended_const,
+            '--enable-threads': options.enable_threads,
             '--enable-multi-memory': options.enable_multi_memory})
 
         options.cflags += shlex.split(os.environ.get('WASM2C_CFLAGS', ''))

--- a/test/wasm2c/bad-enable-feature.txt
+++ b/test/wasm2c/bad-enable-feature.txt
@@ -1,5 +1,5 @@
 ;;; RUN: %(wasm2c)s
-;;; ARGS: --enable-threads %(in_file)s
+;;; ARGS: --enable-gc %(in_file)s
 ;;; ERROR: 1
 (;; STDERR ;;;
 wasm2c currently only supports a limited set of features.

--- a/test/wasm2c/spec/threads/atomic.txt
+++ b/test/wasm2c/spec/threads/atomic.txt
@@ -1,0 +1,543 @@
+;;; TOOL: run-spec-wasm2c
+;;; ARGS*: --enable-threads
+;; atomic operations --- This is a subset of the full test suite, that is currently supported by wasm2c
+(module
+  (memory 1 1 shared)
+
+  (func (export "init") (param $value i64) (i64.store (i32.const 0) (local.get $value)))
+
+  (func (export "i32.atomic.load") (param $addr i32) (result i32) (i32.atomic.load (local.get $addr)))
+  (func (export "i64.atomic.load") (param $addr i32) (result i64) (i64.atomic.load (local.get $addr)))
+  (func (export "i32.atomic.load8_u") (param $addr i32) (result i32) (i32.atomic.load8_u (local.get $addr)))
+  (func (export "i32.atomic.load16_u") (param $addr i32) (result i32) (i32.atomic.load16_u (local.get $addr)))
+  (func (export "i64.atomic.load8_u") (param $addr i32) (result i64) (i64.atomic.load8_u (local.get $addr)))
+  (func (export "i64.atomic.load16_u") (param $addr i32) (result i64) (i64.atomic.load16_u (local.get $addr)))
+  (func (export "i64.atomic.load32_u") (param $addr i32) (result i64) (i64.atomic.load32_u (local.get $addr)))
+
+  (func (export "i32.atomic.store") (param $addr i32) (param $value i32) (i32.atomic.store (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.store") (param $addr i32) (param $value i64) (i64.atomic.store (local.get $addr) (local.get $value)))
+  (func (export "i32.atomic.store8") (param $addr i32) (param $value i32) (i32.atomic.store8 (local.get $addr) (local.get $value)))
+  (func (export "i32.atomic.store16") (param $addr i32) (param $value i32) (i32.atomic.store16 (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.store8") (param $addr i32) (param $value i64) (i64.atomic.store8 (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.store16") (param $addr i32) (param $value i64) (i64.atomic.store16 (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.store32") (param $addr i32) (param $value i64) (i64.atomic.store32 (local.get $addr) (local.get $value)))
+
+  (func (export "i32.atomic.rmw.add") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw.add (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw.add") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw.add (local.get $addr) (local.get $value)))
+  (func (export "i32.atomic.rmw8.add_u") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw8.add_u (local.get $addr) (local.get $value)))
+  (func (export "i32.atomic.rmw16.add_u") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw16.add_u (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw8.add_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw8.add_u (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw16.add_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw16.add_u (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw32.add_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw32.add_u (local.get $addr) (local.get $value)))
+
+  (func (export "i32.atomic.rmw.sub") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw.sub (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw.sub") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw.sub (local.get $addr) (local.get $value)))
+  (func (export "i32.atomic.rmw8.sub_u") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw8.sub_u (local.get $addr) (local.get $value)))
+  (func (export "i32.atomic.rmw16.sub_u") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw16.sub_u (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw8.sub_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw8.sub_u (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw16.sub_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw16.sub_u (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw32.sub_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw32.sub_u (local.get $addr) (local.get $value)))
+
+  (func (export "i32.atomic.rmw.and") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw.and (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw.and") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw.and (local.get $addr) (local.get $value)))
+  (func (export "i32.atomic.rmw8.and_u") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw8.and_u (local.get $addr) (local.get $value)))
+  (func (export "i32.atomic.rmw16.and_u") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw16.and_u (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw8.and_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw8.and_u (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw16.and_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw16.and_u (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw32.and_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw32.and_u (local.get $addr) (local.get $value)))
+
+  (func (export "i32.atomic.rmw.or") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw.or (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw.or") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw.or (local.get $addr) (local.get $value)))
+  (func (export "i32.atomic.rmw8.or_u") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw8.or_u (local.get $addr) (local.get $value)))
+  (func (export "i32.atomic.rmw16.or_u") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw16.or_u (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw8.or_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw8.or_u (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw16.or_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw16.or_u (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw32.or_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw32.or_u (local.get $addr) (local.get $value)))
+
+  (func (export "i32.atomic.rmw.xor") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw.xor (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw.xor") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw.xor (local.get $addr) (local.get $value)))
+  (func (export "i32.atomic.rmw8.xor_u") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw8.xor_u (local.get $addr) (local.get $value)))
+  (func (export "i32.atomic.rmw16.xor_u") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw16.xor_u (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw8.xor_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw8.xor_u (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw16.xor_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw16.xor_u (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw32.xor_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw32.xor_u (local.get $addr) (local.get $value)))
+
+  (func (export "i32.atomic.rmw.xchg") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw.xchg (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw.xchg") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw.xchg (local.get $addr) (local.get $value)))
+  (func (export "i32.atomic.rmw8.xchg_u") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw8.xchg_u (local.get $addr) (local.get $value)))
+  (func (export "i32.atomic.rmw16.xchg_u") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw16.xchg_u (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw8.xchg_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw8.xchg_u (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw16.xchg_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw16.xchg_u (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw32.xchg_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw32.xchg_u (local.get $addr) (local.get $value)))
+
+  (func (export "i32.atomic.rmw.cmpxchg") (param $addr i32) (param $expected i32) (param $value i32) (result i32) (i32.atomic.rmw.cmpxchg (local.get $addr) (local.get $expected) (local.get $value)))
+  (func (export "i64.atomic.rmw.cmpxchg") (param $addr i32) (param $expected i64)  (param $value i64) (result i64) (i64.atomic.rmw.cmpxchg (local.get $addr) (local.get $expected) (local.get $value)))
+  (func (export "i32.atomic.rmw8.cmpxchg_u") (param $addr i32) (param $expected i32)  (param $value i32) (result i32) (i32.atomic.rmw8.cmpxchg_u (local.get $addr) (local.get $expected) (local.get $value)))
+  (func (export "i32.atomic.rmw16.cmpxchg_u") (param $addr i32) (param $expected i32)  (param $value i32) (result i32) (i32.atomic.rmw16.cmpxchg_u (local.get $addr) (local.get $expected) (local.get $value)))
+  (func (export "i64.atomic.rmw8.cmpxchg_u") (param $addr i32) (param $expected i64)  (param $value i64) (result i64) (i64.atomic.rmw8.cmpxchg_u (local.get $addr) (local.get $expected) (local.get $value)))
+  (func (export "i64.atomic.rmw16.cmpxchg_u") (param $addr i32) (param $expected i64)  (param $value i64) (result i64) (i64.atomic.rmw16.cmpxchg_u (local.get $addr) (local.get $expected) (local.get $value)))
+  (func (export "i64.atomic.rmw32.cmpxchg_u") (param $addr i32) (param $expected i64)  (param $value i64) (result i64) (i64.atomic.rmw32.cmpxchg_u (local.get $addr) (local.get $expected) (local.get $value)))
+
+)
+
+;; *.atomic.load*
+
+(invoke "init" (i64.const 0x0706050403020100))
+
+(assert_return (invoke "i32.atomic.load" (i32.const 0)) (i32.const 0x03020100))
+(assert_return (invoke "i32.atomic.load" (i32.const 4)) (i32.const 0x07060504))
+
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x0706050403020100))
+
+(assert_return (invoke "i32.atomic.load8_u" (i32.const 0)) (i32.const 0x00))
+(assert_return (invoke "i32.atomic.load8_u" (i32.const 5)) (i32.const 0x05))
+
+(assert_return (invoke "i32.atomic.load16_u" (i32.const 0)) (i32.const 0x0100))
+(assert_return (invoke "i32.atomic.load16_u" (i32.const 6)) (i32.const 0x0706))
+
+(assert_return (invoke "i64.atomic.load8_u" (i32.const 0)) (i64.const 0x00))
+(assert_return (invoke "i64.atomic.load8_u" (i32.const 5)) (i64.const 0x05))
+
+(assert_return (invoke "i64.atomic.load16_u" (i32.const 0)) (i64.const 0x0100))
+(assert_return (invoke "i64.atomic.load16_u" (i32.const 6)) (i64.const 0x0706))
+
+(assert_return (invoke "i64.atomic.load32_u" (i32.const 0)) (i64.const 0x03020100))
+(assert_return (invoke "i64.atomic.load32_u" (i32.const 4)) (i64.const 0x07060504))
+
+;; *.atomic.store*
+
+(invoke "init" (i64.const 0x0000000000000000))
+
+(assert_return (invoke "i32.atomic.store" (i32.const 0) (i32.const 0xffeeddcc)))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x00000000ffeeddcc))
+
+(assert_return (invoke "i64.atomic.store" (i32.const 0) (i64.const 0x0123456789abcdef)))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x0123456789abcdef))
+
+(assert_return (invoke "i32.atomic.store8" (i32.const 1) (i32.const 0x42)))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x0123456789ab42ef))
+
+(assert_return (invoke "i32.atomic.store16" (i32.const 4) (i32.const 0x8844)))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x0123884489ab42ef))
+
+(assert_return (invoke "i64.atomic.store8" (i32.const 1) (i64.const 0x99)))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x0123884489ab99ef))
+
+(assert_return (invoke "i64.atomic.store16" (i32.const 4) (i64.const 0xcafe)))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x0123cafe89ab99ef))
+
+(assert_return (invoke "i64.atomic.store32" (i32.const 4) (i64.const 0xdeadbeef)))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0xdeadbeef89ab99ef))
+
+;; *.atomic.rmw*.add
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw.add" (i32.const 0) (i32.const 0x12345678)) (i32.const 0x11111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111123456789))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw.add" (i32.const 0) (i64.const 0x0101010102020202)) (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1212121213131313))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw8.add_u" (i32.const 0) (i32.const 0xcdcdcdcd)) (i32.const 0x11))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x11111111111111de))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw16.add_u" (i32.const 0) (i32.const 0xcafecafe)) (i32.const 0x1111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x111111111111dc0f))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw8.add_u" (i32.const 0) (i64.const 0x4242424242424242)) (i64.const 0x11))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111111111153))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw16.add_u" (i32.const 0) (i64.const 0xbeefbeefbeefbeef)) (i64.const 0x1111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x111111111111d000))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw32.add_u" (i32.const 0) (i64.const 0xcabba6e5cabba6e5)) (i64.const 0x11111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x11111111dbccb7f6))
+
+;; *.atomic.rmw*.sub
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw.sub" (i32.const 0) (i32.const 0x12345678)) (i32.const 0x11111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x11111111fedcba99))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw.sub" (i32.const 0) (i64.const 0x0101010102020202)) (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x101010100f0f0f0f))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw8.sub_u" (i32.const 0) (i32.const 0xcdcdcdcd)) (i32.const 0x11))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111111111144))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw16.sub_u" (i32.const 0) (i32.const 0xcafecafe)) (i32.const 0x1111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111111114613))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw8.sub_u" (i32.const 0) (i64.const 0x4242424242424242)) (i64.const 0x11))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x11111111111111cf))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw16.sub_u" (i32.const 0) (i64.const 0xbeefbeefbeefbeef)) (i64.const 0x1111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111111115222))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw32.sub_u" (i32.const 0) (i64.const 0xcabba6e5cabba6e5)) (i64.const 0x11111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111146556a2c))
+
+;; *.atomic.rmw*.and
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw.and" (i32.const 0) (i32.const 0x12345678)) (i32.const 0x11111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111110101010))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw.and" (i32.const 0) (i64.const 0x0101010102020202)) (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x0101010100000000))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw8.and_u" (i32.const 0) (i32.const 0xcdcdcdcd)) (i32.const 0x11))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111111111101))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw16.and_u" (i32.const 0) (i32.const 0xcafecafe)) (i32.const 0x1111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111111110010))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw8.and_u" (i32.const 0) (i64.const 0x4242424242424242)) (i64.const 0x11))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111111111100))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw16.and_u" (i32.const 0) (i64.const 0xbeefbeefbeefbeef)) (i64.const 0x1111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111111111001))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw32.and_u" (i32.const 0) (i64.const 0xcabba6e5cabba6e5)) (i64.const 0x11111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111100110001))
+
+;; *.atomic.rmw*.or
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw.or" (i32.const 0) (i32.const 0x12345678)) (i32.const 0x11111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111113355779))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw.or" (i32.const 0) (i64.const 0x0101010102020202)) (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111113131313))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw8.or_u" (i32.const 0) (i32.const 0xcdcdcdcd)) (i32.const 0x11))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x11111111111111dd))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw16.or_u" (i32.const 0) (i32.const 0xcafecafe)) (i32.const 0x1111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x111111111111dbff))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw8.or_u" (i32.const 0) (i64.const 0x4242424242424242)) (i64.const 0x11))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111111111153))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw16.or_u" (i32.const 0) (i64.const 0xbeefbeefbeefbeef)) (i64.const 0x1111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x111111111111bfff))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw32.or_u" (i32.const 0) (i64.const 0xcabba6e5cabba6e5)) (i64.const 0x11111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x11111111dbbbb7f5))
+
+;; *.atomic.rmw*.xor
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw.xor" (i32.const 0) (i32.const 0x12345678)) (i32.const 0x11111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111103254769))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw.xor" (i32.const 0) (i64.const 0x0101010102020202)) (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1010101013131313))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw8.xor_u" (i32.const 0) (i32.const 0xcdcdcdcd)) (i32.const 0x11))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x11111111111111dc))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw16.xor_u" (i32.const 0) (i32.const 0xcafecafe)) (i32.const 0x1111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x111111111111dbef))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw8.xor_u" (i32.const 0) (i64.const 0x4242424242424242)) (i64.const 0x11))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111111111153))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw16.xor_u" (i32.const 0) (i64.const 0xbeefbeefbeefbeef)) (i64.const 0x1111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x111111111111affe))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw32.xor_u" (i32.const 0) (i64.const 0xcabba6e5cabba6e5)) (i64.const 0x11111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x11111111dbaab7f4))
+
+;; *.atomic.rmw*.xchg
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw.xchg" (i32.const 0) (i32.const 0x12345678)) (i32.const 0x11111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111112345678))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw.xchg" (i32.const 0) (i64.const 0x0101010102020202)) (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x0101010102020202))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw8.xchg_u" (i32.const 0) (i32.const 0xcdcdcdcd)) (i32.const 0x11))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x11111111111111cd))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw16.xchg_u" (i32.const 0) (i32.const 0xcafecafe)) (i32.const 0x1111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x111111111111cafe))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw8.xchg_u" (i32.const 0) (i64.const 0x4242424242424242)) (i64.const 0x11))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111111111142))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw16.xchg_u" (i32.const 0) (i64.const 0xbeefbeefbeefbeef)) (i64.const 0x1111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x111111111111beef))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw32.xchg_u" (i32.const 0) (i64.const 0xcabba6e5cabba6e5)) (i64.const 0x11111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x11111111cabba6e5))
+
+;; *.atomic.rmw*.cmpxchg (compare false)
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw.cmpxchg" (i32.const 0) (i32.const 0) (i32.const 0x12345678)) (i32.const 0x11111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111111111111))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw.cmpxchg" (i32.const 0) (i64.const 0) (i64.const 0x0101010102020202)) (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111111111111))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw8.cmpxchg_u" (i32.const 0) (i32.const 0) (i32.const 0xcdcdcdcd)) (i32.const 0x11))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111111111111))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw16.cmpxchg_u" (i32.const 0) (i32.const 0) (i32.const 0xcafecafe)) (i32.const 0x1111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111111111111))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw8.cmpxchg_u" (i32.const 0) (i64.const 0) (i64.const 0x4242424242424242)) (i64.const 0x11))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111111111111))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw16.cmpxchg_u" (i32.const 0) (i64.const 0) (i64.const 0xbeefbeefbeefbeef)) (i64.const 0x1111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111111111111))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw32.cmpxchg_u" (i32.const 0) (i64.const 0) (i64.const 0xcabba6e5cabba6e5)) (i64.const 0x11111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111111111111))
+
+;; *.atomic.rmw*.cmpxchg (compare true)
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw.cmpxchg" (i32.const 0) (i32.const 0x11111111) (i32.const 0x12345678)) (i32.const 0x11111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111112345678))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw.cmpxchg" (i32.const 0) (i64.const 0x1111111111111111) (i64.const 0x0101010102020202)) (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x0101010102020202))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw8.cmpxchg_u" (i32.const 0) (i32.const 0x11) (i32.const 0xcdcdcdcd)) (i32.const 0x11))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x11111111111111cd))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw16.cmpxchg_u" (i32.const 0) (i32.const 0x1111) (i32.const 0xcafecafe)) (i32.const 0x1111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x111111111111cafe))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw8.cmpxchg_u" (i32.const 0) (i64.const 0x11) (i64.const 0x4242424242424242)) (i64.const 0x11))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111111111142))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw16.cmpxchg_u" (i32.const 0) (i64.const 0x1111) (i64.const 0xbeefbeefbeefbeef)) (i64.const 0x1111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x111111111111beef))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw32.cmpxchg_u" (i32.const 0) (i64.const 0x11111111) (i64.const 0xcabba6e5cabba6e5)) (i64.const 0x11111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x11111111cabba6e5))
+
+
+;; unaligned accesses
+
+(assert_trap (invoke "i32.atomic.load" (i32.const 1)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.load" (i32.const 1)) "unaligned atomic")
+(assert_trap (invoke "i32.atomic.load16_u" (i32.const 1)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.load16_u" (i32.const 1)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.load32_u" (i32.const 1)) "unaligned atomic")
+(assert_trap (invoke "i32.atomic.store" (i32.const 1) (i32.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.store" (i32.const 1) (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "i32.atomic.store16" (i32.const 1) (i32.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.store16" (i32.const 1) (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.store32" (i32.const 1) (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "i32.atomic.rmw.add" (i32.const 1) (i32.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.rmw.add" (i32.const 1) (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "i32.atomic.rmw16.add_u" (i32.const 1) (i32.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.rmw16.add_u" (i32.const 1) (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.rmw32.add_u" (i32.const 1) (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "i32.atomic.rmw.sub" (i32.const 1) (i32.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.rmw.sub" (i32.const 1) (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "i32.atomic.rmw16.sub_u" (i32.const 1) (i32.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.rmw16.sub_u" (i32.const 1) (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.rmw32.sub_u" (i32.const 1) (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "i32.atomic.rmw.and" (i32.const 1) (i32.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.rmw.and" (i32.const 1) (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "i32.atomic.rmw16.and_u" (i32.const 1) (i32.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.rmw16.and_u" (i32.const 1) (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.rmw32.and_u" (i32.const 1) (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "i32.atomic.rmw.or" (i32.const 1) (i32.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.rmw.or" (i32.const 1) (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "i32.atomic.rmw16.or_u" (i32.const 1) (i32.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.rmw16.or_u" (i32.const 1) (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.rmw32.or_u" (i32.const 1) (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "i32.atomic.rmw.xor" (i32.const 1) (i32.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.rmw.xor" (i32.const 1) (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "i32.atomic.rmw16.xor_u" (i32.const 1) (i32.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.rmw16.xor_u" (i32.const 1) (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.rmw32.xor_u" (i32.const 1) (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "i32.atomic.rmw.xchg" (i32.const 1) (i32.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.rmw.xchg" (i32.const 1) (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "i32.atomic.rmw16.xchg_u" (i32.const 1) (i32.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.rmw16.xchg_u" (i32.const 1) (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.rmw32.xchg_u" (i32.const 1) (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "i32.atomic.rmw.cmpxchg" (i32.const 1) (i32.const 0) (i32.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.rmw.cmpxchg" (i32.const 1) (i64.const 0)  (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "i32.atomic.rmw16.cmpxchg_u" (i32.const 1) (i32.const 0) (i32.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.rmw16.cmpxchg_u" (i32.const 1) (i64.const 0) (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.rmw32.cmpxchg_u" (i32.const 1) (i64.const 0) (i64.const 0)) "unaligned atomic")
+
+(module
+  (memory 1 1 shared)
+
+  (func (export "init") (param $value i64) (i64.store (i32.const 0) (local.get $value)))
+
+;;   ;; (func (export "memory.atomic.notify") (param $addr i32) (param $count i32) (result i32)
+;;   ;;     (memory.atomic.notify (local.get 0) (local.get 1)))
+;;   ;; (func (export "memory.atomic.wait32") (param $addr i32) (param $expected i32) (param $timeout i64) (result i32)
+;;   ;;     (memory.atomic.wait32 (local.get 0) (local.get 1) (local.get 2)))
+;;   ;; (func (export "memory.atomic.wait64") (param $addr i32) (param $expected i64) (param $timeout i64) (result i32)
+;;   ;;     (memory.atomic.wait64 (local.get 0) (local.get 1) (local.get 2)))
+)
+
+;; (invoke "init" (i64.const 0xffffffffffff))
+;; ;; (assert_return (invoke "memory.atomic.wait32" (i32.const 0) (i32.const 0) (i64.const 0)) (i32.const 1))
+;; ;; (assert_return (invoke "memory.atomic.wait64" (i32.const 0) (i64.const 0) (i64.const 0)) (i32.const 1))
+;; ;; (assert_return (invoke "memory.atomic.notify" (i32.const 0) (i32.const 0)) (i32.const 0))
+
+;; unshared memory is OK
+(module
+  (memory 1 1)
+  ;; (func (drop (memory.atomic.notify (i32.const 0) (i32.const 0))))
+  ;; (func (drop (memory.atomic.wait32 (i32.const 0) (i32.const 0) (i64.const 0))))
+  ;; (func (drop (memory.atomic.wait64 (i32.const 0) (i64.const 0) (i64.const 0))))
+  (func (drop (i32.atomic.load (i32.const 0))))
+  (func (drop (i64.atomic.load (i32.const 0))))
+  (func (drop (i32.atomic.load16_u (i32.const 0))))
+  (func (drop (i64.atomic.load16_u (i32.const 0))))
+  (func (drop (i64.atomic.load32_u (i32.const 0))))
+  (func       (i32.atomic.store (i32.const 0) (i32.const 0)))
+  (func       (i64.atomic.store (i32.const 0) (i64.const 0)))
+  (func       (i32.atomic.store16 (i32.const 0) (i32.const 0)))
+  (func       (i64.atomic.store16 (i32.const 0) (i64.const 0)))
+  (func       (i64.atomic.store32 (i32.const 0) (i64.const 0)))
+  (func (drop (i32.atomic.rmw.add (i32.const 0) (i32.const 0))))
+  (func (drop (i64.atomic.rmw.add (i32.const 0) (i64.const 0))))
+  (func (drop (i32.atomic.rmw16.add_u (i32.const 0) (i32.const 0))))
+  (func (drop (i64.atomic.rmw16.add_u (i32.const 0) (i64.const 0))))
+  (func (drop (i64.atomic.rmw32.add_u (i32.const 0) (i64.const 0))))
+  (func (drop (i32.atomic.rmw.sub (i32.const 0) (i32.const 0))))
+  (func (drop (i64.atomic.rmw.sub (i32.const 0) (i64.const 0))))
+  (func (drop (i32.atomic.rmw16.sub_u (i32.const 0) (i32.const 0))))
+  (func (drop (i64.atomic.rmw16.sub_u (i32.const 0) (i64.const 0))))
+  (func (drop (i64.atomic.rmw32.sub_u (i32.const 0) (i64.const 0))))
+  (func (drop (i32.atomic.rmw.and (i32.const 0) (i32.const 0))))
+  (func (drop (i64.atomic.rmw.and (i32.const 0) (i64.const 0))))
+  (func (drop (i32.atomic.rmw16.and_u (i32.const 0) (i32.const 0))))
+  (func (drop (i64.atomic.rmw16.and_u (i32.const 0) (i64.const 0))))
+  (func (drop (i64.atomic.rmw32.and_u (i32.const 0) (i64.const 0))))
+  (func (drop (i32.atomic.rmw.or (i32.const 0) (i32.const 0))))
+  (func (drop (i64.atomic.rmw.or (i32.const 0) (i64.const 0))))
+  (func (drop (i32.atomic.rmw16.or_u (i32.const 0) (i32.const 0))))
+  (func (drop (i64.atomic.rmw16.or_u (i32.const 0) (i64.const 0))))
+  (func (drop (i64.atomic.rmw32.or_u (i32.const 0) (i64.const 0))))
+  (func (drop (i32.atomic.rmw.xor (i32.const 0) (i32.const 0))))
+  (func (drop (i64.atomic.rmw.xor (i32.const 0) (i64.const 0))))
+  (func (drop (i32.atomic.rmw16.xor_u (i32.const 0) (i32.const 0))))
+  (func (drop (i64.atomic.rmw16.xor_u (i32.const 0) (i64.const 0))))
+  (func (drop (i64.atomic.rmw32.xor_u (i32.const 0) (i64.const 0))))
+  (func (drop (i32.atomic.rmw.xchg (i32.const 0) (i32.const 0))))
+  (func (drop (i64.atomic.rmw.xchg (i32.const 0) (i64.const 0))))
+  (func (drop (i32.atomic.rmw16.xchg_u (i32.const 0) (i32.const 0))))
+  (func (drop (i64.atomic.rmw16.xchg_u (i32.const 0) (i64.const 0))))
+  (func (drop (i64.atomic.rmw32.xchg_u (i32.const 0) (i64.const 0))))
+  (func (drop (i32.atomic.rmw.cmpxchg (i32.const 0) (i32.const 0) (i32.const 0))))
+  (func (drop (i64.atomic.rmw.cmpxchg (i32.const 0) (i64.const 0)  (i64.const 0))))
+  (func (drop (i32.atomic.rmw16.cmpxchg_u (i32.const 0) (i32.const 0) (i32.const 0))))
+  (func (drop (i64.atomic.rmw16.cmpxchg_u (i32.const 0) (i64.const 0) (i64.const 0))))
+  (func (drop (i64.atomic.rmw32.cmpxchg_u (i32.const 0) (i64.const 0) (i64.const 0))))
+)
+
+;; Fails with no memory
+;; (assert_invalid (module (func (drop (memory.atomic.notify (i32.const 0) (i32.const 0))))) "unknown memory")
+;; (assert_invalid (module (func (drop (memory.atomic.wait32 (i32.const 0) (i32.const 0) (i64.const 0))))) "unknown memory")
+;; (assert_invalid (module (func (drop (memory.atomic.wait64 (i32.const 0) (i64.const 0) (i64.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i32.atomic.load (i32.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.load (i32.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i32.atomic.load16_u (i32.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.load16_u (i32.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.load32_u (i32.const 0))))) "unknown memory")
+(assert_invalid (module (func       (i32.atomic.store (i32.const 0) (i32.const 0)))) "unknown memory")
+(assert_invalid (module (func       (i64.atomic.store (i32.const 0) (i64.const 0)))) "unknown memory")
+(assert_invalid (module (func       (i32.atomic.store16 (i32.const 0) (i32.const 0)))) "unknown memory")
+(assert_invalid (module (func       (i64.atomic.store16 (i32.const 0) (i64.const 0)))) "unknown memory")
+(assert_invalid (module (func       (i64.atomic.store32 (i32.const 0) (i64.const 0)))) "unknown memory")
+(assert_invalid (module (func (drop (i32.atomic.rmw.add (i32.const 0) (i32.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.rmw.add (i32.const 0) (i64.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i32.atomic.rmw16.add_u (i32.const 0) (i32.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.rmw16.add_u (i32.const 0) (i64.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.rmw32.add_u (i32.const 0) (i64.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i32.atomic.rmw.sub (i32.const 0) (i32.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.rmw.sub (i32.const 0) (i64.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i32.atomic.rmw16.sub_u (i32.const 0) (i32.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.rmw16.sub_u (i32.const 0) (i64.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.rmw32.sub_u (i32.const 0) (i64.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i32.atomic.rmw.and (i32.const 0) (i32.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.rmw.and (i32.const 0) (i64.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i32.atomic.rmw16.and_u (i32.const 0) (i32.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.rmw16.and_u (i32.const 0) (i64.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.rmw32.and_u (i32.const 0) (i64.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i32.atomic.rmw.or (i32.const 0) (i32.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.rmw.or (i32.const 0) (i64.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i32.atomic.rmw16.or_u (i32.const 0) (i32.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.rmw16.or_u (i32.const 0) (i64.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.rmw32.or_u (i32.const 0) (i64.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i32.atomic.rmw.xor (i32.const 0) (i32.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.rmw.xor (i32.const 0) (i64.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i32.atomic.rmw16.xor_u (i32.const 0) (i32.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.rmw16.xor_u (i32.const 0) (i64.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.rmw32.xor_u (i32.const 0) (i64.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i32.atomic.rmw.xchg (i32.const 0) (i32.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.rmw.xchg (i32.const 0) (i64.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i32.atomic.rmw16.xchg_u (i32.const 0) (i32.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.rmw16.xchg_u (i32.const 0) (i64.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.rmw32.xchg_u (i32.const 0) (i64.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i32.atomic.rmw.cmpxchg (i32.const 0) (i32.const 0) (i32.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.rmw.cmpxchg (i32.const 0) (i64.const 0)  (i64.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i32.atomic.rmw16.cmpxchg_u (i32.const 0) (i32.const 0) (i32.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.rmw16.cmpxchg_u (i32.const 0) (i64.const 0) (i64.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.rmw32.cmpxchg_u (i32.const 0) (i64.const 0) (i64.const 0))))) "unknown memory")
+(;; STDOUT ;;;
+184/184 tests passed.
+;;; STDOUT ;;)

--- a/wasm2c/wasm-rt-impl.c
+++ b/wasm2c/wasm-rt-impl.c
@@ -417,6 +417,8 @@ const char* wasm_rt_strerror(wasm_rt_trap_t trap) {
       return "Invalid call_indirect";
     case WASM_RT_TRAP_UNCAUGHT_EXCEPTION:
       return "Uncaught exception";
+    case WASM_RT_TRAP_UNALIGNED:
+      return "Unaligned atomic memory access";
   }
   return "invalid trap code";
 }

--- a/wasm2c/wasm-rt.h
+++ b/wasm2c/wasm-rt.h
@@ -217,7 +217,8 @@ typedef enum {
   WASM_RT_TRAP_INVALID_CONVERSION, /** Conversion from NaN to integer. */
   WASM_RT_TRAP_UNREACHABLE,        /** Unreachable instruction executed. */
   WASM_RT_TRAP_CALL_INDIRECT,      /** Invalid call_indirect, for any reason. */
-  WASM_RT_TRAP_UNCAUGHT_EXCEPTION, /* Exception thrown and not caught */
+  WASM_RT_TRAP_UNCAUGHT_EXCEPTION, /* Exception thrown and not caught. */
+  WASM_RT_TRAP_UNALIGNED, /** Unaligned atomic instruction executed. */
 #if WASM_RT_MERGED_OOB_AND_EXHAUSTION_TRAPS
   WASM_RT_TRAP_EXHAUSTION = WASM_RT_TRAP_OOB,
 #else


### PR DESCRIPTION
This PR starts the work for support for the threads proposal. In this initial PR, I am only starting with support for the  Atomic memory operations part of the spec https://github.com/WebAssembly/threads/blob/cc01bf0d17ba3fb1dc59fb7c5c725838aff18b50/proposals/threads/Overview.md?plain=1#L228

Since there is a large amount of support needed, it seemed sensible to land this in chunks.

Broadly, there are three types of operations
1. atomics (load, store, add, sub, cmp_xchg)
2. fence
3. conditional variables (wait, notify)

This PR focuses on implementing operations 1 and 2 and relies on atomic builtins provided by gcc, clang and icc https://gcc.gnu.org/onlinedocs/gcc/_005f_005fatomic-Builtins.html
and the MSVC equivalents 
https://learn.microsoft.com/en-us/cpp/intrinsics/intrinsics-available-on-all-architectures?view=msvc-170

On godbolt, it appears that this has support from 

on x86_64
- starting gcc 4.7
- starting clang 3.1
- at least icc 13.0.1

on arm/arm64
- at least gcc 5.4
- at least clang 9

Unfortunately, we can't use C11 operations as casting to/from atomics from/to a regular pointer in the Wasm heap is undefined behavior in C https://stackoverflow.com/questions/55299525/casting-pointers-to-atomic-pointers-and-atomic-sizes --- this means we can't use these ops on pointers to Wasm's linear memory

**Next steps**

- Operation 3 needs further thinking on the best way to implement this, so we can continue to support different compilers and OSes. Currently the best way forward is to implement this, seems to be to implement this on top of atomic ops, similar to [this](There's https://developers.redhat.com/articles/2022/12/06/implementing-c20-atomic-waiting-libstdc#how_can_we_implement_atomic_waiting_). Thoughts welcome.

- This code is tested with a subset of the thread atomic tests. These tests are included in-tree, with unsupported tests (relying on wait/notify) commented out. We can start testing with the full testsuite, once wait/notify is also supported.

- It would be nice to find more efficient ways to perform atomic alignment checks instead of an explicit conditional