### PR TITLE
BinaryReader/Writer: roundtrip large memory64 offsets

### DIFF
--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -598,7 +598,7 @@ Result BinaryReader::ReadMemory(Limits* out_page_limits) {
            "memory may not be shared: threads not allowed");
   ERROR_IF(is_64 && !options_.features.memory64_enabled(),
            "memory64 not allowed");
-  if (is_64) {
+  if (options_.features.memory64_enabled()) {
     CHECK_RESULT(ReadU64Leb128(&initial, "memory initial page count"));
     if (has_max) {
       CHECK_RESULT(ReadU64Leb128(&max, "memory max page count"));

--- a/src/binary-writer.cc
+++ b/src/binary-writer.cc
@@ -694,7 +694,7 @@ void BinaryWriter::WriteLoadStoreExpr(const Func* func,
   } else {
     stream_->WriteU8(log2_u32(align), "alignment");
   }
-  WriteU32Leb128(stream_, typed_expr->offset, desc);
+  WriteU64Leb128(stream_, typed_expr->offset, desc);
 }
 
 template <typename T>

--- a/test/regress/huge-offset.txt
+++ b/test/regress/huge-offset.txt
@@ -1,0 +1,13 @@
+;;; TOOL: run-roundtrip
+;;; ARGS: --enable-memory64 --fold-exprs --stdout
+(memory i64 0)
+(func (drop (i32.load offset=18446744073709551615 (i64.const 0))))
+(;; STDOUT ;;;
+(module
+  (type (;0;) (func))
+  (func (;0;) (type 0)
+    (drop
+      (i32.load offset=18446744073709551615
+        (i64.const 0))))
+  (memory (;0;) i64 0))
+;;; STDOUT ;;)

--- a/test/spec/memory64/binary-leb128.txt
+++ b/test/spec/memory64/binary-leb128.txt
@@ -3,9 +3,9 @@
 ;;; ARGS*: --enable-memory64
 (;; STDOUT ;;;
 out/test/spec/memory64/binary-leb128.wast:217: assert_malformed passed:
-  000000c: error: unable to read u32 leb128: memory initial page count
+  000000c: error: unable to read u64 leb128: memory initial page count
 out/test/spec/memory64/binary-leb128.wast:225: assert_malformed passed:
-  000000e: error: unable to read u32 leb128: memory max page count
+  000000e: error: unable to read u64 leb128: memory max page count
 out/test/spec/memory64/binary-leb128.wast:234: assert_malformed passed:
   0000010: error: unable to read u32 leb128: data segment flags
 out/test/spec/memory64/binary-leb128.wast:245: assert_malformed passed:
@@ -49,13 +49,13 @@ out/test/spec/memory64/binary-leb128.wast:503: assert_malformed passed:
 out/test/spec/memory64/binary-leb128.wast:513: assert_malformed passed:
   000000e: error: unable to read i64 leb128: i64.const value
 out/test/spec/memory64/binary-leb128.wast:525: assert_malformed passed:
-  000000c: error: unable to read u32 leb128: memory initial page count
+  000000c: error: unable to read u64 leb128: memory initial page count
 out/test/spec/memory64/binary-leb128.wast:533: assert_malformed passed:
-  000000c: error: unable to read u32 leb128: memory initial page count
+  000000c: error: unable to read u64 leb128: memory initial page count
 out/test/spec/memory64/binary-leb128.wast:541: assert_malformed passed:
-  000000e: error: unable to read u32 leb128: memory max page count
+  000000e: error: unable to read u64 leb128: memory max page count
 out/test/spec/memory64/binary-leb128.wast:550: assert_malformed passed:
-  000000e: error: unable to read u32 leb128: memory max page count
+  000000e: error: unable to read u64 leb128: memory max page count
 out/test/spec/memory64/binary-leb128.wast:559: assert_malformed passed:
   0000010: error: unable to read u32 leb128: data segment flags
 out/test/spec/memory64/binary-leb128.wast:570: assert_malformed passed:


### PR DESCRIPTION
Previously we weren't able to write a LoadStoreExpr with an offset > 2^32.

~~This depends on #2253 (the tests won't pass until it's merged).~~