### PR TITLE
wasm2c: Use inline asm to force reads only on explicitly listed archs

### DIFF
--- a/src/prebuilt/wasm2c_atomicops_source_declarations.cc
+++ b/src/prebuilt/wasm2c_atomicops_source_declarations.cc
@@ -239,7 +239,7 @@ R"w2c_template(    wasm_rt_memcpy(&result, &mem->data[addr], sizeof(t1)); \
 )w2c_template"
 R"w2c_template(    result = atomic_load_##t1(&mem->data[addr]);           \
 )w2c_template"
-R"w2c_template(    wasm_asm("" ::"r"(result));                            \
+R"w2c_template(    FORCE_READ(result);                                    \
 )w2c_template"
 R"w2c_template(    return (t3)(t2)result;                                 \
 )w2c_template"

--- a/src/prebuilt/wasm2c_simd_source_declarations.cc
+++ b/src/prebuilt/wasm2c_simd_source_declarations.cc
@@ -1,6 +1,6 @@
-const char* s_simd_source_declarations = R"w2c_template(#ifdef __x86_64__
+const char* s_simd_source_declarations = R"w2c_template(#if defined(__GNUC__) && defined(__x86_64__)
 )w2c_template"
-R"w2c_template(#define SIMD_FORCE_READ(var) wasm_asm("" ::"x"(var));
+R"w2c_template(#define SIMD_FORCE_READ(var) __asm__("" ::"x"(var));
 )w2c_template"
 R"w2c_template(#else
 )w2c_template"

--- a/src/prebuilt/wasm2c_source_declarations.cc
+++ b/src/prebuilt/wasm2c_source_declarations.cc
@@ -86,15 +86,17 @@ R"w2c_template(#define MEMCHECK(mem, a, t) RANGE_CHECK(mem, a, sizeof(t))
 R"w2c_template(#endif
 )w2c_template"
 R"w2c_template(
-#ifdef __GNUC__
+#if defined(__GNUC__) && (defined(__x86_64__) || defined(__aarch64__))
 )w2c_template"
-R"w2c_template(#define wasm_asm __asm__
+R"w2c_template(#define FORCE_READ(var) __asm__("" ::"r"(var));
 )w2c_template"
 R"w2c_template(#else
 )w2c_template"
-R"w2c_template(#define wasm_asm(X)
+R"w2c_template(#define FORCE_READ(var)
 )w2c_template"
 R"w2c_template(#endif
+)w2c_template"
+R"w2c_template(// TODO: handle MIPS and other architectures
 )w2c_template"
 R"w2c_template(
 #if WABT_BIG_ENDIAN
@@ -147,7 +149,7 @@ R"w2c_template(    wasm_rt_memcpy(&result, &mem->data[mem->size - addr - sizeof(
 )w2c_template"
 R"w2c_template(                   sizeof(t1));                                        \
 )w2c_template"
-R"w2c_template(    wasm_asm("" ::"r"(result));                                        \
+R"w2c_template(    FORCE_READ(result);                                                \
 )w2c_template"
 R"w2c_template(    return (t3)(t2)result;                                             \
 )w2c_template"
@@ -202,7 +204,7 @@ R"w2c_template(    t1 result;                                             \
 )w2c_template"
 R"w2c_template(    wasm_rt_memcpy(&result, &mem->data[addr], sizeof(t1)); \
 )w2c_template"
-R"w2c_template(    wasm_asm("" ::"r"(result));                            \
+R"w2c_template(    FORCE_READ(result);                                    \
 )w2c_template"
 R"w2c_template(    return (t3)(t2)result;                                 \
 )w2c_template"

--- a/src/template/wasm2c.declarations.c
+++ b/src/template/wasm2c.declarations.c
@@ -47,11 +47,12 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
 #define MEMCHECK(mem, a, t) RANGE_CHECK(mem, a, sizeof(t))
 #endif
 
