### PR TITLE
Validator: normalize handling of Select in ExprVisitor Delegate

### DIFF
--- a/src/validator.cc
+++ b/src/validator.cc
@@ -524,12 +524,7 @@ Result Validator::OnReturnCallIndirectExpr(ReturnCallIndirectExpr* expr) {
 Result Validator::OnSelectExpr(SelectExpr* expr) {
   result_ |= validator_.OnSelect(expr->loc, expr->result_type.size(),
                                  expr->result_type.data());
-  // TODO: Existing behavior fails when select fails.
-#if 0
   return Result::Ok;
-#else
-  return result_;
-#endif
 }
 
 Result Validator::OnStoreExpr(StoreExpr* expr) {

--- a/test/parse/expr/bad-select-multi.txt
+++ b/test/parse/expr/bad-select-multi.txt
@@ -14,7 +14,4 @@
 out/test/parse/expr/bad-select-multi.txt:10:5: error: invalid arity in select instruction: 2.
     select (result i32 i32)
     ^^^^^^
-out/test/parse/expr/bad-select-multi.txt:11:5: error: type mismatch at end of function, expected [] but got [... i32, i32, i32, i32]
-    unreachable
-    ^^^^^^^^^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-select-value0.txt
+++ b/test/typecheck/bad-select-value0.txt
@@ -11,7 +11,4 @@
 out/test/typecheck/bad-select-value0.txt:8:5: error: type mismatch in select, expected [f64, f64, i32] but got [i32, f64, f32]
     select
     ^^^^^^
-out/test/typecheck/bad-select-value0.txt:9:5: error: type mismatch at end of function, expected [] but got [f64]
-    drop))
-    ^^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-select-value1.txt
+++ b/test/typecheck/bad-select-value1.txt
@@ -11,7 +11,4 @@
 out/test/typecheck/bad-select-value1.txt:8:5: error: type mismatch in select, expected [i64, i64, i32] but got [i32, i64, f32]
     select
     ^^^^^^
-out/test/typecheck/bad-select-value1.txt:9:5: error: type mismatch at end of function, expected [] but got [i64]
-    drop))
-    ^^^^
 ;;; STDERR ;;)


### PR DESCRIPTION
Fixes #2283

Previously, the OnSelectExpr delegate would terminate validation if the SharedValidator found an error in the expression, or if the Validator had previously found an error at any point in validating the module. This commit normalizes the behavior to match how the Validator handles other expression types.

I'd be more comfortable with this if I had been able to replicate the bug that's hinted at by the TODO we're removing (https://github.com/WebAssembly/wabt/blob/main/src/validator.cc#L527-L532), but I haven't been able to. :-( @binji any ideas? (cc: @majaha)