### PR TITLE
WastParser: allow empty modules/scripts with warning

### DIFF
--- a/include/wabt/wast-parser.h
+++ b/include/wabt/wast-parser.h
@@ -252,7 +252,6 @@ class WastParser {
   Result ParseSimdV128Const(Const*, TokenType, ConstType);
 
   void CheckImportOrdering(Module*);
-
   bool HasError() const;
 
   WastLexer* lexer_;

--- a/include/wabt/wast-parser.h
+++ b/include/wabt/wast-parser.h
@@ -253,6 +253,8 @@ class WastParser {
 
   void CheckImportOrdering(Module*);
 
+  bool HasError() const;
+
   WastLexer* lexer_;
   Index last_module_index_ = kInvalidIndex;
   Errors* errors_;

--- a/test/parse/empty-file.txt
+++ b/test/parse/empty-file.txt
@@ -1,6 +1,5 @@
 ;;; TOOL: wat2wasm
-;;; ERROR: 1
 ;; empty file
 (;; STDERR ;;;
-out/test/parse/empty-file.txt:4:1: error: unexpected token "EOF", expected a module field or a module.
+out/test/parse/empty-file.txt:3:1: warning: empty module
 ;;; STDERR ;;)

--- a/test/regress/regress-30.txt
+++ b/test/regress/regress-30.txt
@@ -7,7 +7,7 @@ out/test/regress/regress-30.txt:3: assert_malformed passed:
   out/test/regress/regress-30/regress-30.0.wat:1:1: error: unexpected char
   €
   ^
-  out/test/regress/regress-30/regress-30.0.wat:1:2: error: unexpected token "EOF", expected a module field or a module.
+  out/test/regress/regress-30/regress-30.0.wat:1:2: warning: empty module
   €
    ^
 1/1 tests passed.


### PR DESCRIPTION
Fixes #2246. Downgrading the error introduced in #264 to a warning.