### PR TITLE
spectest-interp: assert_malformed must error in reader alone

### DIFF
--- a/test/spec/binary.txt
+++ b/test/spec/binary.txt
@@ -277,8 +277,7 @@ out/test/spec/binary.wast:1772: assert_malformed passed:
 out/test/spec/binary.wast:1786: assert_malformed passed:
   000001a: error: unfinished section (expected end: 0x1b)
 out/test/spec/binary.wast:1817: assert_malformed passed:
-  out/test/spec/binary/binary.174.wasm:0000025: error: function type variable out of range: 11 (max 1)
-  0000025: error: OnBlockExpr callback failed
+  0000027: error: function body must end with END opcode
 out/test/spec/binary.wast:1852: assert_malformed passed:
   0000017: error: multiple Start sections
 177/177 tests passed.

--- a/test/spec/exception-handling/binary.txt
+++ b/test/spec/exception-handling/binary.txt
@@ -278,8 +278,7 @@ out/test/spec/exception-handling/binary.wast:1772: assert_malformed passed:
 out/test/spec/exception-handling/binary.wast:1786: assert_malformed passed:
   000001a: error: unfinished section (expected end: 0x1b)
 out/test/spec/exception-handling/binary.wast:1817: assert_malformed passed:
-  out/test/spec/exception-handling/binary/binary.174.wasm:0000025: error: function type variable out of range: 11 (max 1)
-  0000025: error: OnBlockExpr callback failed
+  0000027: error: function body must end with END opcode
 out/test/spec/exception-handling/binary.wast:1852: assert_malformed passed:
   0000017: error: multiple Start sections
 177/177 tests passed.

--- a/test/spec/memory64/binary.txt
+++ b/test/spec/memory64/binary.txt
@@ -175,8 +175,7 @@ out/test/spec/memory64/binary.wast:900: assert_malformed passed:
 out/test/spec/memory64/binary.wast:914: assert_malformed passed:
   000001a: error: unfinished section (expected end: 0x1b)
 out/test/spec/memory64/binary.wast:945: assert_malformed passed:
-  out/test/spec/memory64/binary/binary.102.wasm:0000025: error: function type variable out of range: 11 (max 1)
-  0000025: error: OnBlockExpr callback failed
+  0000026: error: unable to read uint8_t: opcode
 out/test/spec/memory64/binary.wast:980: assert_malformed passed:
   0000017: error: multiple Start sections
 105/105 tests passed.

--- a/test/spec/multi-memory/binary.txt
+++ b/test/spec/multi-memory/binary.txt
@@ -258,8 +258,7 @@ out/test/spec/multi-memory/binary.wast:1581: assert_malformed passed:
 out/test/spec/multi-memory/binary.wast:1595: assert_malformed passed:
   000001a: error: unfinished section (expected end: 0x1b)
 out/test/spec/multi-memory/binary.wast:1626: assert_malformed passed:
-  out/test/spec/multi-memory/binary/binary.164.wasm:0000025: error: function type variable out of range: 11 (max 1)
-  0000025: error: OnBlockExpr callback failed
+  0000027: error: function body must end with END opcode
 out/test/spec/multi-memory/binary.wast:1661: assert_malformed passed:
   0000017: error: multiple Start sections
 167/167 tests passed.


### PR DESCRIPTION
In the spectest interpreter, currently `assert_malformed` is treated the same as `assert_invalid`. This PR requires that `assert_malformed` modules must fail in the reader (not later in validation).

This also fixes an issue where `assert_invalid` wasn't validating text modules, so spectest-interp wasn't working properly for something like `(assert_invalid (module quote "...") "")`. There aren't a lot of tests like this because usually there's no need for `(module quote)` unless it's going to be in an `(assert_malformed)`, but the memory64 tests [have one](https://github.com/WebAssembly/memory64/blob/main/test/core/address.wast#L213-L219) because overlarge offsets are moving from a malformed failure to a validation failure. So this is a prerequisite for #2253.

~~This is logically dependent on #2251 (the tests won't pass until #2251 is merged).~~