### PR TITLE
wasm2c: ensure force read constraints compile for clang on mips

### DIFF
--- a/src/prebuilt/wasm2c_atomicops_source_declarations.cc
+++ b/src/prebuilt/wasm2c_atomicops_source_declarations.cc
@@ -225,7 +225,7 @@ R"w2c_template(    TRAP(UNALIGNED);                     \
 R"w2c_template(  }
 )w2c_template"
 R"w2c_template(
-#define DEFINE_ATOMIC_LOAD(name, t1, t2, t3)               \
+#define DEFINE_ATOMIC_LOAD(name, t1, t2, t3, force_read)   \
 )w2c_template"
 R"w2c_template(  static inline t3 name(wasm_rt_memory_t* mem, u64 addr) { \
 )w2c_template"
@@ -239,26 +239,26 @@ R"w2c_template(    wasm_rt_memcpy(&result, &mem->data[addr], sizeof(t1)); \
 )w2c_template"
 R"w2c_template(    result = atomic_load_##t1(&mem->data[addr]);           \
 )w2c_template"
-R"w2c_template(    wasm_asm("" ::"r"(result));                            \
+R"w2c_template(    force_read(result);                                    \
 )w2c_template"
 R"w2c_template(    return (t3)(t2)result;                                 \
 )w2c_template"
 R"w2c_template(  }
 )w2c_template"
 R"w2c_template(
-DEFINE_ATOMIC_LOAD(i32_atomic_load, u32, u32, u32)
+DEFINE_ATOMIC_LOAD(i32_atomic_load, u32, u32, u32, FORCE_READ_INT)
 )w2c_template"
-R"w2c_template(DEFINE_ATOMIC_LOAD(i64_atomic_load, u64, u64, u64)
+R"w2c_template(DEFINE_ATOMIC_LOAD(i64_atomic_load, u64, u64, u64, FORCE_READ_INT)
 )w2c_template"
-R"w2c_template(DEFINE_ATOMIC_LOAD(i32_atomic_load8_u, u8, u32, u32)
+R"w2c_template(DEFINE_ATOMIC_LOAD(i32_atomic_load8_u, u8, u32, u32, FORCE_READ_INT)
 )w2c_template"
-R"w2c_template(DEFINE_ATOMIC_LOAD(i64_atomic_load8_u, u8, u64, u64)
+R"w2c_template(DEFINE_ATOMIC_LOAD(i64_atomic_load8_u, u8, u64, u64, FORCE_READ_INT)
 )w2c_template"
-R"w2c_template(DEFINE_ATOMIC_LOAD(i32_atomic_load16_u, u16, u32, u32)
+R"w2c_template(DEFINE_ATOMIC_LOAD(i32_atomic_load16_u, u16, u32, u32, FORCE_READ_INT)
 )w2c_template"
-R"w2c_template(DEFINE_ATOMIC_LOAD(i64_atomic_load16_u, u16, u64, u64)
+R"w2c_template(DEFINE_ATOMIC_LOAD(i64_atomic_load16_u, u16, u64, u64, FORCE_READ_INT)
 )w2c_template"
-R"w2c_template(DEFINE_ATOMIC_LOAD(i64_atomic_load32_u, u32, u64, u64)
+R"w2c_template(DEFINE_ATOMIC_LOAD(i64_atomic_load32_u, u32, u64, u64, FORCE_READ_INT)
 )w2c_template"
 R"w2c_template(
 #define DEFINE_ATOMIC_STORE(name, t1, t2)                              \

--- a/src/prebuilt/wasm2c_simd_source_declarations.cc
+++ b/src/prebuilt/wasm2c_simd_source_declarations.cc
@@ -1,6 +1,6 @@
-const char* s_simd_source_declarations = R"w2c_template(#ifdef __x86_64__
+const char* s_simd_source_declarations = R"w2c_template(#if defined(__GNUC__) && defined(__x86_64__)
 )w2c_template"
-R"w2c_template(#define SIMD_FORCE_READ(var) wasm_asm("" ::"x"(var));
+R"w2c_template(#define SIMD_FORCE_READ(var) __asm__("" ::"x"(var));
 )w2c_template"
 R"w2c_template(#else
 )w2c_template"

--- a/src/template/wasm2c.declarations.c
+++ b/src/template/wasm2c.declarations.c
@@ -48,9 +48,17 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
 #endif
 
 #ifdef __GNUC__
-#define wasm_asm __asm__
+#define FORCE_READ_INT(var) __asm__("" ::"r"(var));
+// Clang on Mips requires "f" constraints on floats
+#if defined(__clang__) && \
+    (defined(mips) || defined(__mips__) || defined(__mips))
+#define FORCE_READ_FLOAT(var) __asm__("" ::"f"(var));
 #else
-#define wasm_asm(X)
+#define FORCE_READ_FLOAT(var) __asm__("" ::"r"(var));
+#endif
+#else
+#define FORCE_READ_INT(var)
+#define FORCE_READ_FLOAT(var)
 #endif
 
 #if WABT_BIG_ENDIAN
@@ -72,13 +80,13 @@ static inline void load_data(void* dest, const void* src, size_t n) {
     RANGE_CHECK((&m), m.size - o - s, s);       \
     load_data(&(m.data[m.size - o - s]), i, s); \
   } while (0)
-#define DEFINE_LOAD(name, t1, t2, t3)                                  \
+#define DEFINE_LOAD(name, t1, t2, t3, force_read)                      \
   static inline t3 name(wasm_rt_memory_t* mem, u64 addr) {             \
     MEMCHECK(mem, addr, t1);                                           \
     t1 result;                                                         \
     wasm_rt_memcpy(&result, &mem->data[mem->size - addr - sizeof(t1)], \
                    sizeof(t1));                                        \
-    wasm_asm("" ::"r"(result));                                        \
+    force_read(result);                                                \
     return (t3)(t2)result;                                             \
   }
 
