### PR TITLE
c-writer.cc: cleanup handling of functions & tags (NFC)

### DIFF
--- a/test/wasm2c/check-imports.txt
+++ b/test/wasm2c/check-imports.txt
@@ -703,7 +703,7 @@ static void init_memories(w2c_test* instance) {
 }
 
 static const wasm_elem_segment_expr_t elem_segment_exprs_w2c_test_e0[] = {
-  {w2c_test_t1, (wasm_rt_function_ptr_t)&w2c_test_f1, 0},
+  {w2c_test_t1, (wasm_rt_function_ptr_t)w2c_test_f1, 0},
 };
 
 static void init_tables(w2c_test* instance) {
@@ -713,7 +713,7 @@ static void init_tables(w2c_test* instance) {
 static void init_elem_instances(w2c_test *instance) {
 }
 
-static void init_instance_import(w2c_test* instance, struct w2c_env* w2c_env_instance){
+static void init_instance_import(w2c_test* instance, struct w2c_env* w2c_env_instance) {
   instance->w2c_env_0x5F_indirect_function_table = w2c_env_0x5F_indirect_function_table(w2c_env_instance);
   instance->w2c_env_0x5F_linear_memory = w2c_env_0x5F_linear_memory(w2c_env_instance);
 }

--- a/test/wasm2c/export-names.txt
+++ b/test/wasm2c/export-names.txt
@@ -700,30 +700,30 @@ static void init_memories(w2c_test* instance) {
 
 /* export: '' */
 void w2c_test_(w2c_test* instance) {
-  return w2c_test__0(instance);
+  w2c_test__0(instance);
 }
 
 /* export: '*\2F' */
 void w2c_test_0x2A0x2F(w2c_test* instance) {
-  return w2c_test__0(instance);
+  w2c_test__0(instance);
 }
 
 /* export: '\3F\3F\2F' */
 void w2c_test_0x3F0x3F0x2F(w2c_test* instance) {
-  return w2c_test__0(instance);
+  w2c_test__0(instance);
 }
 
 /* export: '\0A' */
 void w2c_test_0x0A(w2c_test* instance) {
-  return w2c_test__0(instance);
+  w2c_test__0(instance);
 }
 
 /* export: '\E2\9D\A4\EF\B8\8F' */
 void w2c_test_0xE20x9D0xA40xEF0xB80x8F(w2c_test* instance) {
-  return w2c_test__0(instance);
+  w2c_test__0(instance);
 }
 
-static void init_instance_import(w2c_test* instance, struct w2c_0x5Cmodule* w2c_0x5Cmodule_instance){
+static void init_instance_import(w2c_test* instance, struct w2c_0x5Cmodule* w2c_0x5Cmodule_instance) {
   instance->w2c_0x5Cmodule_import0x200x2A0x2F = w2c_0x5Cmodule_import0x200x2A0x2F(w2c_0x5Cmodule_instance);
 }
 

--- a/test/wasm2c/hello.txt
+++ b/test/wasm2c/hello.txt
@@ -737,10 +737,10 @@ wasm_rt_memory_t* w2c_test_memory(w2c_test* instance) {
 
 /* export: '_start' */
 void w2c_test_0x5Fstart(w2c_test* instance) {
-  return w2c_test_0x5Fstart_0(instance);
+  w2c_test_0x5Fstart_0(instance);
 }
 
-static void init_instance_import(w2c_test* instance, struct w2c_wasi__snapshot__preview1* w2c_wasi__snapshot__preview1_instance){
+static void init_instance_import(w2c_test* instance, struct w2c_wasi__snapshot__preview1* w2c_wasi__snapshot__preview1_instance) {
   instance->w2c_wasi__snapshot__preview1_instance = w2c_wasi__snapshot__preview1_instance;
 }
 
@@ -806,7 +806,7 @@ void w2c_test_0x5Fstart_0(w2c_test* instance) {
   var_i3 = 0u;
   var_i4 = 0u;
   var_i0 = CALL_INDIRECT(instance->w2c_T0, u32 (*)(void*, u32, u32, u32, u32), w2c_test_t0, var_i4, instance->w2c_T0.data[var_i4].module_instance, var_i0, var_i1, var_i2, var_i3);
-  (*w2c_wasi__snapshot__preview1_proc_exit)(instance->w2c_wasi__snapshot__preview1_instance, var_i0);
+  w2c_wasi__snapshot__preview1_proc_exit(instance->w2c_wasi__snapshot__preview1_instance, var_i0);
   FUNC_EPILOGUE;
 }
 ;;; STDOUT ;;)


### PR DESCRIPTION
This PR has a bunch of miscellaneous cleanups in c-writer.cc, in preparation for the tail-call PR.

- ~~eliminate redundant import_syms_ SymbolSet~~ (split out to #2275)
- eliminate ResultType struct
- replace ExternalPtr (only used for tags) with TagPtr
- refer to functions with bare name (no need for * or &)
- don't use "return" for functions returning void (fixes warning on MSVC)
- add missing "static" on ExportName
- fix spacing around init_instance_import