### PR TITLE
Use tag or sha for tarball name

### DIFF
--- a/.github/actions/release-archive/action.yml
+++ b/.github/actions/release-archive/action.yml
@@ -14,7 +14,7 @@ runs:
       shell: bash
       run: |
         OSNAME=$(echo ${{ inputs.os }} | sed 's/-latest//')
-        VERSION=${{ github.ref_name }}
+        VERSION=${{ github.event.release.tag_name || github.sha }}
         PKGNAME="wabt-$VERSION-$OSNAME"
         TARBALL=$PKGNAME.tar.gz
         SHASUM=$PKGNAME.tar.gz.sha256


### PR DESCRIPTION
I realized branch name can have arbitrary characters problematic for filenames, especially `/`.

Fixes https://github.com/WebAssembly/wabt/pull/2254#issuecomment-1586600199