-#ifdef __GNUC__
-#define wasm_asm __asm__
+#if defined(__GNUC__) && (defined(__x86_64__) || defined(__aarch64__))
+#define FORCE_READ(var) __asm__("" ::"r"(var));
 #else
-#define wasm_asm(X)
+#define FORCE_READ(var)
 #endif
+// TODO: handle MIPS and other architectures
 
 #if WABT_BIG_ENDIAN
 static inline void load_data(void* dest, const void* src, size_t n) {
@@ -78,7 +79,7 @@ static inline void load_data(void* dest, const void* src, size_t n) {
     t1 result;                                                         \
     wasm_rt_memcpy(&result, &mem->data[mem->size - addr - sizeof(t1)], \
                    sizeof(t1));                                        \
-    wasm_asm("" ::"r"(result));                                        \
+    FORCE_READ(result);                                                \
     return (t3)(t2)result;                                             \
   }
 
@@ -106,7 +107,7 @@ static inline void load_data(void* dest, const void* src, size_t n) {
     MEMCHECK(mem, addr, t1);                               \
     t1 result;                                             \
     wasm_rt_memcpy(&result, &mem->data[addr], sizeof(t1)); \
-    wasm_asm("" ::"r"(result));                            \
+    FORCE_READ(result);                                    \
     return (t3)(t2)result;                                 \
   }
 

--- a/src/template/wasm2c_atomicops.declarations.c
+++ b/src/template/wasm2c_atomicops.declarations.c
@@ -132,7 +132,7 @@
     t1 result;                                             \
     wasm_rt_memcpy(&result, &mem->data[addr], sizeof(t1)); \
     result = atomic_load_##t1(&mem->data[addr]);           \
-    wasm_asm("" ::"r"(result));                            \
+    FORCE_READ(result);                                    \
     return (t3)(t2)result;                                 \
   }
 

--- a/src/template/wasm2c_simd.declarations.c
+++ b/src/template/wasm2c_simd.declarations.c
@@ -1,5 +1,5 @@
-#ifdef __x86_64__
-#define SIMD_FORCE_READ(var) wasm_asm("" ::"x"(var));
+#if defined(__GNUC__) && defined(__x86_64__)
+#define SIMD_FORCE_READ(var) __asm__("" ::"x"(var));
 #else
 #define SIMD_FORCE_READ(var)
 #endif

--- a/test/wasm2c/add.txt
+++ b/test/wasm2c/add.txt
@@ -114,11 +114,12 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
 #define MEMCHECK(mem, a, t) RANGE_CHECK(mem, a, sizeof(t))
 #endif
 
-#ifdef __GNUC__
-#define wasm_asm __asm__
+#if defined(__GNUC__) && (defined(__x86_64__) || defined(__aarch64__))
+#define FORCE_READ(var) __asm__("" ::"r"(var));
 #else
-#define wasm_asm(X)
+#define FORCE_READ(var)
 #endif
