### PR TITLE
wasm2c: add link to clang bug on mips force read constraint

### DIFF
--- a/src/prebuilt/wasm2c_source_declarations.cc
+++ b/src/prebuilt/wasm2c_source_declarations.cc
@@ -92,6 +92,8 @@ R"w2c_template(#define FORCE_READ_INT(var) __asm__("" ::"r"(var));
 )w2c_template"
 R"w2c_template(// Clang on Mips requires "f" constraints on floats
 )w2c_template"
+R"w2c_template(// See https://github.com/llvm/llvm-project/issues/64241
+)w2c_template"
 R"w2c_template(#if defined(__clang__) && \
 )w2c_template"
 R"w2c_template(    (defined(mips) || defined(__mips__) || defined(__mips))

--- a/src/template/wasm2c.declarations.c
+++ b/src/template/wasm2c.declarations.c
@@ -50,6 +50,7 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
 #ifdef __GNUC__
 #define FORCE_READ_INT(var) __asm__("" ::"r"(var));
 // Clang on Mips requires "f" constraints on floats
+// See https://github.com/llvm/llvm-project/issues/64241
 #if defined(__clang__) && \
     (defined(mips) || defined(__mips__) || defined(__mips))
 #define FORCE_READ_FLOAT(var) __asm__("" ::"f"(var));

--- a/test/wasm2c/add.txt
+++ b/test/wasm2c/add.txt
@@ -117,6 +117,7 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
 #ifdef __GNUC__
 #define FORCE_READ_INT(var) __asm__("" ::"r"(var));
 // Clang on Mips requires "f" constraints on floats
+// See https://github.com/llvm/llvm-project/issues/64241
 #if defined(__clang__) && \
     (defined(mips) || defined(__mips__) || defined(__mips))
 #define FORCE_READ_FLOAT(var) __asm__("" ::"f"(var));

--- a/test/wasm2c/check-imports.txt
+++ b/test/wasm2c/check-imports.txt
@@ -140,6 +140,7 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
 #ifdef __GNUC__
 #define FORCE_READ_INT(var) __asm__("" ::"r"(var));
 // Clang on Mips requires "f" constraints on floats
+// See https://github.com/llvm/llvm-project/issues/64241
 #if defined(__clang__) && \
     (defined(mips) || defined(__mips__) || defined(__mips))
 #define FORCE_READ_FLOAT(var) __asm__("" ::"f"(var));

--- a/test/wasm2c/export-names.txt
+++ b/test/wasm2c/export-names.txt
@@ -140,6 +140,7 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
 #ifdef __GNUC__
 #define FORCE_READ_INT(var) __asm__("" ::"r"(var));
 // Clang on Mips requires "f" constraints on floats
+// See https://github.com/llvm/llvm-project/issues/64241
 #if defined(__clang__) && \
     (defined(mips) || defined(__mips__) || defined(__mips))
 #define FORCE_READ_FLOAT(var) __asm__("" ::"f"(var));

--- a/test/wasm2c/hello.txt
+++ b/test/wasm2c/hello.txt
@@ -148,6 +148,7 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
 #ifdef __GNUC__
 #define FORCE_READ_INT(var) __asm__("" ::"r"(var));
 // Clang on Mips requires "f" constraints on floats
+// See https://github.com/llvm/llvm-project/issues/64241
 #if defined(__clang__) && \
     (defined(mips) || defined(__mips__) || defined(__mips))
 #define FORCE_READ_FLOAT(var) __asm__("" ::"f"(var));

--- a/test/wasm2c/minimal.txt
+++ b/test/wasm2c/minimal.txt
@@ -111,6 +111,7 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
 #ifdef __GNUC__
 #define FORCE_READ_INT(var) __asm__("" ::"r"(var));
 // Clang on Mips requires "f" constraints on floats
+// See https://github.com/llvm/llvm-project/issues/64241
 #if defined(__clang__) && \
     (defined(mips) || defined(__mips__) || defined(__mips))
 #define FORCE_READ_FLOAT(var) __asm__("" ::"f"(var));

--- a/wasm2c/examples/fac/fac.c
+++ b/wasm2c/examples/fac/fac.c
@@ -69,6 +69,7 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
 #ifdef __GNUC__
 #define FORCE_READ_INT(var) __asm__("" ::"r"(var));
 // Clang on Mips requires "f" constraints on floats
+// See https://github.com/llvm/llvm-project/issues/64241
 #if defined(__clang__) && \
     (defined(mips) || defined(__mips__) || defined(__mips))
 #define FORCE_READ_FLOAT(var) __asm__("" ::"f"(var));


### PR DESCRIPTION
Add link tracking clang bug on mips floating point constraints on inline asm