### PR TITLE
memory64: when enabled, check offset range at validation-time

### DIFF
--- a/include/wabt/shared-validator.h
+++ b/include/wabt/shared-validator.h
@@ -104,12 +104,36 @@ class SharedValidator {
   Result OnLocalDecl(const Location&, Index count, Type type);
 
   Result OnAtomicFence(const Location&, uint32_t consistency_model);
-  Result OnAtomicLoad(const Location&, Opcode, Var memidx, Address align);
-  Result OnAtomicNotify(const Location&, Opcode, Var memidx, Address align);
-  Result OnAtomicRmwCmpxchg(const Location&, Opcode, Var memidx, Address align);
-  Result OnAtomicRmw(const Location&, Opcode, Var memidx, Address align);
-  Result OnAtomicStore(const Location&, Opcode, Var memidx, Address align);
-  Result OnAtomicWait(const Location&, Opcode, Var memidx, Address align);
+  Result OnAtomicLoad(const Location&,
+                      Opcode,
+                      Var memidx,
+                      Address align,
+                      Address offset);
+  Result OnAtomicNotify(const Location&,
+                        Opcode,
+                        Var memidx,
+                        Address align,
+                        Address offset);
+  Result OnAtomicRmwCmpxchg(const Location&,
+                            Opcode,
+                            Var memidx,
+                            Address align,
+                            Address offset);
+  Result OnAtomicRmw(const Location&,
+                     Opcode,
+                     Var memidx,
+                     Address align,
+                     Address offset);
+  Result OnAtomicStore(const Location&,
+                       Opcode,
+                       Var memidx,
+                       Address align,
+                       Address offset);
+  Result OnAtomicWait(const Location&,
+                      Opcode,
+                      Var memidx,
+                      Address align,
+                      Address offset);
   Result OnBinary(const Location&, Opcode);
   Result OnBlock(const Location&, Type sig_type);
   Result OnBr(const Location&, Var depth);
@@ -133,9 +157,17 @@ class SharedValidator {
   Result OnGlobalGet(const Location&, Var);
   Result OnGlobalSet(const Location&, Var);
   Result OnIf(const Location&, Type sig_type);
-  Result OnLoad(const Location&, Opcode, Var memidx, Address align);
-  Result OnLoadSplat(const Location&, Opcode, Var memidx, Address align);
-  Result OnLoadZero(const Location&, Opcode, Var memidx, Address align);
+  Result OnLoad(const Location&, Opcode, Var memidx, Address align, Address offset);
+  Result OnLoadSplat(const Location&,
+                     Opcode,
+                     Var memidx,
+                     Address align,
+                     Address offset);
+  Result OnLoadZero(const Location&,
+                    Opcode,
+                    Var memidx,
+                    Address align,
+                    Address offset);
   Result OnLocalGet(const Location&, Var);
   Result OnLocalSet(const Location&, Var);
   Result OnLocalTee(const Location&, Var);
@@ -159,14 +191,20 @@ class SharedValidator {
                         Opcode,
                         Var memidx,
                         Address align,
+                        Address offset,
                         uint64_t lane_idx);
   Result OnSimdStoreLane(const Location&,
                          Opcode,
                          Var memidx,
                          Address align,
+                         Address offset,
                          uint64_t lane_idx);
   Result OnSimdShuffleOp(const Location&, Opcode, v128 lane_idx);
-  Result OnStore(const Location&, Opcode, Var memidx, Address align);
+  Result OnStore(const Location&,
+                 Opcode,
+                 Var memidx,
+                 Address align,
+                 Address offset);
   Result OnTableCopy(const Location&, Var dst_var, Var src_var);
   Result OnTableFill(const Location&, Var table_var);
   Result OnTableGet(const Location&, Var table_var);
@@ -280,6 +318,7 @@ class SharedValidator {
   Result CheckDataSegmentIndex(Var data_segment_var);
 
   Result CheckAlign(const Location&, Address align, Address natural_align);
+  Result CheckOffset(const Location&, Address offset, const Limits& limits);
   Result CheckAtomicAlign(const Location&,
                           Address align,
                           Address natural_align);

--- a/src/interp/binary-reader-interp.cc
+++ b/src/interp/binary-reader-interp.cc
@@ -907,9 +907,9 @@ Result BinaryReaderInterp::OnSimdLoadLaneExpr(Opcode opcode,
                                               Address alignment_log2,
                                               Address offset,
                                               uint64_t value) {
-  CHECK_RESULT(validator_.OnSimdLoadLane(GetLocation(), opcode,
-                                         Var(memidx, GetLocation()),
-                                         GetAlignment(alignment_log2), value));
+  CHECK_RESULT(validator_.OnSimdLoadLane(
+      GetLocation(), opcode, Var(memidx, GetLocation()),
+      GetAlignment(alignment_log2), offset, value));
   istream_.Emit(opcode, memidx, offset, static_cast<u8>(value));
   return Result::Ok;
 }
@@ -919,9 +919,9 @@ Result BinaryReaderInterp::OnSimdStoreLaneExpr(Opcode opcode,
                                                Address alignment_log2,
                                                Address offset,
                                                uint64_t value) {
-  CHECK_RESULT(validator_.OnSimdStoreLane(GetLocation(), opcode,
-                                          Var(memidx, GetLocation()),
-                                          GetAlignment(alignment_log2), value));
+  CHECK_RESULT(validator_.OnSimdStoreLane(
+      GetLocation(), opcode, Var(memidx, GetLocation()),
+      GetAlignment(alignment_log2), offset, value));
   istream_.Emit(opcode, memidx, offset, static_cast<u8>(value));
   return Result::Ok;
 }
@@ -938,7 +938,7 @@ Result BinaryReaderInterp::OnLoadSplatExpr(Opcode opcode,
                                            Address offset) {
   CHECK_RESULT(validator_.OnLoadSplat(GetLocation(), opcode,
                                       Var(memidx, GetLocation()),
-                                      GetAlignment(align_log2)));
+                                      GetAlignment(align_log2), offset));
   istream_.Emit(opcode, memidx, offset);
   return Result::Ok;
 }
@@ -949,7 +949,7 @@ Result BinaryReaderInterp::OnLoadZeroExpr(Opcode opcode,
                                           Address offset) {
   CHECK_RESULT(validator_.OnLoadZero(GetLocation(), opcode,
                                      Var(memidx, GetLocation()),
-                                     GetAlignment(align_log2)));
+                                     GetAlignment(align_log2), offset));
   istream_.Emit(opcode, memidx, offset);
   return Result::Ok;
 }
