### PR TITLE
Revert "Version 1.0.33"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@
 #
 
 cmake_minimum_required(VERSION 3.16)
-project(WABT LANGUAGES C CXX VERSION 1.0.33)
+project(WABT LANGUAGES C CXX VERSION 1.0.32)
 
 include(GNUInstallDirs)
 


### PR DESCRIPTION
This reverts commit 0e6861f0480dfbb6461121463e0963391cc38ccf.

I just discovered to my chagrin that GitHub allows rule-violating pushes (but not force-pushes) to our main branch if typoed from the command-line. :-( I do want us to release 1.0.33 (once #2236 lands) but didn't intend to do it accidentally.

This PR reverts the accidental push. Alternately we could leave it there and just merge #2236 afterwards and then tag, whatever you want.

Edit: disabled this in the GitHub settings for the future...