### PR TITLE
Support NetBSD's mprotect hardening

### DIFF
--- a/wasm2c/wasm-rt-impl.c
+++ b/wasm2c/wasm-rt-impl.c
@@ -145,6 +145,11 @@ static void os_cleanup_signal_handler(void) {
 static void* os_mmap(size_t size) {
   int map_prot = PROT_NONE;
   int map_flags = MAP_ANONYMOUS | MAP_PRIVATE;
+#ifdef PROT_MPROTECT
+  /* NetBSD's MPROTECT hardening requries declaring that the memory will
+     later change protections to W/X. */
+  map_prot |= PROT_MPROTECT(PROT_READ | PROT_WRITE | PROT_EXEC);
+#endif
   uint8_t* addr = mmap(NULL, size, map_prot, map_flags, -1, 0);
   if (addr == MAP_FAILED)
     return NULL;


### PR DESCRIPTION
From https://man.netbsd.org/mmap.2 :

>As a NetBSD extension, the PROT_MPROTECT macro can be used to request additional permissions for later use with mprotect(2).  For example PROT_MPROTECT(PROT_READ) requests that future PROT_READ mappings are allowed and can be enabled using mprotect(2), but does not currently grant read mappings to the returned memory segment.  This is necessary for switching pages between writable and executable when PaX MPROTECT restrictions are in place.

This allows wasm2c binaries to run without being branded with paxctl +m.