@@ -960,7 +960,7 @@ Result BinaryReaderInterp::OnAtomicLoadExpr(Opcode opcode,
                                             Address offset) {
   CHECK_RESULT(validator_.OnAtomicLoad(GetLocation(), opcode,
                                        Var(memidx, GetLocation()),
-                                       GetAlignment(align_log2)));
+                                       GetAlignment(align_log2), offset));
   istream_.Emit(opcode, memidx, offset);
   return Result::Ok;
 }
@@ -971,7 +971,7 @@ Result BinaryReaderInterp::OnAtomicStoreExpr(Opcode opcode,
                                              Address offset) {
   CHECK_RESULT(validator_.OnAtomicStore(GetLocation(), opcode,
                                         Var(memidx, GetLocation()),
-                                        GetAlignment(align_log2)));
+                                        GetAlignment(align_log2), offset));
   istream_.Emit(opcode, memidx, offset);
   return Result::Ok;
 }
@@ -982,7 +982,7 @@ Result BinaryReaderInterp::OnAtomicRmwExpr(Opcode opcode,
                                            Address offset) {
   CHECK_RESULT(validator_.OnAtomicRmw(GetLocation(), opcode,
                                       Var(memidx, GetLocation()),
-                                      GetAlignment(align_log2)));
+                                      GetAlignment(align_log2), offset));
   istream_.Emit(opcode, memidx, offset);
   return Result::Ok;
 }
@@ -993,7 +993,7 @@ Result BinaryReaderInterp::OnAtomicRmwCmpxchgExpr(Opcode opcode,
                                                   Address offset) {
   CHECK_RESULT(validator_.OnAtomicRmwCmpxchg(GetLocation(), opcode,
                                              Var(memidx, GetLocation()),
-                                             GetAlignment(align_log2)));
+                                             GetAlignment(align_log2), offset));
   istream_.Emit(opcode, memidx, offset);
   return Result::Ok;
 }
@@ -1294,7 +1294,7 @@ Result BinaryReaderInterp::OnLoadExpr(Opcode opcode,
                                       Address offset) {
   CHECK_RESULT(validator_.OnLoad(GetLocation(), opcode,
                                  Var(memidx, GetLocation()),
-                                 GetAlignment(align_log2)));
+                                 GetAlignment(align_log2), offset));
   istream_.Emit(opcode, memidx, offset);
   return Result::Ok;
 }
@@ -1305,7 +1305,7 @@ Result BinaryReaderInterp::OnStoreExpr(Opcode opcode,
                                        Address offset) {
   CHECK_RESULT(validator_.OnStore(GetLocation(), opcode,
                                   Var(memidx, GetLocation()),
-                                  GetAlignment(align_log2)));
+                                  GetAlignment(align_log2), offset));
   istream_.Emit(opcode, memidx, offset);
   return Result::Ok;
 }
@@ -1400,7 +1400,7 @@ Result BinaryReaderInterp::OnAtomicWaitExpr(Opcode opcode,
                                             Address offset) {
   CHECK_RESULT(validator_.OnAtomicWait(GetLocation(), opcode,
                                        Var(memidx, GetLocation()),
-                                       GetAlignment(align_log2)));
+                                       GetAlignment(align_log2), offset));
   istream_.Emit(opcode, memidx, offset);
   return Result::Ok;
 }
@@ -1417,7 +1417,7 @@ Result BinaryReaderInterp::OnAtomicNotifyExpr(Opcode opcode,
                                               Address offset) {
   CHECK_RESULT(validator_.OnAtomicNotify(GetLocation(), opcode,
                                          Var(memidx, GetLocation()),
-                                         GetAlignment(align_log2)));
+                                         GetAlignment(align_log2), offset));
   istream_.Emit(opcode, memidx, offset);
   return Result::Ok;
 }

