### PR TITLE
Add error when parameter size does not match on wasm-interp run-export

### DIFF
--- a/src/tools/wasm-interp.cc
+++ b/src/tools/wasm-interp.cc
@@ -228,9 +228,12 @@ Result RunSpecificExports(const Instance::Ptr& instance,
                                  call_.name.c_str());
         }
         auto* func_type = cast<FuncType>(export_.type.type.get());
-        ERROR_EXIT_UNLESS(func_type->params.size() == call_.args.size(),
-                          "The number of provided arguments does not match "
-                          "with the export parameters\n");
+        int params_size = func_type->params.size();
+        int args_size = call_.args.size();
+        ERROR_EXIT_UNLESS(params_size == args_size,
+                          "Exported function '%s' expects %d arguments, but %d "
+                          "were provided\n",
+                          export_.type.name.c_str(), params_size, args_size);
 
         auto func = s_store.UnsafeGet<Func>(instance->funcs()[export_.index]);
         Values results;

--- a/src/tools/wasm-interp.cc
+++ b/src/tools/wasm-interp.cc
@@ -228,6 +228,10 @@ Result RunSpecificExports(const Instance::Ptr& instance,
                                  call_.name.c_str());
         }
         auto* func_type = cast<FuncType>(export_.type.type.get());
+        ERROR_EXIT_UNLESS(func_type->params.size() == call_.args.size(),
+                          "The number of provided arguments does not match "
+                          "with the export parameters\n");
+
         auto func = s_store.UnsafeGet<Func>(instance->funcs()[export_.index]);
         Values results;
         Trap::Ptr trap;

--- a/test/interp/run-export-with-invalid-arguments-size.txt
+++ b/test/interp/run-export-with-invalid-arguments-size.txt
@@ -5,5 +5,5 @@
   (func (export "id") (param i32) (result i32) (local.get 0))
 )
 (;; STDOUT ;;;
-The number of provided arguments does not match with the export parameters
+Exported function 'id' expects 1 arguments, but 2 were provided
 ;;; STDOUT ;;)

--- a/test/interp/run-export-with-invalid-arguments-size.txt
+++ b/test/interp/run-export-with-invalid-arguments-size.txt
@@ -1,0 +1,9 @@
+;;; TOOL: run-interp
+;;; ARGS1: --run-export=id --argument=i32:7 --argument=i32:8
+;;; ERROR: 1
+(module
+  (func (export "id") (param i32) (result i32) (local.get 0))
+)
+(;; STDOUT ;;;
+The number of provided arguments does not match with the export parameters
+;;; STDOUT ;;)


### PR DESCRIPTION
Closes #2242 

**text.wat**

```lisp
(module
  (func (export "id") (param i32) (result i32) (local.get 0))
)
```

Example:

```bash
$ wasm-interp test.wasm --run-export=id --argument=i32:7 --argument=i32:8
Exported function 'id' expects 1 arguments, but 2 were provided
```