+// TODO: handle MIPS and other architectures
 
 #if WABT_BIG_ENDIAN
 static inline void load_data(void* dest, const void* src, size_t n) {
@@ -145,7 +146,7 @@ static inline void load_data(void* dest, const void* src, size_t n) {
     t1 result;                                                         \
     wasm_rt_memcpy(&result, &mem->data[mem->size - addr - sizeof(t1)], \
                    sizeof(t1));                                        \
-    wasm_asm("" ::"r"(result));                                        \
+    FORCE_READ(result);                                                \
     return (t3)(t2)result;                                             \
   }
 
@@ -173,7 +174,7 @@ static inline void load_data(void* dest, const void* src, size_t n) {
     MEMCHECK(mem, addr, t1);                               \
     t1 result;                                             \
     wasm_rt_memcpy(&result, &mem->data[addr], sizeof(t1)); \
-    wasm_asm("" ::"r"(result));                            \
+    FORCE_READ(result);                                    \
     return (t3)(t2)result;                                 \
   }
 

--- a/test/wasm2c/check-imports.txt
+++ b/test/wasm2c/check-imports.txt
@@ -137,11 +137,12 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
 #define MEMCHECK(mem, a, t) RANGE_CHECK(mem, a, sizeof(t))
 #endif
 
-#ifdef __GNUC__
-#define wasm_asm __asm__
+#if defined(__GNUC__) && (defined(__x86_64__) || defined(__aarch64__))
+#define FORCE_READ(var) __asm__("" ::"r"(var));
 #else
-#define wasm_asm(X)
+#define FORCE_READ(var)
 #endif
+// TODO: handle MIPS and other architectures
 
 #if WABT_BIG_ENDIAN
 static inline void load_data(void* dest, const void* src, size_t n) {
@@ -168,7 +169,7 @@ static inline void load_data(void* dest, const void* src, size_t n) {
     t1 result;                                                         \
     wasm_rt_memcpy(&result, &mem->data[mem->size - addr - sizeof(t1)], \
                    sizeof(t1));                                        \
-    wasm_asm("" ::"r"(result));                                        \
+    FORCE_READ(result);                                                \
     return (t3)(t2)result;                                             \
   }
 
@@ -196,7 +197,7 @@ static inline void load_data(void* dest, const void* src, size_t n) {
     MEMCHECK(mem, addr, t1);                               \
     t1 result;                                             \
     wasm_rt_memcpy(&result, &mem->data[addr], sizeof(t1)); \
-    wasm_asm("" ::"r"(result));                            \
+    FORCE_READ(result);                                    \
     return (t3)(t2)result;                                 \
   }
 

--- a/test/wasm2c/export-names.txt
+++ b/test/wasm2c/export-names.txt
@@ -137,11 +137,12 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
 #define MEMCHECK(mem, a, t) RANGE_CHECK(mem, a, sizeof(t))
 #endif
 
-#ifdef __GNUC__
-#define wasm_asm __asm__
+#if defined(__GNUC__) && (defined(__x86_64__) || defined(__aarch64__))
+#define FORCE_READ(var) __asm__("" ::"r"(var));
 #else
-#define wasm_asm(X)
+#define FORCE_READ(var)
 #endif
+// TODO: handle MIPS and other architectures
 
 #if WABT_BIG_ENDIAN
 static inline void load_data(void* dest, const void* src, size_t n) {
@@ -168,7 +169,7 @@ static inline void load_data(void* dest, const void* src, size_t n) {
     t1 result;                                                         \
     wasm_rt_memcpy(&result, &mem->data[mem->size - addr - sizeof(t1)], \
                    sizeof(t1));                                        \
-    wasm_asm("" ::"r"(result));                                        \
+    FORCE_READ(result);                                                \
     return (t3)(t2)result;                                             \
   }
 
@@ -196,7 +197,7 @@ static inline void load_data(void* dest, const void* src, size_t n) {
     MEMCHECK(mem, addr, t1);                               \
     t1 result;                                             \
     wasm_rt_memcpy(&result, &mem->data[addr], sizeof(t1)); \
-    wasm_asm("" ::"r"(result));                            \
+    FORCE_READ(result);                                    \
     return (t3)(t2)result;                                 \
   }
 

--- a/test/wasm2c/hello.txt
+++ b/test/wasm2c/hello.txt
@@ -145,11 +145,12 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
 #define MEMCHECK(mem, a, t) RANGE_CHECK(mem, a, sizeof(t))
 #endif
 
-#ifdef __GNUC__
-#define wasm_asm __asm__
+#if defined(__GNUC__) && (defined(__x86_64__) || defined(__aarch64__))
+#define FORCE_READ(var) __asm__("" ::"r"(var));
 #else
-#define wasm_asm(X)
+#define FORCE_READ(var)
 #endif
+// TODO: handle MIPS and other architectures
 
 #if WABT_BIG_ENDIAN
 static inline void load_data(void* dest, const void* src, size_t n) {
@@ -176,7 +177,7 @@ static inline void load_data(void* dest, const void* src, size_t n) {
     t1 result;                                                         \
     wasm_rt_memcpy(&result, &mem->data[mem->size - addr - sizeof(t1)], \
                    sizeof(t1));                                        \
-    wasm_asm("" ::"r"(result));                                        \
+    FORCE_READ(result);                                                \
     return (t3)(t2)result;                                             \
   }
 
@@ -204,7 +205,7 @@ static inline void load_data(void* dest, const void* src, size_t n) {
     MEMCHECK(mem, addr, t1);                               \
     t1 result;                                             \
     wasm_rt_memcpy(&result, &mem->data[addr], sizeof(t1)); \
-    wasm_asm("" ::"r"(result));                            \
+    FORCE_READ(result);                                    \
     return (t3)(t2)result;                                 \
   }
 

--- a/test/wasm2c/minimal.txt
+++ b/test/wasm2c/minimal.txt
@@ -108,11 +108,12 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
 #define MEMCHECK(mem, a, t) RANGE_CHECK(mem, a, sizeof(t))
 #endif
 
-#ifdef __GNUC__
-#define wasm_asm __asm__
+#if defined(__GNUC__) && (defined(__x86_64__) || defined(__aarch64__))
+#define FORCE_READ(var) __asm__("" ::"r"(var));
 #else
-#define wasm_asm(X)
+#define FORCE_READ(var)
 #endif
+// TODO: handle MIPS and other architectures
 
 #if WABT_BIG_ENDIAN
 static inline void load_data(void* dest, const void* src, size_t n) {
@@ -139,7 +140,7 @@ static inline void load_data(void* dest, const void* src, size_t n) {
     t1 result;                                                         \
     wasm_rt_memcpy(&result, &mem->data[mem->size - addr - sizeof(t1)], \
                    sizeof(t1));                                        \
-    wasm_asm("" ::"r"(result));                                        \
+    FORCE_READ(result);                                                \
     return (t3)(t2)result;                                             \
   }
 
@@ -167,7 +168,7 @@ static inline void load_data(void* dest, const void* src, size_t n) {
     MEMCHECK(mem, addr, t1);                               \
     t1 result;                                             \
     wasm_rt_memcpy(&result, &mem->data[addr], sizeof(t1)); \
-    wasm_asm("" ::"r"(result));                            \
+    FORCE_READ(result);                                    \
     return (t3)(t2)result;                                 \
   }
 

--- a/wasm2c/examples/fac/fac.c
+++ b/wasm2c/examples/fac/fac.c
@@ -66,11 +66,12 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
 #define MEMCHECK(mem, a, t) RANGE_CHECK(mem, a, sizeof(t))
 #endif
 
-#ifdef __GNUC__
-#define wasm_asm __asm__
+#if defined(__GNUC__) && (defined(__x86_64__) || defined(__aarch64__))
+#define FORCE_READ(var) __asm__("" ::"r"(var));
 #else
-#define wasm_asm(X)
+#define FORCE_READ(var)
 #endif
+// TODO: handle MIPS and other architectures
 
 #if WABT_BIG_ENDIAN
 static inline void load_data(void* dest, const void* src, size_t n) {
@@ -97,7 +98,7 @@ static inline void load_data(void* dest, const void* src, size_t n) {
     t1 result;                                                         \
     wasm_rt_memcpy(&result, &mem->data[mem->size - addr - sizeof(t1)], \
                    sizeof(t1));                                        \
-    wasm_asm("" ::"r"(result));                                        \
+    FORCE_READ(result);                                                \
     return (t3)(t2)result;                                             \
   }
 
@@ -125,7 +126,7 @@ static inline void load_data(void* dest, const void* src, size_t n) {
     MEMCHECK(mem, addr, t1);                               \
     t1 result;                                             \
     wasm_rt_memcpy(&result, &mem->data[addr], sizeof(t1)); \
-    wasm_asm("" ::"r"(result));                            \
+    FORCE_READ(result);                                    \
     return (t3)(t2)result;                                 \
   }
 


### PR DESCRIPTION
Fixes #2266