### PR TITLE
binary-reader.cc: detect more malformed modules

### DIFF
--- a/test/binary/bad-extra-end.txt
+++ b/test/binary/bad-extra-end.txt
@@ -12,8 +12,6 @@ section(CODE) {
   }
 }
 (;; STDERR ;;;
-error: popping empty label stack
-000001a: error: OnEndExpr callback failed
-error: popping empty label stack
-000001a: error: OnEndExpr callback failed
+0000019: error: function body shorter than given size
+0000019: error: function body shorter than given size
 ;;; STDERR ;;)

--- a/test/binary/bad-function-body-size.txt
+++ b/test/binary/bad-function-body-size.txt
@@ -13,5 +13,5 @@ section(CODE) {
     drop
 }
 (;; STDERR ;;;
-0000019: error: function body longer than given size
+0000019: error: function body must end with END opcode
 ;;; STDERR ;;)

--- a/test/binary/bad-op-after-end.txt
+++ b/test/binary/bad-op-after-end.txt
@@ -12,8 +12,6 @@ section(CODE) {
   }
 }
 (;; STDERR ;;;
-error: accessing stack depth: 0 >= max: 0
-000001a: error: OnNopExpr callback failed
-error: accessing stack depth: 0 >= max: 0
-000001a: error: OnNopExpr callback failed
+0000019: error: function body shorter than given size
+0000019: error: function body shorter than given size
 ;;; STDERR ;;)

--- a/test/regress/regress-28.txt
+++ b/test/regress/regress-28.txt
@@ -15,6 +15,5 @@ section(CODE) {
   }
 }
 (;; STDERR ;;;
-out/test/regress/regress-28/regress-28.wasm:000001c: error: type mismatch at end of function, expected [] but got [any]
-000001c: error: EndFunctionBody callback failed
+0000019: error: function body shorter than given size
 ;;; STDERR ;;)


### PR DESCRIPTION
This PR lets the BinaryReader detect malformed modules in the binary format that:

- are missing END opcodes at the end of functions
- have too many END opcodes at the end of functions
- have DELEGATE opcodes outside a TRY
- have ELSE opcodes outside an IF

Previously we were only catching some of these situations later in validation. This is a prelude for a future PR that will make the spectest interpreter require that `assert_malformed` fail to parse the module (currently `assert_malformed` is treated the same as `assert_invalid`, i.e. the command passes as long as validation fails).