@@ -101,12 +109,12 @@ static inline void load_data(void* dest, const void* src, size_t n) {
     RANGE_CHECK((&m), o, s);       \
     load_data(&(m.data[o]), i, s); \
   } while (0)
-#define DEFINE_LOAD(name, t1, t2, t3)                      \
+#define DEFINE_LOAD(name, t1, t2, t3, force_read)          \
   static inline t3 name(wasm_rt_memory_t* mem, u64 addr) { \
     MEMCHECK(mem, addr, t1);                               \
     t1 result;                                             \
     wasm_rt_memcpy(&result, &mem->data[addr], sizeof(t1)); \
-    wasm_asm("" ::"r"(result));                            \
+    force_read(result);                                    \
     return (t3)(t2)result;                                 \
   }
 
@@ -118,20 +126,20 @@ static inline void load_data(void* dest, const void* src, size_t n) {
   }
 #endif
 
-DEFINE_LOAD(i32_load, u32, u32, u32)
-DEFINE_LOAD(i64_load, u64, u64, u64)
-DEFINE_LOAD(f32_load, f32, f32, f32)
-DEFINE_LOAD(f64_load, f64, f64, f64)
-DEFINE_LOAD(i32_load8_s, s8, s32, u32)
-DEFINE_LOAD(i64_load8_s, s8, s64, u64)
-DEFINE_LOAD(i32_load8_u, u8, u32, u32)
-DEFINE_LOAD(i64_load8_u, u8, u64, u64)
-DEFINE_LOAD(i32_load16_s, s16, s32, u32)
-DEFINE_LOAD(i64_load16_s, s16, s64, u64)
-DEFINE_LOAD(i32_load16_u, u16, u32, u32)
-DEFINE_LOAD(i64_load16_u, u16, u64, u64)
-DEFINE_LOAD(i64_load32_s, s32, s64, u64)
-DEFINE_LOAD(i64_load32_u, u32, u64, u64)
+DEFINE_LOAD(i32_load, u32, u32, u32, FORCE_READ_INT)
+DEFINE_LOAD(i64_load, u64, u64, u64, FORCE_READ_INT)
+DEFINE_LOAD(f32_load, f32, f32, f32, FORCE_READ_FLOAT)
+DEFINE_LOAD(f64_load, f64, f64, f64, FORCE_READ_FLOAT)
+DEFINE_LOAD(i32_load8_s, s8, s32, u32, FORCE_READ_INT)
+DEFINE_LOAD(i64_load8_s, s8, s64, u64, FORCE_READ_INT)
+DEFINE_LOAD(i32_load8_u, u8, u32, u32, FORCE_READ_INT)
+DEFINE_LOAD(i64_load8_u, u8, u64, u64, FORCE_READ_INT)
+DEFINE_LOAD(i32_load16_s, s16, s32, u32, FORCE_READ_INT)
+DEFINE_LOAD(i64_load16_s, s16, s64, u64, FORCE_READ_INT)
+DEFINE_LOAD(i32_load16_u, u16, u32, u32, FORCE_READ_INT)
+DEFINE_LOAD(i64_load16_u, u16, u64, u64, FORCE_READ_INT)
+DEFINE_LOAD(i64_load32_s, s32, s64, u64, FORCE_READ_INT)
+DEFINE_LOAD(i64_load32_u, u32, u64, u64, FORCE_READ_INT)
 DEFINE_STORE(i32_store, u32, u32)
 DEFINE_STORE(i64_store, u64, u64)
 DEFINE_STORE(f32_store, f32, f32)

--- a/src/template/wasm2c_atomicops.declarations.c
+++ b/src/template/wasm2c_atomicops.declarations.c
@@ -125,24 +125,24 @@
     TRAP(UNALIGNED);                     \
   }
 
-#define DEFINE_ATOMIC_LOAD(name, t1, t2, t3)               \
+#define DEFINE_ATOMIC_LOAD(name, t1, t2, t3, force_read)   \
   static inline t3 name(wasm_rt_memory_t* mem, u64 addr) { \
     MEMCHECK(mem, addr, t1);                               \
     ATOMIC_ALIGNMENT_CHECK(addr, t1);                      \
     t1 result;                                             \
     wasm_rt_memcpy(&result, &mem->data[addr], sizeof(t1)); \
     result = atomic_load_##t1(&mem->data[addr]);           \
-    wasm_asm("" ::"r"(result));                            \
+    force_read(result);                                    \
     return (t3)(t2)result;                                 \
   }
 