--- a/src/shared-validator.cc
+++ b/src/shared-validator.cc
@@ -518,6 +518,18 @@ Result SharedValidator::CheckAlign(const Location& loc,
   return Result::Ok;
 }
 
+Result SharedValidator::CheckOffset(const Location& loc,
+                                    Address offset,
+                                    const Limits& limits) {
+  if (limits.is_64 || (offset <= UINT32_MAX)) {
+    return Result::Ok;
+  }
+
+  PrintError(loc, "offset must be less than or equal to 0xffffffff");
+
+  return Result::Error;
+}
+
 Result SharedValidator::CheckAtomicAlign(const Location& loc,
                                          Address alignment,
                                          Address natural_alignment) {
@@ -579,11 +591,13 @@ Result SharedValidator::OnAtomicFence(const Location& loc,
 Result SharedValidator::OnAtomicLoad(const Location& loc,
                                      Opcode opcode,
                                      Var memidx,
-                                     Address alignment) {
+                                     Address alignment,
+                                     Address offset) {
   Result result = CheckInstr(opcode, loc);
   MemoryType mt;
   result |= CheckMemoryIndex(memidx, &mt);
   result |= CheckAtomicAlign(loc, alignment, opcode.GetMemorySize());
+  result |= CheckOffset(loc, offset, mt.limits);
   result |= typechecker_.OnAtomicLoad(opcode, mt.limits);
   return result;
 }
@@ -591,11 +605,13 @@ Result SharedValidator::OnAtomicLoad(const Location& loc,
 Result SharedValidator::OnAtomicNotify(const Location& loc,
                                        Opcode opcode,
                                        Var memidx,
-                                       Address alignment) {
+                                       Address alignment,
+                                       Address offset) {
   Result result = CheckInstr(opcode, loc);
   MemoryType mt;
   result |= CheckMemoryIndex(memidx, &mt);
   result |= CheckAtomicAlign(loc, alignment, opcode.GetMemorySize());
+  result |= CheckOffset(loc, offset, mt.limits);
   result |= typechecker_.OnAtomicNotify(opcode, mt.limits);
   return result;
 }
@@ -603,11 +619,13 @@ Result SharedValidator::OnAtomicNotify(const Location& loc,
 Result SharedValidator::OnAtomicRmwCmpxchg(const Location& loc,
                                            Opcode opcode,
                                            Var memidx,
-                                           Address alignment) {
+                                           Address alignment,
+                                           Address offset) {
   Result result = CheckInstr(opcode, loc);
   MemoryType mt;
   result |= CheckMemoryIndex(memidx, &mt);
   result |= CheckAtomicAlign(loc, alignment, opcode.GetMemorySize());
+  result |= CheckOffset(loc, offset, mt.limits);
   result |= typechecker_.OnAtomicRmwCmpxchg(opcode, mt.limits);
   return result;
 }
@@ -615,11 +633,13 @@ Result SharedValidator::OnAtomicRmwCmpxchg(const Location& loc,
 Result SharedValidator::OnAtomicRmw(const Location& loc,
                                     Opcode opcode,
                                     Var memidx,
-                                    Address alignment) {
+                                    Address alignment,
+                                    Address offset) {
   Result result = CheckInstr(opcode, loc);
   MemoryType mt;
   result |= CheckMemoryIndex(memidx, &mt);
   result |= CheckAtomicAlign(loc, alignment, opcode.GetMemorySize());
+  result |= CheckOffset(loc, offset, mt.limits);
   result |= typechecker_.OnAtomicRmw(opcode, mt.limits);
   return result;
 }
@@ -627,11 +647,13 @@ Result SharedValidator::OnAtomicRmw(const Location& loc,
 Result SharedValidator::OnAtomicStore(const Location& loc,
                                       Opcode opcode,
                                       Var memidx,
-                                      Address alignment) {
+                                      Address alignment,
+                                      Address offset) {
   Result result = CheckInstr(opcode, loc);
   MemoryType mt;
   result |= CheckMemoryIndex(memidx, &mt);
   result |= CheckAtomicAlign(loc, alignment, opcode.GetMemorySize());
+  result |= CheckOffset(loc, offset, mt.limits);
   result |= typechecker_.OnAtomicStore(opcode, mt.limits);
   return result;
 }
@@ -639,11 +661,13 @@ Result SharedValidator::OnAtomicStore(const Location& loc,
 Result SharedValidator::OnAtomicWait(const Location& loc,
                                      Opcode opcode,
                                      Var memidx,
-                                     Address alignment) {
+                                     Address alignment,
+                                     Address offset) {
   Result result = CheckInstr(opcode, loc);
   MemoryType mt;
   result |= CheckMemoryIndex(memidx, &mt);
   result |= CheckAtomicAlign(loc, alignment, opcode.GetMemorySize());
+  result |= CheckOffset(loc, offset, mt.limits);
   result |= typechecker_.OnAtomicWait(opcode, mt.limits);
   return result;
 }
@@ -850,11 +874,13 @@ Result SharedValidator::OnIf(const Location& loc, Type sig_type) {
 Result SharedValidator::OnLoad(const Location& loc,
                                Opcode opcode,
                                Var memidx,
-                               Address alignment) {
+                               Address alignment,
+                               Address offset) {
   Result result = CheckInstr(opcode, loc);
   MemoryType mt;
   result |= CheckMemoryIndex(memidx, &mt);
   result |= CheckAlign(loc, alignment, opcode.GetMemorySize());
+  result |= CheckOffset(loc, offset, mt.limits);
   result |= typechecker_.OnLoad(opcode, mt.limits);
   return result;
 }
@@ -862,11 +888,13 @@ Result SharedValidator::OnLoad(const Location& loc,
 Result SharedValidator::OnLoadSplat(const Location& loc,
                                     Opcode opcode,
                                     Var memidx,
-                                    Address alignment) {
+                                    Address alignment,
+                                    Address offset) {
   Result result = CheckInstr(opcode, loc);
   MemoryType mt;
   result |= CheckMemoryIndex(memidx, &mt);
   result |= CheckAlign(loc, alignment, opcode.GetMemorySize());
+  result |= CheckOffset(loc, offset, mt.limits);
   result |= typechecker_.OnLoad(opcode, mt.limits);
   return result;
 }
@@ -874,11 +902,13 @@ Result SharedValidator::OnLoadSplat(const Location& loc,
 Result SharedValidator::OnLoadZero(const Location& loc,
                                    Opcode opcode,
                                    Var memidx,
-                                   Address alignment) {
+                                   Address alignment,
+                                   Address offset) {
   Result result = CheckInstr(opcode, loc);
   MemoryType mt;
   result |= CheckMemoryIndex(memidx, &mt);
   result |= CheckAlign(loc, alignment, opcode.GetMemorySize());
+  result |= CheckOffset(loc, offset, mt.limits);
   result |= typechecker_.OnLoad(opcode, mt.limits);
   return result;
 }
@@ -1058,11 +1088,13 @@ Result SharedValidator::OnSimdLoadLane(const Location& loc,
                                        Opcode opcode,
                                        Var memidx,
                                        Address alignment,
+                                       Address offset,
                                        uint64_t value) {
   Result result = CheckInstr(opcode, loc);
   MemoryType mt;
   result |= CheckMemoryIndex(memidx, &mt);
   result |= CheckAlign(loc, alignment, opcode.GetMemorySize());
+  result |= CheckOffset(loc, offset, mt.limits);
   result |= typechecker_.OnSimdLoadLane(opcode, mt.limits, value);
   return result;
 }
@@ -1071,11 +1103,13 @@ Result SharedValidator::OnSimdStoreLane(const Location& loc,
                                         Opcode opcode,
                                         Var memidx,
                                         Address alignment,
+                                        Address offset,
                                         uint64_t value) {
   Result result = CheckInstr(opcode, loc);
   MemoryType mt;
   result |= CheckMemoryIndex(memidx, &mt);
   result |= CheckAlign(loc, alignment, opcode.GetMemorySize());
+  result |= CheckOffset(loc, offset, mt.limits);
   result |= typechecker_.OnSimdStoreLane(opcode, mt.limits, value);
   return result;
 }
@@ -1091,11 +1125,13 @@ Result SharedValidator::OnSimdShuffleOp(const Location& loc,
 Result SharedValidator::OnStore(const Location& loc,
                                 Opcode opcode,
                                 Var memidx,
-                                Address alignment) {
+                                Address alignment,
+                                Address offset) {
   Result result = CheckInstr(opcode, loc);
   MemoryType mt;
   result |= CheckMemoryIndex(memidx, &mt);
   result |= CheckAlign(loc, alignment, opcode.GetMemorySize());
+  result |= CheckOffset(loc, offset, mt.limits);
   result |= typechecker_.OnStore(opcode, mt.limits);
   return result;
 }

--- a/src/shared-validator.cc
+++ b/src/shared-validator.cc
@@ -521,13 +521,12 @@ Result SharedValidator::CheckAlign(const Location& loc,
 Result SharedValidator::CheckOffset(const Location& loc,
                                     Address offset,
                                     const Limits& limits) {
-  if (limits.is_64 || (offset <= UINT32_MAX)) {
-    return Result::Ok;
+  if ((!limits.is_64) && (offset > UINT32_MAX)) {
+    PrintError(loc, "offset must be less than or equal to 0xffffffff");
+    return Result::Error;
   }
 
-  PrintError(loc, "offset must be less than or equal to 0xffffffff");
-
-  return Result::Error;
+  return Result::Ok;
 }
 
 Result SharedValidator::CheckAtomicAlign(const Location& loc,

--- a/src/validator.cc
+++ b/src/validator.cc
@@ -381,8 +381,9 @@ Result Validator::EndIfExpr(IfExpr* expr) {
 }
 
 Result Validator::OnLoadExpr(LoadExpr* expr) {
-  result_ |= validator_.OnLoad(expr->loc, expr->opcode, expr->memidx,
-                               expr->opcode.GetAlignment(expr->align));
+  result_ |=
+      validator_.OnLoad(expr->loc, expr->opcode, expr->memidx,
+                        expr->opcode.GetAlignment(expr->align), expr->offset);
   return Result::Ok;
 }
 
@@ -532,8 +533,9 @@ Result Validator::OnSelectExpr(SelectExpr* expr) {
 }
 
 Result Validator::OnStoreExpr(StoreExpr* expr) {
-  result_ |= validator_.OnStore(expr->loc, expr->opcode, expr->memidx,
-                                expr->opcode.GetAlignment(expr->align));
+  result_ |=
+      validator_.OnStore(expr->loc, expr->opcode, expr->memidx,
+                         expr->opcode.GetAlignment(expr->align), expr->offset);
   return Result::Ok;
 }
 
@@ -579,7 +581,8 @@ Result Validator::OnRethrowExpr(RethrowExpr* expr) {
 
 Result Validator::OnAtomicWaitExpr(AtomicWaitExpr* expr) {
   result_ |= validator_.OnAtomicWait(expr->loc, expr->opcode, expr->memidx,
-                                     expr->opcode.GetAlignment(expr->align));
+                                     expr->opcode.GetAlignment(expr->align),
+                                     expr->offset);
   return Result::Ok;
 }
 
@@ -590,32 +593,36 @@ Result Validator::OnAtomicFenceExpr(AtomicFenceExpr* expr) {
 
 Result Validator::OnAtomicNotifyExpr(AtomicNotifyExpr* expr) {
   result_ |= validator_.OnAtomicNotify(expr->loc, expr->opcode, expr->memidx,
-                                       expr->opcode.GetAlignment(expr->align));
+                                       expr->opcode.GetAlignment(expr->align),
+                                       expr->offset);
   return Result::Ok;
 }
 
 Result Validator::OnAtomicLoadExpr(AtomicLoadExpr* expr) {
   result_ |= validator_.OnAtomicLoad(expr->loc, expr->opcode, expr->memidx,
-                                     expr->opcode.GetAlignment(expr->align));
+                                     expr->opcode.GetAlignment(expr->align),
+                                     expr->offset);
   return Result::Ok;
 }
 
 Result Validator::OnAtomicStoreExpr(AtomicStoreExpr* expr) {
   result_ |= validator_.OnAtomicStore(expr->loc, expr->opcode, expr->memidx,
-                                      expr->opcode.GetAlignment(expr->align));
+                                      expr->opcode.GetAlignment(expr->align),
+                                      expr->offset);
   return Result::Ok;
 }
 
 Result Validator::OnAtomicRmwExpr(AtomicRmwExpr* expr) {
   result_ |= validator_.OnAtomicRmw(expr->loc, expr->opcode, expr->memidx,
-                                    expr->opcode.GetAlignment(expr->align));
+                                    expr->opcode.GetAlignment(expr->align),
+                                    expr->offset);
   return Result::Ok;
 }
 
 Result Validator::OnAtomicRmwCmpxchgExpr(AtomicRmwCmpxchgExpr* expr) {
-  result_ |=
-      validator_.OnAtomicRmwCmpxchg(expr->loc, expr->opcode, expr->memidx,
-                                    expr->opcode.GetAlignment(expr->align));
+  result_ |= validator_.OnAtomicRmwCmpxchg(
+      expr->loc, expr->opcode, expr->memidx,
+      expr->opcode.GetAlignment(expr->align), expr->offset);
   return Result::Ok;
 }
 
@@ -632,14 +639,14 @@ Result Validator::OnSimdLaneOpExpr(SimdLaneOpExpr* expr) {
 Result Validator::OnSimdLoadLaneExpr(SimdLoadLaneExpr* expr) {
   result_ |= validator_.OnSimdLoadLane(expr->loc, expr->opcode, expr->memidx,
                                        expr->opcode.GetAlignment(expr->align),
-                                       expr->val);
+                                       expr->offset, expr->val);
   return Result::Ok;
 }
 
 Result Validator::OnSimdStoreLaneExpr(SimdStoreLaneExpr* expr) {
   result_ |= validator_.OnSimdStoreLane(expr->loc, expr->opcode, expr->memidx,
                                         expr->opcode.GetAlignment(expr->align),
-                                        expr->val);
+                                        expr->offset, expr->val);
   return Result::Ok;
 }
 
@@ -650,13 +657,15 @@ Result Validator::OnSimdShuffleOpExpr(SimdShuffleOpExpr* expr) {
 
 Result Validator::OnLoadSplatExpr(LoadSplatExpr* expr) {
   result_ |= validator_.OnLoadSplat(expr->loc, expr->opcode, expr->memidx,
-                                    expr->opcode.GetAlignment(expr->align));
+                                    expr->opcode.GetAlignment(expr->align),
+                                    expr->offset);
   return Result::Ok;
 }
 
 Result Validator::OnLoadZeroExpr(LoadZeroExpr* expr) {
   result_ |= validator_.OnLoadZero(expr->loc, expr->opcode, expr->memidx,
-                                   expr->opcode.GetAlignment(expr->align));
+                                   expr->opcode.GetAlignment(expr->align),
+                                   expr->offset);
   return Result::Ok;
 }
 

--- a/src/wast-parser.cc
+++ b/src/wast-parser.cc
@@ -1050,8 +1050,9 @@ bool WastParser::ParseOffsetOpt(Address* out_offset) {
       Error(token.loc, "invalid offset \"" PRIstringview "\"",
             WABT_PRINTF_STRING_VIEW_ARG(sv));
     }
-    // FIXME: make this depend on the current memory.
-    if (offset64 > UINT32_MAX) {
+    // With memory64, offsets > UINT32_MAX for i32 memories are no longer
+    // malformed (just invalid)
+    if ((!options_->features.memory64_enabled()) && (offset64 > UINT32_MAX)) {
       Error(token.loc, "offset must be less than or equal to 0xffffffff");
     }
     *out_offset = offset64;

--- a/test/binary/bad-data-without-memory.txt
+++ b/test/binary/bad-data-without-memory.txt
@@ -9,6 +9,6 @@ section(DATA) {
 }
 section(DATACOUNT) { count[1] }
 (;; STDERR ;;;
-000000c: error: no memory to copy data to
-000000c: error: no memory to copy data to
+0000012: error: section DataCount out of order
+0000012: error: section DataCount out of order
 ;;; STDERR ;;)

--- a/test/spec/memory.txt
+++ b/test/spec/memory.txt
@@ -17,13 +17,17 @@ out/test/spec/memory.wast:22: assert_invalid passed:
   out/test/spec/memory/memory.13.wasm:000000c: error: memory variable out of range: 0 (max 0)
   000000c: error: BeginDataSegment callback failed
 out/test/spec/memory.wast:25: assert_invalid passed:
-  000001b: error: load/store memory 0 out of range 0
+  out/test/spec/memory/memory.14.wasm:000001c: error: memory variable out of range: 0 (max 0)
+  000001c: error: OnLoadExpr callback failed
 out/test/spec/memory.wast:29: assert_invalid passed:
-  0000020: error: load/store memory 0 out of range 0
+  out/test/spec/memory/memory.15.wasm:0000021: error: memory variable out of range: 0 (max 0)
+  0000021: error: OnStoreExpr callback failed
 out/test/spec/memory.wast:33: assert_invalid passed:
-  000001b: error: load/store memory 0 out of range 0
+  out/test/spec/memory/memory.16.wasm:000001c: error: memory variable out of range: 0 (max 0)
+  000001c: error: OnLoadExpr callback failed
 out/test/spec/memory.wast:37: assert_invalid passed:
-  000001d: error: load/store memory 0 out of range 0
+  out/test/spec/memory/memory.17.wasm:000001e: error: memory variable out of range: 0 (max 0)
+  000001e: error: OnStoreExpr callback failed
 out/test/spec/memory.wast:41: assert_invalid passed:
   out/test/spec/memory/memory.18.wasm:0000019: error: memory variable out of range: 0 (max 0)
   0000019: error: OnMemorySizeExpr callback failed

--- a/test/spec/memory64/address.txt
+++ b/test/spec/memory64/address.txt
@@ -20,9 +20,9 @@ out/test/spec/memory64/address.wast:209: assert_trap passed: out of bounds memor
 out/test/spec/memory64/address.wast:210: assert_trap passed: out of bounds memory access: access at 4294967296+2 >= max value 65536
 out/test/spec/memory64/address.wast:211: assert_trap passed: out of bounds memory access: access at 4294967296+4 >= max value 65536
 out/test/spec/memory64/address.wast:214: assert_invalid passed:
-  out/test/spec/memory64/address/address.1.wat:1:33: error: offset must be less than or equal to 0xffffffff
+  out/test/spec/memory64/address/address.1.wat:1:24: error: offset must be less than or equal to 0xffffffff
   (memory 1)(func (drop (i32.load offset=4294967296 (i32.const 0))))
-                                  ^^^^^^^^^^^^^^^^^
+                         ^^^^^^^^
 out/test/spec/memory64/address.wast:486: assert_trap passed: out of bounds memory access: access at 65529+8 >= max value 65536
 out/test/spec/memory64/address.wast:488: assert_trap passed: out of bounds memory access: access at 4294967296+1 >= max value 65536
 out/test/spec/memory64/address.wast:489: assert_trap passed: out of bounds memory access: access at 4294967296+1 >= max value 65536

--- a/test/spec/memory64/binary-leb128.txt
+++ b/test/spec/memory64/binary-leb128.txt
@@ -33,13 +33,13 @@ out/test/spec/memory64/binary-leb128.wast:375: assert_malformed passed:
 out/test/spec/memory64/binary-leb128.wast:391: assert_malformed passed:
   0000014: error: unable to read u32 leb128: function body count
 out/test/spec/memory64/binary-leb128.wast:404: assert_malformed passed:
-  0000022: error: unable to read u32 leb128: load offset
+  0000022: error: unable to read u64 leb128: load offset
 out/test/spec/memory64/binary-leb128.wast:423: assert_malformed passed:
   0000021: error: unable to read u32 leb128: load alignment
 out/test/spec/memory64/binary-leb128.wast:442: assert_malformed passed:
   0000023: error: unable to read u32 leb128: store alignment
 out/test/spec/memory64/binary-leb128.wast:461: assert_malformed passed:
-  0000024: error: unable to read u32 leb128: store offset
+  0000024: error: unable to read u64 leb128: store offset
 out/test/spec/memory64/binary-leb128.wast:482: assert_malformed passed:
   000000e: error: unable to read i32 leb128: i32.const value
 out/test/spec/memory64/binary-leb128.wast:492: assert_malformed passed:
@@ -83,9 +83,9 @@ out/test/spec/memory64/binary-leb128.wast:701: assert_malformed passed:
 out/test/spec/memory64/binary-leb128.wast:717: assert_malformed passed:
   0000014: error: unable to read u32 leb128: function body count
 out/test/spec/memory64/binary-leb128.wast:730: assert_malformed passed:
-  0000022: error: unable to read u32 leb128: load offset
+  0000022: error: unable to read u64 leb128: load offset
 out/test/spec/memory64/binary-leb128.wast:749: assert_malformed passed:
-  0000022: error: unable to read u32 leb128: load offset
+  0000022: error: unable to read u64 leb128: load offset
 out/test/spec/memory64/binary-leb128.wast:768: assert_malformed passed:
   0000021: error: unable to read u32 leb128: load alignment
 out/test/spec/memory64/binary-leb128.wast:786: assert_malformed passed:
@@ -95,9 +95,9 @@ out/test/spec/memory64/binary-leb128.wast:805: assert_malformed passed:
 out/test/spec/memory64/binary-leb128.wast:824: assert_malformed passed:
   0000023: error: unable to read u32 leb128: store alignment
 out/test/spec/memory64/binary-leb128.wast:843: assert_malformed passed:
-  0000024: error: unable to read u32 leb128: store offset
+  0000024: error: unable to read u64 leb128: store offset
 out/test/spec/memory64/binary-leb128.wast:862: assert_malformed passed:
-  0000024: error: unable to read u32 leb128: store offset
+  0000024: error: unable to read u64 leb128: store offset
 out/test/spec/memory64/binary-leb128.wast:884: assert_malformed passed:
   000000e: error: unable to read i32 leb128: i32.const value
 out/test/spec/memory64/binary-leb128.wast:894: assert_malformed passed:

--- a/test/spec/memory64/memory.txt
+++ b/test/spec/memory64/memory.txt
@@ -18,13 +18,17 @@ out/test/spec/memory64/memory.wast:22: assert_invalid passed:
   out/test/spec/memory64/memory/memory.13.wasm:000000c: error: memory variable out of range: 0 (max 0)
   000000c: error: BeginDataSegment callback failed
 out/test/spec/memory64/memory.wast:25: assert_invalid passed:
-  000001b: error: load/store memory 0 out of range 0
+  out/test/spec/memory64/memory/memory.14.wasm:000001c: error: memory variable out of range: 0 (max 0)
+  000001c: error: OnLoadExpr callback failed
 out/test/spec/memory64/memory.wast:29: assert_invalid passed:
-  0000020: error: load/store memory 0 out of range 0
+  out/test/spec/memory64/memory/memory.15.wasm:0000021: error: memory variable out of range: 0 (max 0)
+  0000021: error: OnStoreExpr callback failed
 out/test/spec/memory64/memory.wast:33: assert_invalid passed:
-  000001b: error: load/store memory 0 out of range 0
+  out/test/spec/memory64/memory/memory.16.wasm:000001c: error: memory variable out of range: 0 (max 0)
+  000001c: error: OnLoadExpr callback failed
 out/test/spec/memory64/memory.wast:37: assert_invalid passed:
-  000001d: error: load/store memory 0 out of range 0
+  out/test/spec/memory64/memory/memory.17.wasm:000001e: error: memory variable out of range: 0 (max 0)
+  000001e: error: OnStoreExpr callback failed
 out/test/spec/memory64/memory.wast:41: assert_invalid passed:
   out/test/spec/memory64/memory/memory.18.wasm:0000019: error: memory variable out of range: 0 (max 0)
   0000019: error: OnMemorySizeExpr callback failed

--- a/test/spec/memory64/memory64.txt
+++ b/test/spec/memory64/memory64.txt
@@ -18,13 +18,21 @@ out/test/spec/memory64/memory64.wast:20: assert_invalid passed:
   out/test/spec/memory64/memory64/memory64.11.wasm:000000c: error: memory variable out of range: 0 (max 0)
   000000c: error: BeginDataSegment callback failed
 out/test/spec/memory64/memory64.wast:23: assert_invalid passed:
-  000001b: error: load/store memory 0 out of range 0
+  out/test/spec/memory64/memory64/memory64.12.wasm:000001c: error: memory variable out of range: 0 (max 0)
+  out/test/spec/memory64/memory64/memory64.12.wasm:000001c: error: type mismatch in f32.load, expected [i32] but got [i64]
+  000001c: error: OnLoadExpr callback failed
 out/test/spec/memory64/memory64.wast:27: assert_invalid passed:
-  0000020: error: load/store memory 0 out of range 0
+  out/test/spec/memory64/memory64/memory64.13.wasm:0000021: error: memory variable out of range: 0 (max 0)
+  out/test/spec/memory64/memory64/memory64.13.wasm:0000021: error: type mismatch in f32.store, expected [i32, f32] but got [i64, f32]
+  0000021: error: OnStoreExpr callback failed
 out/test/spec/memory64/memory64.wast:31: assert_invalid passed:
-  000001b: error: load/store memory 0 out of range 0
+  out/test/spec/memory64/memory64/memory64.14.wasm:000001c: error: memory variable out of range: 0 (max 0)
+  out/test/spec/memory64/memory64/memory64.14.wasm:000001c: error: type mismatch in i32.load8_s, expected [i32] but got [i64]
+  000001c: error: OnLoadExpr callback failed
 out/test/spec/memory64/memory64.wast:35: assert_invalid passed:
-  000001d: error: load/store memory 0 out of range 0
+  out/test/spec/memory64/memory64/memory64.15.wasm:000001e: error: memory variable out of range: 0 (max 0)
+  out/test/spec/memory64/memory64/memory64.15.wasm:000001e: error: type mismatch in i32.store8, expected [i32, i32] but got [i64, i32]
+  000001e: error: OnStoreExpr callback failed
 out/test/spec/memory64/memory64.wast:39: assert_invalid passed:
   out/test/spec/memory64/memory64/memory64.16.wasm:0000019: error: memory variable out of range: 0 (max 0)
   0000019: error: OnMemorySizeExpr callback failed

--- a/test/spec/multi-memory/memory.txt
+++ b/test/spec/multi-memory/memory.txt
@@ -12,17 +12,23 @@ out/test/spec/multi-memory/memory.wast:19: assert_invalid passed:
   out/test/spec/multi-memory/memory/memory.11.wasm:000000c: error: memory variable out of range: 0 (max 0)
   000000c: error: BeginDataSegment callback failed
 out/test/spec/multi-memory/memory.wast:22: assert_invalid passed:
-  000001b: error: load/store memory 0 out of range 0
+  out/test/spec/multi-memory/memory/memory.12.wasm:000001c: error: memory variable out of range: 0 (max 0)
+  000001c: error: OnLoadExpr callback failed
 out/test/spec/multi-memory/memory.wast:26: assert_invalid passed:
-  0000020: error: load/store memory 0 out of range 0
+  out/test/spec/multi-memory/memory/memory.13.wasm:0000021: error: memory variable out of range: 0 (max 0)
+  0000021: error: OnStoreExpr callback failed
 out/test/spec/multi-memory/memory.wast:30: assert_invalid passed:
-  000001b: error: load/store memory 0 out of range 0
+  out/test/spec/multi-memory/memory/memory.14.wasm:000001c: error: memory variable out of range: 0 (max 0)
+  000001c: error: OnLoadExpr callback failed
 out/test/spec/multi-memory/memory.wast:34: assert_invalid passed:
-  000001d: error: load/store memory 0 out of range 0
+  out/test/spec/multi-memory/memory/memory.15.wasm:000001e: error: memory variable out of range: 0 (max 0)
+  000001e: error: OnStoreExpr callback failed
 out/test/spec/multi-memory/memory.wast:38: assert_invalid passed:
-  0000019: error: memory index 0 out of range
+  out/test/spec/multi-memory/memory/memory.16.wasm:0000019: error: memory variable out of range: 0 (max 0)
+  0000019: error: OnMemorySizeExpr callback failed
 out/test/spec/multi-memory/memory.wast:42: assert_invalid passed:
-  000001b: error: memory index 0 out of range
+  out/test/spec/multi-memory/memory/memory.17.wasm:000001b: error: memory variable out of range: 0 (max 0)
+  000001b: error: OnMemoryGrowExpr callback failed
 out/test/spec/multi-memory/memory.wast:48: assert_invalid passed:
   out/test/spec/multi-memory/memory/memory.18.wasm:000000e: error: max pages (0) must be >= initial pages (1)
   000000e: error: OnMemory callback failed


### PR DESCRIPTION
Before memory64, the "offset" in a load/store expression was a u32, and we enforced this in the WastParser and BinaryReader. After memory64, the "offset" becomes a u64 syntactically, and the validator checks that it's <= UINT32_MAX for i32 memories.

We hadn't been correctly allowing these very large offsets in the text format (even when memory64 was enabled and the memory was i64).

(This change also eliminates the "memories" member in the BinaryReader. The BinaryReader no longer needs to keep track of the memories and their types to check well-formedness.)

~~This PR is logically dependent on #2252 (I don't think the tests will pass until #2252 is merged).~~

All of this is a long prelude to eventually fixing #2192 with a good regression test!