### PR TITLE
wasm-objdump: Fix local numbering in disassembly

### DIFF
--- a/include/wabt/binary-reader-objdump.h
+++ b/include/wabt/binary-reader-objdump.h
@@ -86,6 +86,7 @@ struct ObjdumpState {
   ObjdumpLocalNames local_names;
   std::vector<ObjdumpSymbol> symtab;
   std::map<Index, Index> function_param_counts;
+  std::map<Index, Index> function_types;
 };
 
 Result ReadBinaryObjdump(const uint8_t* data,

--- a/src/binary-reader-objdump.cc
+++ b/src/binary-reader-objdump.cc
@@ -953,7 +953,8 @@ Result BinaryReaderObjdumpDisassemble::BeginFunctionBody(Index index,
   last_opcode_end = 0;
   in_function_body = true;
   current_function_index = index;
-  local_index_ = objdump_state_->function_param_counts[index];
+  auto type_index = objdump_state_->function_types[index];
+  local_index_ = objdump_state_->function_param_counts[type_index];
   return Result::Ok;
 }
 
@@ -1452,6 +1453,7 @@ Result BinaryReaderObjdump::OnFunction(Index index, Index sig_index) {
     PrintDetails(" <" PRIstringview ">", WABT_PRINTF_STRING_VIEW_ARG(name));
   }
   PrintDetails("\n");
+  objdump_state_->function_types[index] = sig_index;
   return Result::Ok;
 }
 

--- a/test/dump/debug-names.txt
+++ b/test/dump/debug-names.txt
@@ -154,7 +154,7 @@ Code Disassembly:
 000024 func[1]:
  000025: 0b                         | end
 000027 func[2] <F2>:
- 000028: 01 7c                      | local[0] type=f64
- 00002a: 02 7e                      | local[1..2] type=i64
+ 000028: 01 7c                      | local[1] type=f64
+ 00002a: 02 7e                      | local[2..3] type=i64
  00002c: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/local-indices.txt
+++ b/test/dump/local-indices.txt
@@ -1,0 +1,19 @@
+;;; TOOL: run-objdump
+(module
+  (func (param i32)
+    (local i32))
+  (func (param i32)
+    (local i32)))
+(;; STDOUT ;;;
+
+local-indices.wasm:	file format wasm 0x1
+
+Code Disassembly:
+
+000018 func[0]:
+ 000019: 01 7f                      | local[1] type=i32
+ 00001b: 0b                         | end
+00001d func[1]:
+ 00001e: 01 7f                      | local[1] type=i32
+ 000020: 0b                         | end
+;;; STDOUT ;;)


### PR DESCRIPTION
Previously, in BinaryReaderObjdumpDisassemble::BeginFunctionBody, we had:

    local_index_ = objdump_state_->function_param_counts[index];

where index is the index of the function i.e. we treat the keys of function_param_counts as function indices.

However, function_param_counts is populated in OnFuncType with:

    objdump_state_->function_param_counts[index] = param_count;

where index is the index of the type i.e. we treat the keys of function_param_counts as type indices.

This discrepancy would cause the locals to be incorrectly numbered in the "Code Disassembly" section.

This fixes the discrepancy by adding a new field, function_types, which maps from function indices to type indices, and is populated in BinaryReaderObjdump::OnFunction. This field is used in BinaryReaderObjdumpDisassemble::BeginFunctionBody to get the type index for the given function, which is then used to get the parameter count.

Fixes #2264.