-DEFINE_ATOMIC_LOAD(i32_atomic_load, u32, u32, u32)
-DEFINE_ATOMIC_LOAD(i64_atomic_load, u64, u64, u64)
-DEFINE_ATOMIC_LOAD(i32_atomic_load8_u, u8, u32, u32)
-DEFINE_ATOMIC_LOAD(i64_atomic_load8_u, u8, u64, u64)
-DEFINE_ATOMIC_LOAD(i32_atomic_load16_u, u16, u32, u32)
-DEFINE_ATOMIC_LOAD(i64_atomic_load16_u, u16, u64, u64)
-DEFINE_ATOMIC_LOAD(i64_atomic_load32_u, u32, u64, u64)
+DEFINE_ATOMIC_LOAD(i32_atomic_load, u32, u32, u32, FORCE_READ_INT)
+DEFINE_ATOMIC_LOAD(i64_atomic_load, u64, u64, u64, FORCE_READ_INT)
+DEFINE_ATOMIC_LOAD(i32_atomic_load8_u, u8, u32, u32, FORCE_READ_INT)
+DEFINE_ATOMIC_LOAD(i64_atomic_load8_u, u8, u64, u64, FORCE_READ_INT)
+DEFINE_ATOMIC_LOAD(i32_atomic_load16_u, u16, u32, u32, FORCE_READ_INT)
+DEFINE_ATOMIC_LOAD(i64_atomic_load16_u, u16, u64, u64, FORCE_READ_INT)
+DEFINE_ATOMIC_LOAD(i64_atomic_load32_u, u32, u64, u64, FORCE_READ_INT)
 
 #define DEFINE_ATOMIC_STORE(name, t1, t2)                              \
   static inline void name(wasm_rt_memory_t* mem, u64 addr, t2 value) { \

--- a/src/template/wasm2c_simd.declarations.c
+++ b/src/template/wasm2c_simd.declarations.c
@@ -1,5 +1,5 @@
-#ifdef __x86_64__
-#define SIMD_FORCE_READ(var) wasm_asm("" ::"x"(var));
+#if defined(__GNUC__) && defined(__x86_64__)
+#define SIMD_FORCE_READ(var) __asm__("" ::"x"(var));
 #else
 #define SIMD_FORCE_READ(var)
 #endif

--- a/test/wasm2c/add.txt
+++ b/test/wasm2c/add.txt
@@ -115,9 +115,17 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
 #endif
 
 #ifdef __GNUC__
-#define wasm_asm __asm__
+#define FORCE_READ_INT(var) __asm__("" ::"r"(var));
+// Clang on Mips requires "f" constraints on floats
+#if defined(__clang__) && \
+    (defined(mips) || defined(__mips__) || defined(__mips))
+#define FORCE_READ_FLOAT(var) __asm__("" ::"f"(var));
 #else
-#define wasm_asm(X)
+#define FORCE_READ_FLOAT(var) __asm__("" ::"r"(var));
+#endif
+#else
+#define FORCE_READ_INT(var)
+#define FORCE_READ_FLOAT(var)
 #endif
 
 #if WABT_BIG_ENDIAN
@@ -139,13 +147,13 @@ static inline void load_data(void* dest, const void* src, size_t n) {
     RANGE_CHECK((&m), m.size - o - s, s);       \
     load_data(&(m.data[m.size - o - s]), i, s); \
   } while (0)
-#define DEFINE_LOAD(name, t1, t2, t3)                                  \
+#define DEFINE_LOAD(name, t1, t2, t3, force_read)                      \
   static inline t3 name(wasm_rt_memory_t* mem, u64 addr) {             \
     MEMCHECK(mem, addr, t1);                                           \
     t1 result;                                                         \
     wasm_rt_memcpy(&result, &mem->data[mem->size - addr - sizeof(t1)], \
                    sizeof(t1));                                        \
-    wasm_asm("" ::"r"(result));                                        \
+    force_read(result);                                                \
     return (t3)(t2)result;                                             \
   }
 
@@ -168,12 +176,12 @@ static inline void load_data(void* dest, const void* src, size_t n) {
     RANGE_CHECK((&m), o, s);       \
     load_data(&(m.data[o]), i, s); \
   } while (0)
-#define DEFINE_LOAD(name, t1, t2, t3)                      \
+#define DEFINE_LOAD(name, t1, t2, t3, force_read)          \
   static inline t3 name(wasm_rt_memory_t* mem, u64 addr) { \
     MEMCHECK(mem, addr, t1);                               \
     t1 result;                                             \
     wasm_rt_memcpy(&result, &mem->data[addr], sizeof(t1)); \
-    wasm_asm("" ::"r"(result));                            \
+    force_read(result);                                    \
     return (t3)(t2)result;                                 \
   }
 
@@ -185,20 +193,20 @@ static inline void load_data(void* dest, const void* src, size_t n) {
   }
 #endif
 
-DEFINE_LOAD(i32_load, u32, u32, u32)
-DEFINE_LOAD(i64_load, u64, u64, u64)
-DEFINE_LOAD(f32_load, f32, f32, f32)
-DEFINE_LOAD(f64_load, f64, f64, f64)
-DEFINE_LOAD(i32_load8_s, s8, s32, u32)
-DEFINE_LOAD(i64_load8_s, s8, s64, u64)
-DEFINE_LOAD(i32_load8_u, u8, u32, u32)
-DEFINE_LOAD(i64_load8_u, u8, u64, u64)
-DEFINE_LOAD(i32_load16_s, s16, s32, u32)
-DEFINE_LOAD(i64_load16_s, s16, s64, u64)
-DEFINE_LOAD(i32_load16_u, u16, u32, u32)
-DEFINE_LOAD(i64_load16_u, u16, u64, u64)
-DEFINE_LOAD(i64_load32_s, s32, s64, u64)
-DEFINE_LOAD(i64_load32_u, u32, u64, u64)
+DEFINE_LOAD(i32_load, u32, u32, u32, FORCE_READ_INT)
+DEFINE_LOAD(i64_load, u64, u64, u64, FORCE_READ_INT)
+DEFINE_LOAD(f32_load, f32, f32, f32, FORCE_READ_FLOAT)
+DEFINE_LOAD(f64_load, f64, f64, f64, FORCE_READ_FLOAT)
+DEFINE_LOAD(i32_load8_s, s8, s32, u32, FORCE_READ_INT)
+DEFINE_LOAD(i64_load8_s, s8, s64, u64, FORCE_READ_INT)
+DEFINE_LOAD(i32_load8_u, u8, u32, u32, FORCE_READ_INT)
+DEFINE_LOAD(i64_load8_u, u8, u64, u64, FORCE_READ_INT)
+DEFINE_LOAD(i32_load16_s, s16, s32, u32, FORCE_READ_INT)
+DEFINE_LOAD(i64_load16_s, s16, s64, u64, FORCE_READ_INT)
+DEFINE_LOAD(i32_load16_u, u16, u32, u32, FORCE_READ_INT)
+DEFINE_LOAD(i64_load16_u, u16, u64, u64, FORCE_READ_INT)
+DEFINE_LOAD(i64_load32_s, s32, s64, u64, FORCE_READ_INT)
+DEFINE_LOAD(i64_load32_u, u32, u64, u64, FORCE_READ_INT)
 DEFINE_STORE(i32_store, u32, u32)
 DEFINE_STORE(i64_store, u64, u64)
 DEFINE_STORE(f32_store, f32, f32)

--- a/test/wasm2c/check-imports.txt
+++ b/test/wasm2c/check-imports.txt
@@ -138,9 +138,17 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
 #endif
 
 #ifdef __GNUC__
-#define wasm_asm __asm__
+#define FORCE_READ_INT(var) __asm__("" ::"r"(var));
+// Clang on Mips requires "f" constraints on floats
+#if defined(__clang__) && \
+    (defined(mips) || defined(__mips__) || defined(__mips))
+#define FORCE_READ_FLOAT(var) __asm__("" ::"f"(var));
 #else
-#define wasm_asm(X)
+#define FORCE_READ_FLOAT(var) __asm__("" ::"r"(var));
+#endif
+#else
+#define FORCE_READ_INT(var)
+#define FORCE_READ_FLOAT(var)
 #endif
 
 #if WABT_BIG_ENDIAN
@@ -162,13 +170,13 @@ static inline void load_data(void* dest, const void* src, size_t n) {
     RANGE_CHECK((&m), m.size - o - s, s);       \
     load_data(&(m.data[m.size - o - s]), i, s); \
   } while (0)
-#define DEFINE_LOAD(name, t1, t2, t3)                                  \
+#define DEFINE_LOAD(name, t1, t2, t3, force_read)                      \
   static inline t3 name(wasm_rt_memory_t* mem, u64 addr) {             \
     MEMCHECK(mem, addr, t1);                                           \
     t1 result;                                                         \
     wasm_rt_memcpy(&result, &mem->data[mem->size - addr - sizeof(t1)], \
                    sizeof(t1));                                        \
-    wasm_asm("" ::"r"(result));                                        \
+    force_read(result);                                                \
     return (t3)(t2)result;                                             \
   }
 
@@ -191,12 +199,12 @@ static inline void load_data(void* dest, const void* src, size_t n) {
     RANGE_CHECK((&m), o, s);       \
     load_data(&(m.data[o]), i, s); \
   } while (0)
-#define DEFINE_LOAD(name, t1, t2, t3)                      \
+#define DEFINE_LOAD(name, t1, t2, t3, force_read)          \
   static inline t3 name(wasm_rt_memory_t* mem, u64 addr) { \
     MEMCHECK(mem, addr, t1);                               \
     t1 result;                                             \
     wasm_rt_memcpy(&result, &mem->data[addr], sizeof(t1)); \
-    wasm_asm("" ::"r"(result));                            \
+    force_read(result);                                    \
     return (t3)(t2)result;                                 \
   }
 
@@ -208,20 +216,20 @@ static inline void load_data(void* dest, const void* src, size_t n) {
   }
 #endif
 
-DEFINE_LOAD(i32_load, u32, u32, u32)
-DEFINE_LOAD(i64_load, u64, u64, u64)
-DEFINE_LOAD(f32_load, f32, f32, f32)
-DEFINE_LOAD(f64_load, f64, f64, f64)
-DEFINE_LOAD(i32_load8_s, s8, s32, u32)
-DEFINE_LOAD(i64_load8_s, s8, s64, u64)
-DEFINE_LOAD(i32_load8_u, u8, u32, u32)
-DEFINE_LOAD(i64_load8_u, u8, u64, u64)
-DEFINE_LOAD(i32_load16_s, s16, s32, u32)
-DEFINE_LOAD(i64_load16_s, s16, s64, u64)
-DEFINE_LOAD(i32_load16_u, u16, u32, u32)
-DEFINE_LOAD(i64_load16_u, u16, u64, u64)
-DEFINE_LOAD(i64_load32_s, s32, s64, u64)
-DEFINE_LOAD(i64_load32_u, u32, u64, u64)
+DEFINE_LOAD(i32_load, u32, u32, u32, FORCE_READ_INT)
+DEFINE_LOAD(i64_load, u64, u64, u64, FORCE_READ_INT)
+DEFINE_LOAD(f32_load, f32, f32, f32, FORCE_READ_FLOAT)
+DEFINE_LOAD(f64_load, f64, f64, f64, FORCE_READ_FLOAT)
+DEFINE_LOAD(i32_load8_s, s8, s32, u32, FORCE_READ_INT)
+DEFINE_LOAD(i64_load8_s, s8, s64, u64, FORCE_READ_INT)
+DEFINE_LOAD(i32_load8_u, u8, u32, u32, FORCE_READ_INT)
+DEFINE_LOAD(i64_load8_u, u8, u64, u64, FORCE_READ_INT)
+DEFINE_LOAD(i32_load16_s, s16, s32, u32, FORCE_READ_INT)
+DEFINE_LOAD(i64_load16_s, s16, s64, u64, FORCE_READ_INT)
+DEFINE_LOAD(i32_load16_u, u16, u32, u32, FORCE_READ_INT)
+DEFINE_LOAD(i64_load16_u, u16, u64, u64, FORCE_READ_INT)
+DEFINE_LOAD(i64_load32_s, s32, s64, u64, FORCE_READ_INT)
+DEFINE_LOAD(i64_load32_u, u32, u64, u64, FORCE_READ_INT)
 DEFINE_STORE(i32_store, u32, u32)
 DEFINE_STORE(i64_store, u64, u64)
 DEFINE_STORE(f32_store, f32, f32)

--- a/test/wasm2c/export-names.txt
+++ b/test/wasm2c/export-names.txt
@@ -138,9 +138,17 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
 #endif
 
 #ifdef __GNUC__
-#define wasm_asm __asm__
+#define FORCE_READ_INT(var) __asm__("" ::"r"(var));
+// Clang on Mips requires "f" constraints on floats
+#if defined(__clang__) && \
+    (defined(mips) || defined(__mips__) || defined(__mips))
+#define FORCE_READ_FLOAT(var) __asm__("" ::"f"(var));
 #else
-#define wasm_asm(X)
+#define FORCE_READ_FLOAT(var) __asm__("" ::"r"(var));
+#endif
+#else
+#define FORCE_READ_INT(var)
+#define FORCE_READ_FLOAT(var)
 #endif
 
 #if WABT_BIG_ENDIAN
@@ -162,13 +170,13 @@ static inline void load_data(void* dest, const void* src, size_t n) {
     RANGE_CHECK((&m), m.size - o - s, s);       \
     load_data(&(m.data[m.size - o - s]), i, s); \
   } while (0)
-#define DEFINE_LOAD(name, t1, t2, t3)                                  \
+#define DEFINE_LOAD(name, t1, t2, t3, force_read)                      \
   static inline t3 name(wasm_rt_memory_t* mem, u64 addr) {             \
     MEMCHECK(mem, addr, t1);                                           \
     t1 result;                                                         \
     wasm_rt_memcpy(&result, &mem->data[mem->size - addr - sizeof(t1)], \
                    sizeof(t1));                                        \
-    wasm_asm("" ::"r"(result));                                        \
+    force_read(result);                                                \
     return (t3)(t2)result;                                             \
   }
 
@@ -191,12 +199,12 @@ static inline void load_data(void* dest, const void* src, size_t n) {
     RANGE_CHECK((&m), o, s);       \
     load_data(&(m.data[o]), i, s); \
   } while (0)
-#define DEFINE_LOAD(name, t1, t2, t3)                      \
+#define DEFINE_LOAD(name, t1, t2, t3, force_read)          \
   static inline t3 name(wasm_rt_memory_t* mem, u64 addr) { \
     MEMCHECK(mem, addr, t1);                               \
     t1 result;                                             \
     wasm_rt_memcpy(&result, &mem->data[addr], sizeof(t1)); \
-    wasm_asm("" ::"r"(result));                            \
+    force_read(result);                                    \
     return (t3)(t2)result;                                 \
   }
 
@@ -208,20 +216,20 @@ static inline void load_data(void* dest, const void* src, size_t n) {
   }
 #endif
 
-DEFINE_LOAD(i32_load, u32, u32, u32)
-DEFINE_LOAD(i64_load, u64, u64, u64)
-DEFINE_LOAD(f32_load, f32, f32, f32)
-DEFINE_LOAD(f64_load, f64, f64, f64)
-DEFINE_LOAD(i32_load8_s, s8, s32, u32)
-DEFINE_LOAD(i64_load8_s, s8, s64, u64)
-DEFINE_LOAD(i32_load8_u, u8, u32, u32)
-DEFINE_LOAD(i64_load8_u, u8, u64, u64)
-DEFINE_LOAD(i32_load16_s, s16, s32, u32)
-DEFINE_LOAD(i64_load16_s, s16, s64, u64)
-DEFINE_LOAD(i32_load16_u, u16, u32, u32)
-DEFINE_LOAD(i64_load16_u, u16, u64, u64)
-DEFINE_LOAD(i64_load32_s, s32, s64, u64)
-DEFINE_LOAD(i64_load32_u, u32, u64, u64)
+DEFINE_LOAD(i32_load, u32, u32, u32, FORCE_READ_INT)
+DEFINE_LOAD(i64_load, u64, u64, u64, FORCE_READ_INT)
+DEFINE_LOAD(f32_load, f32, f32, f32, FORCE_READ_FLOAT)
+DEFINE_LOAD(f64_load, f64, f64, f64, FORCE_READ_FLOAT)
+DEFINE_LOAD(i32_load8_s, s8, s32, u32, FORCE_READ_INT)
+DEFINE_LOAD(i64_load8_s, s8, s64, u64, FORCE_READ_INT)
+DEFINE_LOAD(i32_load8_u, u8, u32, u32, FORCE_READ_INT)
+DEFINE_LOAD(i64_load8_u, u8, u64, u64, FORCE_READ_INT)
+DEFINE_LOAD(i32_load16_s, s16, s32, u32, FORCE_READ_INT)
+DEFINE_LOAD(i64_load16_s, s16, s64, u64, FORCE_READ_INT)
+DEFINE_LOAD(i32_load16_u, u16, u32, u32, FORCE_READ_INT)
+DEFINE_LOAD(i64_load16_u, u16, u64, u64, FORCE_READ_INT)
+DEFINE_LOAD(i64_load32_s, s32, s64, u64, FORCE_READ_INT)
+DEFINE_LOAD(i64_load32_u, u32, u64, u64, FORCE_READ_INT)
 DEFINE_STORE(i32_store, u32, u32)
 DEFINE_STORE(i64_store, u64, u64)
 DEFINE_STORE(f32_store, f32, f32)

--- a/test/wasm2c/hello.txt
+++ b/test/wasm2c/hello.txt
@@ -146,9 +146,17 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
 #endif
 
 #ifdef __GNUC__
-#define wasm_asm __asm__
+#define FORCE_READ_INT(var) __asm__("" ::"r"(var));
+// Clang on Mips requires "f" constraints on floats
+#if defined(__clang__) && \
+    (defined(mips) || defined(__mips__) || defined(__mips))
+#define FORCE_READ_FLOAT(var) __asm__("" ::"f"(var));
 #else
-#define wasm_asm(X)
+#define FORCE_READ_FLOAT(var) __asm__("" ::"r"(var));
+#endif
+#else
+#define FORCE_READ_INT(var)
+#define FORCE_READ_FLOAT(var)
 #endif
 
 #if WABT_BIG_ENDIAN
@@ -170,13 +178,13 @@ static inline void load_data(void* dest, const void* src, size_t n) {
     RANGE_CHECK((&m), m.size - o - s, s);       \
     load_data(&(m.data[m.size - o - s]), i, s); \
   } while (0)
-#define DEFINE_LOAD(name, t1, t2, t3)                                  \
+#define DEFINE_LOAD(name, t1, t2, t3, force_read)                      \
   static inline t3 name(wasm_rt_memory_t* mem, u64 addr) {             \
     MEMCHECK(mem, addr, t1);                                           \
     t1 result;                                                         \
     wasm_rt_memcpy(&result, &mem->data[mem->size - addr - sizeof(t1)], \
                    sizeof(t1));                                        \
-    wasm_asm("" ::"r"(result));                                        \
+    force_read(result);                                                \
     return (t3)(t2)result;                                             \
   }
 
@@ -199,12 +207,12 @@ static inline void load_data(void* dest, const void* src, size_t n) {
     RANGE_CHECK((&m), o, s);       \
     load_data(&(m.data[o]), i, s); \
   } while (0)
-#define DEFINE_LOAD(name, t1, t2, t3)                      \
+#define DEFINE_LOAD(name, t1, t2, t3, force_read)          \
   static inline t3 name(wasm_rt_memory_t* mem, u64 addr) { \
     MEMCHECK(mem, addr, t1);                               \
     t1 result;                                             \
     wasm_rt_memcpy(&result, &mem->data[addr], sizeof(t1)); \
-    wasm_asm("" ::"r"(result));                            \
+    force_read(result);                                    \
     return (t3)(t2)result;                                 \
   }
 
@@ -216,20 +224,20 @@ static inline void load_data(void* dest, const void* src, size_t n) {
   }
 #endif
 
-DEFINE_LOAD(i32_load, u32, u32, u32)
-DEFINE_LOAD(i64_load, u64, u64, u64)
-DEFINE_LOAD(f32_load, f32, f32, f32)
-DEFINE_LOAD(f64_load, f64, f64, f64)
-DEFINE_LOAD(i32_load8_s, s8, s32, u32)
-DEFINE_LOAD(i64_load8_s, s8, s64, u64)
-DEFINE_LOAD(i32_load8_u, u8, u32, u32)
-DEFINE_LOAD(i64_load8_u, u8, u64, u64)
-DEFINE_LOAD(i32_load16_s, s16, s32, u32)
-DEFINE_LOAD(i64_load16_s, s16, s64, u64)
-DEFINE_LOAD(i32_load16_u, u16, u32, u32)
-DEFINE_LOAD(i64_load16_u, u16, u64, u64)
-DEFINE_LOAD(i64_load32_s, s32, s64, u64)
-DEFINE_LOAD(i64_load32_u, u32, u64, u64)
+DEFINE_LOAD(i32_load, u32, u32, u32, FORCE_READ_INT)
+DEFINE_LOAD(i64_load, u64, u64, u64, FORCE_READ_INT)
+DEFINE_LOAD(f32_load, f32, f32, f32, FORCE_READ_FLOAT)
+DEFINE_LOAD(f64_load, f64, f64, f64, FORCE_READ_FLOAT)
+DEFINE_LOAD(i32_load8_s, s8, s32, u32, FORCE_READ_INT)
+DEFINE_LOAD(i64_load8_s, s8, s64, u64, FORCE_READ_INT)
+DEFINE_LOAD(i32_load8_u, u8, u32, u32, FORCE_READ_INT)
+DEFINE_LOAD(i64_load8_u, u8, u64, u64, FORCE_READ_INT)
+DEFINE_LOAD(i32_load16_s, s16, s32, u32, FORCE_READ_INT)
+DEFINE_LOAD(i64_load16_s, s16, s64, u64, FORCE_READ_INT)
+DEFINE_LOAD(i32_load16_u, u16, u32, u32, FORCE_READ_INT)
+DEFINE_LOAD(i64_load16_u, u16, u64, u64, FORCE_READ_INT)
+DEFINE_LOAD(i64_load32_s, s32, s64, u64, FORCE_READ_INT)
+DEFINE_LOAD(i64_load32_u, u32, u64, u64, FORCE_READ_INT)
 DEFINE_STORE(i32_store, u32, u32)
 DEFINE_STORE(i64_store, u64, u64)
 DEFINE_STORE(f32_store, f32, f32)

--- a/test/wasm2c/minimal.txt
+++ b/test/wasm2c/minimal.txt
@@ -109,9 +109,17 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
 #endif
 
 #ifdef __GNUC__
-#define wasm_asm __asm__
+#define FORCE_READ_INT(var) __asm__("" ::"r"(var));
+// Clang on Mips requires "f" constraints on floats
+#if defined(__clang__) && \
+    (defined(mips) || defined(__mips__) || defined(__mips))
+#define FORCE_READ_FLOAT(var) __asm__("" ::"f"(var));
 #else
-#define wasm_asm(X)
+#define FORCE_READ_FLOAT(var) __asm__("" ::"r"(var));
+#endif
+#else
+#define FORCE_READ_INT(var)
+#define FORCE_READ_FLOAT(var)
 #endif
 
 #if WABT_BIG_ENDIAN
@@ -133,13 +141,13 @@ static inline void load_data(void* dest, const void* src, size_t n) {
     RANGE_CHECK((&m), m.size - o - s, s);       \
     load_data(&(m.data[m.size - o - s]), i, s); \
   } while (0)
-#define DEFINE_LOAD(name, t1, t2, t3)                                  \
+#define DEFINE_LOAD(name, t1, t2, t3, force_read)                      \
   static inline t3 name(wasm_rt_memory_t* mem, u64 addr) {             \
     MEMCHECK(mem, addr, t1);                                           \
     t1 result;                                                         \
     wasm_rt_memcpy(&result, &mem->data[mem->size - addr - sizeof(t1)], \
                    sizeof(t1));                                        \
-    wasm_asm("" ::"r"(result));                                        \
+    force_read(result);                                                \
     return (t3)(t2)result;                                             \
   }
 
@@ -162,12 +170,12 @@ static inline void load_data(void* dest, const void* src, size_t n) {
     RANGE_CHECK((&m), o, s);       \
     load_data(&(m.data[o]), i, s); \
   } while (0)
-#define DEFINE_LOAD(name, t1, t2, t3)                      \
+#define DEFINE_LOAD(name, t1, t2, t3, force_read)          \
   static inline t3 name(wasm_rt_memory_t* mem, u64 addr) { \
     MEMCHECK(mem, addr, t1);                               \
     t1 result;                                             \
     wasm_rt_memcpy(&result, &mem->data[addr], sizeof(t1)); \
-    wasm_asm("" ::"r"(result));                            \
+    force_read(result);                                    \
     return (t3)(t2)result;                                 \
   }
 
@@ -179,20 +187,20 @@ static inline void load_data(void* dest, const void* src, size_t n) {
   }
 #endif
 
-DEFINE_LOAD(i32_load, u32, u32, u32)
-DEFINE_LOAD(i64_load, u64, u64, u64)
-DEFINE_LOAD(f32_load, f32, f32, f32)
-DEFINE_LOAD(f64_load, f64, f64, f64)
-DEFINE_LOAD(i32_load8_s, s8, s32, u32)
-DEFINE_LOAD(i64_load8_s, s8, s64, u64)
-DEFINE_LOAD(i32_load8_u, u8, u32, u32)
-DEFINE_LOAD(i64_load8_u, u8, u64, u64)
-DEFINE_LOAD(i32_load16_s, s16, s32, u32)
-DEFINE_LOAD(i64_load16_s, s16, s64, u64)
-DEFINE_LOAD(i32_load16_u, u16, u32, u32)
-DEFINE_LOAD(i64_load16_u, u16, u64, u64)
-DEFINE_LOAD(i64_load32_s, s32, s64, u64)
-DEFINE_LOAD(i64_load32_u, u32, u64, u64)
+DEFINE_LOAD(i32_load, u32, u32, u32, FORCE_READ_INT)
+DEFINE_LOAD(i64_load, u64, u64, u64, FORCE_READ_INT)
+DEFINE_LOAD(f32_load, f32, f32, f32, FORCE_READ_FLOAT)
+DEFINE_LOAD(f64_load, f64, f64, f64, FORCE_READ_FLOAT)
+DEFINE_LOAD(i32_load8_s, s8, s32, u32, FORCE_READ_INT)
+DEFINE_LOAD(i64_load8_s, s8, s64, u64, FORCE_READ_INT)
+DEFINE_LOAD(i32_load8_u, u8, u32, u32, FORCE_READ_INT)
+DEFINE_LOAD(i64_load8_u, u8, u64, u64, FORCE_READ_INT)
+DEFINE_LOAD(i32_load16_s, s16, s32, u32, FORCE_READ_INT)
+DEFINE_LOAD(i64_load16_s, s16, s64, u64, FORCE_READ_INT)
+DEFINE_LOAD(i32_load16_u, u16, u32, u32, FORCE_READ_INT)
+DEFINE_LOAD(i64_load16_u, u16, u64, u64, FORCE_READ_INT)
+DEFINE_LOAD(i64_load32_s, s32, s64, u64, FORCE_READ_INT)
+DEFINE_LOAD(i64_load32_u, u32, u64, u64, FORCE_READ_INT)
 DEFINE_STORE(i32_store, u32, u32)
 DEFINE_STORE(i64_store, u64, u64)
 DEFINE_STORE(f32_store, f32, f32)

--- a/wasm2c/examples/fac/fac.c
+++ b/wasm2c/examples/fac/fac.c
@@ -67,9 +67,17 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
 #endif
 
 #ifdef __GNUC__
-#define wasm_asm __asm__
+#define FORCE_READ_INT(var) __asm__("" ::"r"(var));
+// Clang on Mips requires "f" constraints on floats
+#if defined(__clang__) && \
+    (defined(mips) || defined(__mips__) || defined(__mips))
+#define FORCE_READ_FLOAT(var) __asm__("" ::"f"(var));
 #else
-#define wasm_asm(X)
+#define FORCE_READ_FLOAT(var) __asm__("" ::"r"(var));
+#endif
+#else
+#define FORCE_READ_INT(var)
+#define FORCE_READ_FLOAT(var)
 #endif
 
 #if WABT_BIG_ENDIAN
@@ -91,13 +99,13 @@ static inline void load_data(void* dest, const void* src, size_t n) {
     RANGE_CHECK((&m), m.size - o - s, s);       \
     load_data(&(m.data[m.size - o - s]), i, s); \
   } while (0)
-#define DEFINE_LOAD(name, t1, t2, t3)                                  \
+#define DEFINE_LOAD(name, t1, t2, t3, force_read)                      \
   static inline t3 name(wasm_rt_memory_t* mem, u64 addr) {             \
     MEMCHECK(mem, addr, t1);                                           \
     t1 result;                                                         \
     wasm_rt_memcpy(&result, &mem->data[mem->size - addr - sizeof(t1)], \
                    sizeof(t1));                                        \
-    wasm_asm("" ::"r"(result));                                        \
+    force_read(result);                                                \
     return (t3)(t2)result;                                             \
   }
 
@@ -120,12 +128,12 @@ static inline void load_data(void* dest, const void* src, size_t n) {
     RANGE_CHECK((&m), o, s);       \
     load_data(&(m.data[o]), i, s); \
   } while (0)
-#define DEFINE_LOAD(name, t1, t2, t3)                      \
+#define DEFINE_LOAD(name, t1, t2, t3, force_read)          \
   static inline t3 name(wasm_rt_memory_t* mem, u64 addr) { \
     MEMCHECK(mem, addr, t1);                               \
     t1 result;                                             \
     wasm_rt_memcpy(&result, &mem->data[addr], sizeof(t1)); \
-    wasm_asm("" ::"r"(result));                            \
+    force_read(result);                                    \
     return (t3)(t2)result;                                 \
   }
 
@@ -137,20 +145,20 @@ static inline void load_data(void* dest, const void* src, size_t n) {
   }
 #endif
 
-DEFINE_LOAD(i32_load, u32, u32, u32)
-DEFINE_LOAD(i64_load, u64, u64, u64)
-DEFINE_LOAD(f32_load, f32, f32, f32)
-DEFINE_LOAD(f64_load, f64, f64, f64)
-DEFINE_LOAD(i32_load8_s, s8, s32, u32)
-DEFINE_LOAD(i64_load8_s, s8, s64, u64)
-DEFINE_LOAD(i32_load8_u, u8, u32, u32)
-DEFINE_LOAD(i64_load8_u, u8, u64, u64)
-DEFINE_LOAD(i32_load16_s, s16, s32, u32)
-DEFINE_LOAD(i64_load16_s, s16, s64, u64)
-DEFINE_LOAD(i32_load16_u, u16, u32, u32)
-DEFINE_LOAD(i64_load16_u, u16, u64, u64)
-DEFINE_LOAD(i64_load32_s, s32, s64, u64)
-DEFINE_LOAD(i64_load32_u, u32, u64, u64)
+DEFINE_LOAD(i32_load, u32, u32, u32, FORCE_READ_INT)
+DEFINE_LOAD(i64_load, u64, u64, u64, FORCE_READ_INT)
+DEFINE_LOAD(f32_load, f32, f32, f32, FORCE_READ_FLOAT)
+DEFINE_LOAD(f64_load, f64, f64, f64, FORCE_READ_FLOAT)
+DEFINE_LOAD(i32_load8_s, s8, s32, u32, FORCE_READ_INT)
+DEFINE_LOAD(i64_load8_s, s8, s64, u64, FORCE_READ_INT)
+DEFINE_LOAD(i32_load8_u, u8, u32, u32, FORCE_READ_INT)
+DEFINE_LOAD(i64_load8_u, u8, u64, u64, FORCE_READ_INT)
+DEFINE_LOAD(i32_load16_s, s16, s32, u32, FORCE_READ_INT)
+DEFINE_LOAD(i64_load16_s, s16, s64, u64, FORCE_READ_INT)
+DEFINE_LOAD(i32_load16_u, u16, u32, u32, FORCE_READ_INT)
+DEFINE_LOAD(i64_load16_u, u16, u64, u64, FORCE_READ_INT)
+DEFINE_LOAD(i64_load32_s, s32, s64, u64, FORCE_READ_INT)
+DEFINE_LOAD(i64_load32_u, u32, u64, u64, FORCE_READ_INT)
 DEFINE_STORE(i32_store, u32, u32)
 DEFINE_STORE(i64_store, u64, u64)
 DEFINE_STORE(f32_store, f32, f32)


### PR DESCRIPTION
This is a clean slate attempt to fix #2266. To fix this i looked into how clang and gcc handle floating point constraints across a host of platforms.

Godbolt link: https://godbolt.org/z/ddeWc6ees
Results are in table below.

Given this, it seems the simplest course of action that maintains functionality as is today, but fix the mips platform is to special case this. We can separately file a bug upstream (but best case scenario is that will likely get fixed only for future clang versions, so I'm not sure we can rely on just that).

Fyi, @glandium

gcc
---

x86 - both
x86-64 - both
aarch32 - only "r"
aarch64 - only "r"
mips - only "r"
mips64 - both
riscv32 - both
riscv64 -  both
sparc - both
sparc64 - both
powerpc - both
powerpc64 - both

clang
-----
x86 - both
x64 - both
aarch32 - only "r"
aarch64 - only "r"
mips -  only "f"
mips64 - only "f"
riscv32 -  both
riscv64 -  both
powerpc64 - both