### PR TITLE
Fix CI from upgraded cmake version on GitHub Ubuntu runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
     - name: mkdir
       run: mkdir -p out
     - name: cmake
-      run: cmake .. -G Ninja -DWITH_WASI=ON -DWERROR=ON -Werror=dev
+      run: cmake .. -G Ninja -DWITH_WASI=ON -DWERROR=ON -Werror=dev -Wno-deprecated
       working-directory: out
       if: matrix.os != 'windows-latest'
     - name: cmake (windows)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -659,7 +659,7 @@ if (BUILD_TESTS)
   find_package(Threads REQUIRED)
 
   # Python 3.5 is the version shipped in Ubuntu Xenial
-  find_package(PythonInterp 3.5 REQUIRED)
+  find_package(Python3 3.5 REQUIRED COMPONENTS Interpreter)
 
   if (NOT USE_SYSTEM_GTEST)
     if (NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/third_party/gtest/googletest)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -718,7 +718,7 @@ if (BUILD_TESTS)
   set(RUN_TESTS_PY ${WABT_SOURCE_DIR}/test/run-tests.py)
 
   add_custom_target(run-tests
-    COMMAND ${CMAKE_COMMAND} -E env WASM2C_CC=${CMAKE_C_COMPILER} WASM2C_CFLAGS=${WASM2C_CFLAGS} ${PYTHON_EXECUTABLE} ${RUN_TESTS_PY} --bindir $<TARGET_FILE_DIR:wat2wasm>
+    COMMAND ${CMAKE_COMMAND} -E env WASM2C_CC=${CMAKE_C_COMPILER} WASM2C_CFLAGS=${WASM2C_CFLAGS} ${Python3_EXECUTABLE} ${RUN_TESTS_PY} --bindir $<TARGET_FILE_DIR:wat2wasm>
     DEPENDS ${WABT_EXECUTABLES}
     WORKING_DIRECTORY ${WABT_SOURCE_DIR}
     USES_TERMINAL
@@ -732,7 +732,7 @@ if (BUILD_TESTS)
   )
 
   add_custom_target(run-c-api-tests
-    COMMAND ${PYTHON_EXECUTABLE} ${WABT_SOURCE_DIR}/test/run-c-api-examples.py --bindir $<TARGET_FILE_DIR:wat2wasm>
+    COMMAND ${Python3_EXECUTABLE} ${WABT_SOURCE_DIR}/test/run-c-api-examples.py --bindir $<TARGET_FILE_DIR:wat2wasm>
     WORKING_DIRECTORY ${WABT_SOURCE_DIR}
     USES_TERMINAL
   )


### PR DESCRIPTION
GitHub recently upgraded the cmake version on its Ubuntu runners, which broke our CI build with some new warnings (errors for us).

One of them is fixable (related to a deprecated Python package), but one of them is in libuv (which is a dependency of the uvwasi submodule) so less easy to fix. I added `-Wno-deprecated` to the cmake command line on GitHub actions to silence the warning for now.