### PR TITLE
Add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,17 +1,14 @@
 # Security Policy
 
-If you have discovered a security vulnerability in this project, please report it
-privately. **Do not disclose it as a public issue.** This gives us time to work with you
-to fix the issue before public exposure, reducing the chance that the exploit will be
-used before a patch is released.
-
-Please submit your report by filling out
-[this form](https://github.com/WebAssembly/wabt/security/advisories/new).
+WABT is maintained by volunteers on a reasonable-effort basis. If you
+have discovered a security vulnerability, please open a GitHub issue
+to report it. In the future, we may move to a system of private
+reporting of security issues. Please submit your report by filling out
+[this form](https://github.com/WebAssembly/wabt/issues/new).
 
 Please provide the following information in your report:
 
 - A description of the vulnerability and its impact
 - How to reproduce the issue
-
-This project is maintained by volunteers on a reasonable-effort basis. As such,
-we ask that you give us 90 days to work on a fix before public exposure.
+- Which WABT tools or library functions are affected
+- Which WebAssembly features (`--enable` flags) must be enabled

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+If you have discovered a security vulnerability in this project, please report it
+privately. **Do not disclose it as a public issue.** This gives us time to work with you
+to fix the issue before public exposure, reducing the chance that the exploit will be
+used before a patch is released.
+
+You may submit the report in the following ways:
+
+- send an email to ???@???; and/or
+- send us a [private vulnerability report](https://github.com/WebAssembly/wabt/security/advisories/new)
+
+Please provide the following information in your report:
+
+- A description of the vulnerability and its impact
+- How to reproduce the issue
+
+This project is maintained by volunteers on a reasonable-effort basis. As such,
+we ask that you give us 90 days to work on a fix before public exposure.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,10 +5,8 @@ privately. **Do not disclose it as a public issue.** This gives us time to work 
 to fix the issue before public exposure, reducing the chance that the exploit will be
 used before a patch is released.
 
-You may submit the report in the following ways:
-
-- send an email to ???@???; and/or
-- send us a [private vulnerability report](https://github.com/WebAssembly/wabt/security/advisories/new)
+Please submit your report by filling out
+[this form](https://github.com/WebAssembly/wabt/security/advisories/new).
 
 Please provide the following information in your report:
 


### PR DESCRIPTION
Fixes #2244.

As described in the issue above, this PR adds a security policy to the repository.

The policy currently allows private reporting to either an email (currently a placeholder) or using GitHub's private reporting tool. If you'd rather use just one of these (or something completely different like an external website), let me know and I'll change the policy.