### PR TITLE
wasm-strip: add `-R/--remove-section` option

### DIFF
--- a/src/tools/wasm-strip.cc
+++ b/src/tools/wasm-strip.cc
@@ -28,7 +28,7 @@ using namespace wabt;
 static std::string s_filename;
 static std::string s_outfile;
 static std::set<std::string_view> v_sections_to_keep{};
-static std::set<std::string_view> v_sections_to_exclude{};
+static std::set<std::string_view> v_sections_to_remove{};
 
 static const char s_description[] =
     R"(  Remove sections of a WebAssembly binary file.
@@ -53,10 +53,10 @@ static void ParseOptions(int argc, char** argv) {
                    [](const char* value) {
                      v_sections_to_keep.insert(std::string_view{value});
                    });
-  parser.AddOption('x', "exclude-section", "SECTION NAME",
-                   "Section to specifically exclude, including all the rest",
+  parser.AddOption('R', "remove-section", "SECTION NAME",
+                   "Section to specifically remove, including all the rest",
                    [](const char* value) {
-                     v_sections_to_exclude.insert(std::string_view{value});
+                     v_sections_to_remove.insert(std::string_view{value});
                    });
   parser.Parse(argc, argv);
 }
@@ -148,7 +148,7 @@ int ProgramMain(int argc, char** argv) {
   ReadBinaryOptions options(features, nullptr, kReadDebugNames,
                             kStopOnFirstError, kFailOnCustomSectionError);
 
-  BinaryReaderStrip reader(v_sections_to_keep, v_sections_to_exclude, &errors);
+  BinaryReaderStrip reader(v_sections_to_keep, v_sections_to_remove, &errors);
   result = ReadBinary(file_data.data(), file_data.size(), &reader, options);
   FormatErrorsToFile(errors, Location::Type::Binary);
   if (Failed(result)) {

--- a/src/tools/wasm-strip.cc
+++ b/src/tools/wasm-strip.cc
@@ -28,6 +28,7 @@ using namespace wabt;
 static std::string s_filename;
 static std::string s_outfile;
 static std::set<std::string_view> v_sections_to_keep{};
+static std::set<std::string_view> v_sections_to_exclude{};
 
 static const char s_description[] =
     R"(  Remove sections of a WebAssembly binary file.
@@ -52,15 +53,22 @@ static void ParseOptions(int argc, char** argv) {
                    [](const char* value) {
                      v_sections_to_keep.insert(std::string_view{value});
                    });
+  parser.AddOption('x', "exclude-section", "SECTION NAME",
+                   "Section to specifically exclude, including all the rest",
+                   [](const char* value) {
+                     v_sections_to_exclude.insert(std::string_view{value});
+                   });
   parser.Parse(argc, argv);
 }
 
 class BinaryReaderStrip : public BinaryReaderNop {
  public:
   explicit BinaryReaderStrip(std::set<std::string_view> sections_to_keep,
+                             std::set<std::string_view> sections_to_exclude,
                              Errors* errors)
       : errors_(errors),
         sections_to_keep_(sections_to_keep),
+        sections_to_exclude_(sections_to_exclude),
         section_start_(0) {
     stream_.WriteU32(WABT_BINARY_MAGIC, "WASM_BINARY_MAGIC");
     stream_.WriteU32(WABT_BINARY_VERSION, "WASM_BINARY_VERSION");
@@ -91,10 +99,16 @@ class BinaryReaderStrip : public BinaryReaderNop {
   Result BeginCustomSection(Index section_index,
                             Offset size,
                             std::string_view section_name) override {
+    if (!sections_to_exclude_.empty() &&
+        sections_to_exclude_.count(section_name) > 0) {
+      return Result::Ok;
+    } else if (!sections_to_exclude_.empty()) {
+      WriteCustom(size);
+      return Result::Ok;
+    }
+
     if (sections_to_keep_.count(section_name) > 0) {
-      stream_.WriteU8Enum(BinarySection::Custom, "section code");
-      WriteU32Leb128(&stream_, size, "section size");
-      stream_.WriteData(state->data + section_start_, size, "section data");
+      WriteCustom(size);
     }
     return Result::Ok;
   }
@@ -103,7 +117,14 @@ class BinaryReaderStrip : public BinaryReaderNop {
   MemoryStream stream_;
   Errors* errors_;
   std::set<std::string_view> sections_to_keep_;
+  std::set<std::string_view> sections_to_exclude_;
   Offset section_start_;
+
+  void WriteCustom(wabt::Offset& size) {
+    stream_.WriteU8Enum(BinarySection::Custom, "section code");
+    WriteU32Leb128(&stream_, size, "section size");
+    stream_.WriteData(state->data + section_start_, size, "section data");
+  }
 };
 
 int ProgramMain(int argc, char** argv) {
@@ -127,7 +148,7 @@ int ProgramMain(int argc, char** argv) {
   ReadBinaryOptions options(features, nullptr, kReadDebugNames,
                             kStopOnFirstError, kFailOnCustomSectionError);
 
-  BinaryReaderStrip reader(v_sections_to_keep, &errors);
+  BinaryReaderStrip reader(v_sections_to_keep, v_sections_to_exclude, &errors);
   result = ReadBinary(file_data.data(), file_data.size(), &reader, options);
   FormatErrorsToFile(errors, Location::Type::Binary);
   if (Failed(result)) {

--- a/src/tools/wasm-strip.cc
+++ b/src/tools/wasm-strip.cc
@@ -99,8 +99,7 @@ class BinaryReaderStrip : public BinaryReaderNop {
   Result BeginCustomSection(Index section_index,
                             Offset size,
                             std::string_view section_name) override {
-    if (!sections_to_remove_.empty() &&
-        sections_to_remove_.count(section_name) > 0) {
+    if (sections_to_remove_.count(section_name) > 0) {
       return Result::Ok;
     }
 

--- a/test/strip/remove_section.txt
+++ b/test/strip/remove_section.txt
@@ -1,0 +1,36 @@
+;;; RUN: %(gen_wasm_py)s %(in_file)s -o %(temp_file)s.wasm
+;;; RUN: %(wasm-strip)s --remove-section one %(temp_file)s.wasm -o %(temp_file)s_stripped.wasm
+;;; RUN: %(wasm-objdump)s -h %(temp_file)s_stripped.wasm
+magic
+version
+section("one") { "Lorem ipsum dolor sit amet," }
+section("two") { "consectetur adipiscing elit," }
+section("three") { "sed do eiusmod tempor incididunt" }
+section("four") { "ut labore et dolore magna aliqua." }
+section(TYPE) { count[1] function params[0] results[1] i32 }
+section(FUNCTION) { count[1] type[0] }
+section(EXPORT) { count[1] str("main") func_kind func[0] }
+section(CODE) {
+  count[1]
+  func {
+    locals[0]
+    i32.const
+    leb_i32(-420)
+    return
+  }
+}
+section("five") { "Ut enim ad minim veniam," }
+(;; STDOUT ;;;
+
+remove_section_stripped.wasm:	file format wasm 0x1
+
+Sections:
+   Custom start=0x0000000a end=0x0000002a (size=0x00000020) "two"
+   Custom start=0x0000002c end=0x00000052 (size=0x00000026) "three"
+   Custom start=0x00000054 end=0x0000007a (size=0x00000026) "four"
+     Type start=0x0000007c end=0x00000081 (size=0x00000005) count: 1
+ Function start=0x00000083 end=0x00000085 (size=0x00000002) count: 1
+   Export start=0x00000087 end=0x0000008f (size=0x00000008) count: 1
+     Code start=0x00000091 end=0x00000099 (size=0x00000008) count: 1
+   Custom start=0x0000009b end=0x000000b8 (size=0x0000001d) "five"
+;;; STDOUT ;;)


### PR DESCRIPTION
This adds an option to the `wasm-strip` tool. When using it, I had cases where I'd want to only cut out a specific section, like `__wasm_bindgen_unstable` while still keeping other information, like DWARF sections.

This change is just a suggestion, but I believe it would be nice to have at least as an option for the `wasm-strip` interface.