### PR TITLE
Update testsuite

### DIFF
--- a/test/spec/binary-leb128.txt
+++ b/test/spec/binary-leb128.txt
@@ -83,37 +83,39 @@ out/test/spec/binary-leb128.wast:718: assert_malformed passed:
   0000014: error: unable to read u32 leb128: function body count
 out/test/spec/binary-leb128.wast:731: assert_malformed passed:
   0000022: error: unable to read u32 leb128: load offset
-out/test/spec/binary-leb128.wast:750: assert_malformed passed:
+out/test/spec/binary-leb128.wast:751: assert_malformed passed:
   0000022: error: unable to read u32 leb128: load offset
-out/test/spec/binary-leb128.wast:769: assert_malformed passed:
+out/test/spec/binary-leb128.wast:771: assert_malformed passed:
   0000021: error: unable to read u32 leb128: load alignment
-out/test/spec/binary-leb128.wast:787: assert_malformed passed:
+out/test/spec/binary-leb128.wast:789: assert_malformed passed:
   0000021: error: unable to read u32 leb128: load alignment
-out/test/spec/binary-leb128.wast:806: assert_malformed passed:
+out/test/spec/binary-leb128.wast:808: assert_malformed passed:
   0000023: error: unable to read u32 leb128: store alignment
-out/test/spec/binary-leb128.wast:825: assert_malformed passed:
+out/test/spec/binary-leb128.wast:827: assert_malformed passed:
   0000023: error: unable to read u32 leb128: store alignment
-out/test/spec/binary-leb128.wast:844: assert_malformed passed:
+out/test/spec/binary-leb128.wast:846: assert_malformed passed:
   0000024: error: unable to read u32 leb128: store offset
-out/test/spec/binary-leb128.wast:863: assert_malformed passed:
+out/test/spec/binary-leb128.wast:866: assert_malformed passed:
   0000024: error: unable to read u32 leb128: store offset
-out/test/spec/binary-leb128.wast:885: assert_malformed passed:
+out/test/spec/binary-leb128.wast:888: assert_malformed passed:
   000000e: error: unable to read i32 leb128: i32.const value
-out/test/spec/binary-leb128.wast:895: assert_malformed passed:
+out/test/spec/binary-leb128.wast:898: assert_malformed passed:
   000000e: error: unable to read i32 leb128: i32.const value
-out/test/spec/binary-leb128.wast:905: assert_malformed passed:
+out/test/spec/binary-leb128.wast:908: assert_malformed passed:
   000000e: error: unable to read i32 leb128: i32.const value
-out/test/spec/binary-leb128.wast:915: assert_malformed passed:
+out/test/spec/binary-leb128.wast:918: assert_malformed passed:
   000000e: error: unable to read i32 leb128: i32.const value
-out/test/spec/binary-leb128.wast:926: assert_malformed passed:
+out/test/spec/binary-leb128.wast:929: assert_malformed passed:
   000000e: error: unable to read i64 leb128: i64.const value
-out/test/spec/binary-leb128.wast:936: assert_malformed passed:
+out/test/spec/binary-leb128.wast:939: assert_malformed passed:
   000000e: error: unable to read i64 leb128: i64.const value
-out/test/spec/binary-leb128.wast:946: assert_malformed passed:
+out/test/spec/binary-leb128.wast:949: assert_malformed passed:
   000000e: error: unable to read i64 leb128: i64.const value
-out/test/spec/binary-leb128.wast:956: assert_malformed passed:
+out/test/spec/binary-leb128.wast:959: assert_malformed passed:
   000000e: error: unable to read i64 leb128: i64.const value
-out/test/spec/binary-leb128.wast:988: assert_malformed passed:
+out/test/spec/binary-leb128.wast:990: assert_malformed passed:
   0000019: error: unable to read u32 leb128: opcode
-83/83 tests passed.
+out/test/spec/binary-leb128.wast:1073: assert_malformed passed:
+  000000c: error: unexpected type form (got 0xe0)
+91/91 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/binary.txt
+++ b/test/spec/binary.txt
@@ -67,217 +67,125 @@ out/test/spec/binary.wast:51: assert_malformed passed:
   000000a: error: invalid section code: 129
 out/test/spec/binary.wast:52: assert_malformed passed:
   000000a: error: invalid section code: 255
-out/test/spec/binary.wast:210: assert_malformed passed:
-  000000c: error: unexpected type form (got 0xe0)
-out/test/spec/binary.wast:223: assert_malformed passed:
-  000000c: error: unable to read u32 leb128: memory initial page count
-out/test/spec/binary.wast:233: assert_malformed passed:
-  000000e: error: unable to read i32 leb128: i32.const value
-out/test/spec/binary.wast:243: assert_malformed passed:
-  000000e: error: unable to read i32 leb128: i32.const value
-out/test/spec/binary.wast:254: assert_malformed passed:
-  000000e: error: unable to read i64 leb128: i64.const value
-out/test/spec/binary.wast:264: assert_malformed passed:
-  000000e: error: unable to read i64 leb128: i64.const value
-out/test/spec/binary.wast:276: assert_malformed passed:
-  000000c: error: unable to read u32 leb128: memory initial page count
-out/test/spec/binary.wast:284: assert_malformed passed:
-  000000c: error: unable to read u32 leb128: memory initial page count
-out/test/spec/binary.wast:294: assert_malformed passed:
-  000000e: error: unable to read i32 leb128: i32.const value
-out/test/spec/binary.wast:304: assert_malformed passed:
-  000000e: error: unable to read i32 leb128: i32.const value
-out/test/spec/binary.wast:314: assert_malformed passed:
-  000000e: error: unable to read i32 leb128: i32.const value
-out/test/spec/binary.wast:324: assert_malformed passed:
-  000000e: error: unable to read i32 leb128: i32.const value
-out/test/spec/binary.wast:335: assert_malformed passed:
-  000000e: error: unable to read i64 leb128: i64.const value
-out/test/spec/binary.wast:345: assert_malformed passed:
-  000000e: error: unable to read i64 leb128: i64.const value
-out/test/spec/binary.wast:355: assert_malformed passed:
-  000000e: error: unable to read i64 leb128: i64.const value
-out/test/spec/binary.wast:365: assert_malformed passed:
-  000000e: error: unable to read i64 leb128: i64.const value
-out/test/spec/binary.wast:376: assert_malformed passed:
-  000000e: error: unable to read i64 leb128: i64.const value
-out/test/spec/binary.wast:386: assert_malformed passed:
-  000000e: error: unable to read i64 leb128: i64.const value
-out/test/spec/binary.wast:396: assert_malformed passed:
-  000000e: error: unable to read i64 leb128: i64.const value
-out/test/spec/binary.wast:406: assert_malformed passed:
-  000000e: error: unable to read i64 leb128: i64.const value
-out/test/spec/binary.wast:418: assert_malformed passed:
+out/test/spec/binary.wast:56: assert_malformed passed:
   000001b: error: function body must end with END opcode
-out/test/spec/binary.wast:439: assert_malformed passed:
+out/test/spec/binary.wast:77: assert_malformed passed:
   000001a: error: function body must end with END opcode
-out/test/spec/binary.wast:455: assert_malformed passed:
+out/test/spec/binary.wast:93: assert_malformed passed:
   000001a: error: function body must end with END opcode
-out/test/spec/binary.wast:475: assert_malformed passed:
-  000000c: error: unable to read u32 leb128: memory initial page count
-out/test/spec/binary.wast:483: assert_malformed passed:
-  0000022: error: unable to read u32 leb128: load offset
-out/test/spec/binary.wast:502: assert_malformed passed:
-  0000021: error: unable to read u32 leb128: load alignment
-out/test/spec/binary.wast:521: assert_malformed passed:
-  0000023: error: unable to read u32 leb128: store alignment
-out/test/spec/binary.wast:540: assert_malformed passed:
-  0000024: error: unable to read u32 leb128: store offset
-out/test/spec/binary.wast:561: assert_malformed passed:
-  000000e: error: unable to read i32 leb128: i32.const value
-out/test/spec/binary.wast:571: assert_malformed passed:
-  000000e: error: unable to read i32 leb128: i32.const value
-out/test/spec/binary.wast:582: assert_malformed passed:
-  000000e: error: unable to read i64 leb128: i64.const value
-out/test/spec/binary.wast:592: assert_malformed passed:
-  000000e: error: unable to read i64 leb128: i64.const value
-out/test/spec/binary.wast:604: assert_malformed passed:
-  000000c: error: unable to read u32 leb128: memory initial page count
-out/test/spec/binary.wast:612: assert_malformed passed:
-  000000c: error: unable to read u32 leb128: memory initial page count
-out/test/spec/binary.wast:620: assert_malformed passed:
-  0000022: error: unable to read u32 leb128: load offset
-out/test/spec/binary.wast:639: assert_malformed passed:
-  0000022: error: unable to read u32 leb128: load offset
-out/test/spec/binary.wast:658: assert_malformed passed:
-  0000021: error: unable to read u32 leb128: load alignment
-out/test/spec/binary.wast:676: assert_malformed passed:
-  0000021: error: unable to read u32 leb128: load alignment
-out/test/spec/binary.wast:695: assert_malformed passed:
-  0000023: error: unable to read u32 leb128: store alignment
-out/test/spec/binary.wast:714: assert_malformed passed:
-  0000023: error: unable to read u32 leb128: store alignment
-out/test/spec/binary.wast:733: assert_malformed passed:
-  0000024: error: unable to read u32 leb128: store offset
-out/test/spec/binary.wast:752: assert_malformed passed:
-  0000024: error: unable to read u32 leb128: store offset
-out/test/spec/binary.wast:774: assert_malformed passed:
-  000000e: error: unable to read i32 leb128: i32.const value
-out/test/spec/binary.wast:784: assert_malformed passed:
-  000000e: error: unable to read i32 leb128: i32.const value
-out/test/spec/binary.wast:794: assert_malformed passed:
-  000000e: error: unable to read i32 leb128: i32.const value
-out/test/spec/binary.wast:804: assert_malformed passed:
-  000000e: error: unable to read i32 leb128: i32.const value
-out/test/spec/binary.wast:815: assert_malformed passed:
-  000000e: error: unable to read i64 leb128: i64.const value
-out/test/spec/binary.wast:825: assert_malformed passed:
-  000000e: error: unable to read i64 leb128: i64.const value
-out/test/spec/binary.wast:835: assert_malformed passed:
-  000000e: error: unable to read i64 leb128: i64.const value
-out/test/spec/binary.wast:845: assert_malformed passed:
-  000000e: error: unable to read i64 leb128: i64.const value
-out/test/spec/binary.wast:857: assert_malformed passed:
+out/test/spec/binary.wast:113: assert_malformed passed:
+  0000019: error: init expression must end with END opcode
+out/test/spec/binary.wast:126: assert_malformed passed:
   0000020: error: memory.grow reserved value must be 0
-out/test/spec/binary.wast:877: assert_malformed passed:
+out/test/spec/binary.wast:146: assert_malformed passed:
   0000020: error: memory.grow reserved value must be 0
-out/test/spec/binary.wast:897: assert_malformed passed:
+out/test/spec/binary.wast:166: assert_malformed passed:
   0000020: error: memory.grow reserved value must be 0
-out/test/spec/binary.wast:916: assert_malformed passed:
+out/test/spec/binary.wast:185: assert_malformed passed:
   0000020: error: memory.grow reserved value must be 0
-out/test/spec/binary.wast:935: assert_malformed passed:
+out/test/spec/binary.wast:204: assert_malformed passed:
   0000020: error: memory.grow reserved value must be 0
-out/test/spec/binary.wast:955: assert_malformed passed:
+out/test/spec/binary.wast:224: assert_malformed passed:
   000001e: error: memory.size reserved value must be 0
-out/test/spec/binary.wast:974: assert_malformed passed:
+out/test/spec/binary.wast:243: assert_malformed passed:
   000001e: error: memory.size reserved value must be 0
-out/test/spec/binary.wast:993: assert_malformed passed:
+out/test/spec/binary.wast:262: assert_malformed passed:
   000001e: error: memory.size reserved value must be 0
-out/test/spec/binary.wast:1011: assert_malformed passed:
+out/test/spec/binary.wast:280: assert_malformed passed:
   000001e: error: memory.size reserved value must be 0
-out/test/spec/binary.wast:1029: assert_malformed passed:
+out/test/spec/binary.wast:298: assert_malformed passed:
   000001e: error: memory.size reserved value must be 0
-out/test/spec/binary.wast:1048: assert_malformed passed:
+out/test/spec/binary.wast:317: assert_malformed passed:
   0000017: error: unable to read u32 leb128: local type count
-out/test/spec/binary.wast:1065: assert_malformed passed:
+out/test/spec/binary.wast:334: assert_malformed passed:
   0000017: error: unable to read u32 leb128: local type count
-out/test/spec/binary.wast:1082: assert_malformed passed:
+out/test/spec/binary.wast:351: assert_malformed passed:
   000001e: error: local count must be <= 0xffffffff
-out/test/spec/binary.wast:1098: assert_malformed passed:
+out/test/spec/binary.wast:367: assert_malformed passed:
   0000030: error: local count must be <= 0xffffffff
-out/test/spec/binary.wast:1132: assert_malformed passed:
+out/test/spec/binary.wast:401: assert_malformed passed:
   0000013: error: function signature count != function body count
-out/test/spec/binary.wast:1142: assert_malformed passed:
+out/test/spec/binary.wast:411: assert_malformed passed:
   000000b: error: function signature count != function body count
-out/test/spec/binary.wast:1151: assert_malformed passed:
+out/test/spec/binary.wast:420: assert_malformed passed:
   0000016: error: function signature count != function body count
-out/test/spec/binary.wast:1162: assert_malformed passed:
+out/test/spec/binary.wast:431: assert_malformed passed:
   0000015: error: function signature count != function body count
-out/test/spec/binary.wast:1185: assert_malformed passed:
+out/test/spec/binary.wast:454: assert_malformed passed:
   000000e: error: data segment count does not equal count in DataCount section
-out/test/spec/binary.wast:1195: assert_malformed passed:
+out/test/spec/binary.wast:464: assert_malformed passed:
   000000e: error: data segment count does not equal count in DataCount section
-out/test/spec/binary.wast:1205: assert_malformed passed:
+out/test/spec/binary.wast:474: assert_malformed passed:
   0000024: error: memory.init requires data count section
-out/test/spec/binary.wast:1227: assert_malformed passed:
+out/test/spec/binary.wast:496: assert_malformed passed:
   000001e: error: data.drop requires data count section
-out/test/spec/binary.wast:1246: assert_malformed passed:
+out/test/spec/binary.wast:515: assert_malformed passed:
   0000024: error: unexpected opcode: 0xf3
-out/test/spec/binary.wast:1272: assert_malformed passed:
+out/test/spec/binary.wast:541: assert_malformed passed:
   0000022: error: table elem type must be a reference type
-out/test/spec/binary.wast:1353: assert_malformed passed:
+out/test/spec/binary.wast:622: assert_malformed passed:
   000000a: error: invalid section size: extends past end
-out/test/spec/binary.wast:1364: assert_malformed passed:
+out/test/spec/binary.wast:633: assert_malformed passed:
   000000e: error: unfinished section (expected end: 0x11)
-out/test/spec/binary.wast:1383: assert_malformed passed:
+out/test/spec/binary.wast:652: assert_malformed passed:
   000000e: error: invalid import tag kind: exceptions not allowed
-out/test/spec/binary.wast:1393: assert_malformed passed:
+out/test/spec/binary.wast:662: assert_malformed passed:
   000000e: error: invalid import tag kind: exceptions not allowed
-out/test/spec/binary.wast:1404: assert_malformed passed:
+out/test/spec/binary.wast:673: assert_malformed passed:
   000000e: error: malformed import kind: 5
-out/test/spec/binary.wast:1414: assert_malformed passed:
+out/test/spec/binary.wast:683: assert_malformed passed:
   000000e: error: malformed import kind: 5
-out/test/spec/binary.wast:1425: assert_malformed passed:
+out/test/spec/binary.wast:694: assert_malformed passed:
   000000e: error: malformed import kind: 128
-out/test/spec/binary.wast:1435: assert_malformed passed:
+out/test/spec/binary.wast:704: assert_malformed passed:
   000000e: error: malformed import kind: 128
-out/test/spec/binary.wast:1448: assert_malformed passed:
+out/test/spec/binary.wast:717: assert_malformed passed:
   0000027: error: unable to read u32 leb128: string length
-out/test/spec/binary.wast:1467: assert_malformed passed:
+out/test/spec/binary.wast:736: assert_malformed passed:
   000002b: error: unfinished section (expected end: 0x40)
-out/test/spec/binary.wast:1498: assert_malformed passed:
+out/test/spec/binary.wast:767: assert_malformed passed:
   000000b: error: invalid table count 1, only 0 bytes left in section
-out/test/spec/binary.wast:1508: assert_malformed passed:
+out/test/spec/binary.wast:777: assert_malformed passed:
   000000d: error: tables may not be shared
-out/test/spec/binary.wast:1517: assert_malformed passed:
+out/test/spec/binary.wast:786: assert_malformed passed:
   000000d: error: tables may not be shared
-out/test/spec/binary.wast:1527: assert_malformed passed:
+out/test/spec/binary.wast:796: assert_malformed passed:
   000000d: error: malformed table limits flag: 129
-out/test/spec/binary.wast:1545: assert_malformed passed:
+out/test/spec/binary.wast:814: assert_malformed passed:
   000000b: error: invalid memory count 1, only 0 bytes left in section
-out/test/spec/binary.wast:1555: assert_malformed passed:
+out/test/spec/binary.wast:824: assert_malformed passed:
   000000c: error: memory may not be shared: threads not allowed
-out/test/spec/binary.wast:1563: assert_malformed passed:
+out/test/spec/binary.wast:832: assert_malformed passed:
   000000c: error: memory may not be shared: threads not allowed
-out/test/spec/binary.wast:1572: assert_malformed passed:
+out/test/spec/binary.wast:841: assert_malformed passed:
   000000c: error: malformed memory limits flag: 129
-out/test/spec/binary.wast:1581: assert_malformed passed:
+out/test/spec/binary.wast:850: assert_malformed passed:
   000000c: error: malformed memory limits flag: 129
-out/test/spec/binary.wast:1598: assert_malformed passed:
+out/test/spec/binary.wast:867: assert_malformed passed:
   0000010: error: unable to read i32 leb128: global type
-out/test/spec/binary.wast:1609: assert_malformed passed:
+out/test/spec/binary.wast:878: assert_malformed passed:
   0000010: error: unfinished section (expected end: 0x15)
-out/test/spec/binary.wast:1632: assert_malformed passed:
+out/test/spec/binary.wast:901: assert_malformed passed:
   000001b: error: unable to read u32 leb128: string length
-out/test/spec/binary.wast:1653: assert_malformed passed:
+out/test/spec/binary.wast:922: assert_malformed passed:
   000001b: error: unfinished section (expected end: 0x20)
-out/test/spec/binary.wast:1687: assert_malformed passed:
+out/test/spec/binary.wast:956: assert_malformed passed:
   0000021: error: unable to read u32 leb128: elem segment flags
-out/test/spec/binary.wast:1703: assert_malformed passed:
+out/test/spec/binary.wast:972: assert_malformed passed:
   0000024: error: init expression must end with END opcode
-out/test/spec/binary.wast:1720: assert_malformed passed:
+out/test/spec/binary.wast:989: assert_malformed passed:
   0000021: error: unfinished section (expected end: 0x27)
-out/test/spec/binary.wast:1746: assert_malformed passed:
+out/test/spec/binary.wast:1015: assert_malformed passed:
   0000016: error: unable to read u32 leb128: data segment flags
-out/test/spec/binary.wast:1759: assert_malformed passed:
+out/test/spec/binary.wast:1028: assert_malformed passed:
   0000016: error: unfinished section (expected end: 0x1c)
-out/test/spec/binary.wast:1772: assert_malformed passed:
+out/test/spec/binary.wast:1041: assert_malformed passed:
   0000015: error: unable to read data: data segment data
-out/test/spec/binary.wast:1786: assert_malformed passed:
+out/test/spec/binary.wast:1055: assert_malformed passed:
   000001a: error: unfinished section (expected end: 0x1b)
-out/test/spec/binary.wast:1817: assert_malformed passed:
+out/test/spec/binary.wast:1086: assert_malformed passed:
   0000027: error: function body must end with END opcode
-out/test/spec/binary.wast:1852: assert_malformed passed:
+out/test/spec/binary.wast:1121: assert_malformed passed:
   0000017: error: multiple Start sections
-177/177 tests passed.
+112/112 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/br_table.txt
+++ b/test/spec/br_table.txt
@@ -1,76 +1,76 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/br_table.wast
 (;; STDOUT ;;;
-out/test/spec/br_table.wast:1442: assert_invalid passed:
+out/test/spec/br_table.wast:1193: assert_invalid passed:
   out/test/spec/br_table/br_table.1.wasm:0000022: error: type mismatch at end of block, expected [] but got [i32]
   0000022: error: OnEndExpr callback failed
-out/test/spec/br_table.wast:1449: assert_invalid passed:
+out/test/spec/br_table.wast:1200: assert_invalid passed:
   out/test/spec/br_table/br_table.2.wasm:000001d: error: type mismatch in br_table, expected [i32] but got []
   000001d: error: OnBrTableExpr callback failed
-out/test/spec/br_table.wast:1456: assert_invalid passed:
+out/test/spec/br_table.wast:1207: assert_invalid passed:
   out/test/spec/br_table/br_table.3.wasm:0000020: error: type mismatch in br_table, expected [i32] but got []
   0000020: error: OnBrTableExpr callback failed
-out/test/spec/br_table.wast:1462: assert_invalid passed:
+out/test/spec/br_table.wast:1213: assert_invalid passed:
   out/test/spec/br_table/br_table.4.wasm:0000023: error: type mismatch in br_table, expected [i32] but got [i64]
   0000023: error: OnBrTableExpr callback failed
-out/test/spec/br_table.wast:1470: assert_invalid passed:
+out/test/spec/br_table.wast:1221: assert_invalid passed:
   out/test/spec/br_table/br_table.5.wasm:0000026: error: br_table labels have inconsistent types: expected [f32], got []
   0000026: error: OnBrTableExpr callback failed
-out/test/spec/br_table.wast:1481: assert_invalid passed:
+out/test/spec/br_table.wast:1232: assert_invalid passed:
   out/test/spec/br_table/br_table.6.wasm:0000023: error: type mismatch in br_table, expected [i64] but got [i32]
   0000023: error: OnBrTableExpr callback failed
-out/test/spec/br_table.wast:1492: assert_invalid passed:
+out/test/spec/br_table.wast:1243: assert_invalid passed:
   out/test/spec/br_table/br_table.7.wasm:000001f: error: type mismatch in br_table, expected [i32] but got []
   000001f: error: OnBrTableExpr callback failed
-out/test/spec/br_table.wast:1498: assert_invalid passed:
+out/test/spec/br_table.wast:1249: assert_invalid passed:
   out/test/spec/br_table/br_table.8.wasm:000001e: error: type mismatch in br_table, expected [i32] but got [i64]
   000001e: error: OnBrTableExpr callback failed
-out/test/spec/br_table.wast:1504: assert_invalid passed:
+out/test/spec/br_table.wast:1255: assert_invalid passed:
   out/test/spec/br_table/br_table.9.wasm:0000021: error: type mismatch in br_table, expected [i32] but got []
   0000021: error: OnBrTableExpr callback failed
-out/test/spec/br_table.wast:1510: assert_invalid passed:
+out/test/spec/br_table.wast:1261: assert_invalid passed:
   out/test/spec/br_table/br_table.10.wasm:0000023: error: type mismatch in br_table, expected [i32] but got []
   0000023: error: OnBrTableExpr callback failed
-out/test/spec/br_table.wast:1516: assert_invalid passed:
+out/test/spec/br_table.wast:1267: assert_invalid passed:
   out/test/spec/br_table/br_table.11.wasm:0000022: error: type mismatch in br_table, expected [i32] but got [... i64]
   0000022: error: OnBrTableExpr callback failed
-out/test/spec/br_table.wast:1525: assert_invalid passed:
+out/test/spec/br_table.wast:1276: assert_invalid passed:
   out/test/spec/br_table/br_table.12.wasm:0000022: error: type mismatch at end of block, expected [] but got [i32]
   0000022: error: OnEndExpr callback failed
-out/test/spec/br_table.wast:1532: assert_invalid passed:
+out/test/spec/br_table.wast:1283: assert_invalid passed:
   out/test/spec/br_table/br_table.13.wasm:0000022: error: type mismatch in br_table, expected [i32] but got []
   0000022: error: OnBrTableExpr callback failed
-out/test/spec/br_table.wast:1544: assert_invalid passed:
+out/test/spec/br_table.wast:1295: assert_invalid passed:
   out/test/spec/br_table/br_table.14.wasm:0000024: error: type mismatch in br_table, expected [i32] but got []
   0000024: error: OnBrTableExpr callback failed
-out/test/spec/br_table.wast:1556: assert_invalid passed:
+out/test/spec/br_table.wast:1307: assert_invalid passed:
   out/test/spec/br_table/br_table.15.wasm:000001c: error: type mismatch in br_table, expected [i32] but got []
   000001c: error: OnBrTableExpr callback failed
-out/test/spec/br_table.wast:1567: assert_invalid passed:
+out/test/spec/br_table.wast:1318: assert_invalid passed:
   out/test/spec/br_table/br_table.16.wasm:000001e: error: type mismatch in br_table, expected [i32] but got []
   000001e: error: OnBrTableExpr callback failed
-out/test/spec/br_table.wast:1579: assert_invalid passed:
+out/test/spec/br_table.wast:1330: assert_invalid passed:
   out/test/spec/br_table/br_table.17.wasm:0000025: error: br_table labels have inconsistent types: expected [i32], got []
   0000025: error: OnBrTableExpr callback failed
-out/test/spec/br_table.wast:1591: assert_invalid passed:
+out/test/spec/br_table.wast:1342: assert_invalid passed:
   out/test/spec/br_table/br_table.18.wasm:0000025: error: br_table labels have inconsistent types: expected [], got [i32]
   0000025: error: OnBrTableExpr callback failed
-out/test/spec/br_table.wast:1605: assert_invalid passed:
+out/test/spec/br_table.wast:1356: assert_invalid passed:
   out/test/spec/br_table/br_table.19.wasm:000001f: error: invalid depth: 2 (max 1)
   000001f: error: OnBrTableExpr callback failed
-out/test/spec/br_table.wast:1611: assert_invalid passed:
+out/test/spec/br_table.wast:1362: assert_invalid passed:
   out/test/spec/br_table/br_table.20.wasm:0000021: error: invalid depth: 5 (max 2)
   0000021: error: OnBrTableExpr callback failed
-out/test/spec/br_table.wast:1617: assert_invalid passed:
+out/test/spec/br_table.wast:1368: assert_invalid passed:
   out/test/spec/br_table/br_table.21.wasm:0000024: error: invalid depth: 268435457 (max 1)
   0000024: error: OnBrTableExpr callback failed
-out/test/spec/br_table.wast:1624: assert_invalid passed:
+out/test/spec/br_table.wast:1375: assert_invalid passed:
   out/test/spec/br_table/br_table.22.wasm:000001f: error: invalid depth: 2 (max 1)
   000001f: error: OnBrTableExpr callback failed
-out/test/spec/br_table.wast:1630: assert_invalid passed:
+out/test/spec/br_table.wast:1381: assert_invalid passed:
   out/test/spec/br_table/br_table.23.wasm:0000021: error: invalid depth: 5 (max 2)
   0000021: error: OnBrTableExpr callback failed
-out/test/spec/br_table.wast:1636: assert_invalid passed:
+out/test/spec/br_table.wast:1387: assert_invalid passed:
   out/test/spec/br_table/br_table.24.wasm:0000024: error: invalid depth: 268435457 (max 1)
   0000024: error: OnBrTableExpr callback failed
 174/174 tests passed.

--- a/test/spec/elem.txt
+++ b/test/spec/elem.txt
@@ -85,5 +85,5 @@ out/test/spec/elem.wast:636: assert_invalid passed:
 out/test/spec/elem.wast:645: assert_invalid passed:
   out/test/spec/elem/elem.65.wasm:0000030: error: type mismatch at table.init. got externref, expected funcref
   0000030: error: OnTableInitExpr callback failed
-93/93 tests passed.
+96/96 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/exception-handling/binary.txt
+++ b/test/spec/exception-handling/binary.txt
@@ -68,217 +68,125 @@ out/test/spec/exception-handling/binary.wast:51: assert_malformed passed:
   000000a: error: invalid section code: 129
 out/test/spec/exception-handling/binary.wast:52: assert_malformed passed:
   000000a: error: invalid section code: 255
-out/test/spec/exception-handling/binary.wast:210: assert_malformed passed:
-  000000c: error: unexpected type form (got 0xe0)
-out/test/spec/exception-handling/binary.wast:223: assert_malformed passed:
-  000000c: error: unable to read u32 leb128: memory initial page count
-out/test/spec/exception-handling/binary.wast:233: assert_malformed passed:
-  000000e: error: unable to read i32 leb128: i32.const value
-out/test/spec/exception-handling/binary.wast:243: assert_malformed passed:
-  000000e: error: unable to read i32 leb128: i32.const value
-out/test/spec/exception-handling/binary.wast:254: assert_malformed passed:
-  000000e: error: unable to read i64 leb128: i64.const value
-out/test/spec/exception-handling/binary.wast:264: assert_malformed passed:
-  000000e: error: unable to read i64 leb128: i64.const value
-out/test/spec/exception-handling/binary.wast:276: assert_malformed passed:
-  000000c: error: unable to read u32 leb128: memory initial page count
-out/test/spec/exception-handling/binary.wast:284: assert_malformed passed:
-  000000c: error: unable to read u32 leb128: memory initial page count
-out/test/spec/exception-handling/binary.wast:294: assert_malformed passed:
-  000000e: error: unable to read i32 leb128: i32.const value
-out/test/spec/exception-handling/binary.wast:304: assert_malformed passed:
-  000000e: error: unable to read i32 leb128: i32.const value
-out/test/spec/exception-handling/binary.wast:314: assert_malformed passed:
-  000000e: error: unable to read i32 leb128: i32.const value
-out/test/spec/exception-handling/binary.wast:324: assert_malformed passed:
-  000000e: error: unable to read i32 leb128: i32.const value
-out/test/spec/exception-handling/binary.wast:335: assert_malformed passed:
-  000000e: error: unable to read i64 leb128: i64.const value
-out/test/spec/exception-handling/binary.wast:345: assert_malformed passed:
-  000000e: error: unable to read i64 leb128: i64.const value
-out/test/spec/exception-handling/binary.wast:355: assert_malformed passed:
-  000000e: error: unable to read i64 leb128: i64.const value
-out/test/spec/exception-handling/binary.wast:365: assert_malformed passed:
-  000000e: error: unable to read i64 leb128: i64.const value
-out/test/spec/exception-handling/binary.wast:376: assert_malformed passed:
-  000000e: error: unable to read i64 leb128: i64.const value
-out/test/spec/exception-handling/binary.wast:386: assert_malformed passed:
-  000000e: error: unable to read i64 leb128: i64.const value
-out/test/spec/exception-handling/binary.wast:396: assert_malformed passed:
-  000000e: error: unable to read i64 leb128: i64.const value
-out/test/spec/exception-handling/binary.wast:406: assert_malformed passed:
-  000000e: error: unable to read i64 leb128: i64.const value
-out/test/spec/exception-handling/binary.wast:418: assert_malformed passed:
+out/test/spec/exception-handling/binary.wast:56: assert_malformed passed:
   000001b: error: function body must end with END opcode
-out/test/spec/exception-handling/binary.wast:439: assert_malformed passed:
+out/test/spec/exception-handling/binary.wast:77: assert_malformed passed:
   000001a: error: function body must end with END opcode
-out/test/spec/exception-handling/binary.wast:455: assert_malformed passed:
+out/test/spec/exception-handling/binary.wast:93: assert_malformed passed:
   000001a: error: function body must end with END opcode
-out/test/spec/exception-handling/binary.wast:475: assert_malformed passed:
-  000000c: error: unable to read u32 leb128: memory initial page count
-out/test/spec/exception-handling/binary.wast:483: assert_malformed passed:
-  0000022: error: unable to read u32 leb128: load offset
-out/test/spec/exception-handling/binary.wast:502: assert_malformed passed:
-  0000021: error: unable to read u32 leb128: load alignment
-out/test/spec/exception-handling/binary.wast:521: assert_malformed passed:
-  0000023: error: unable to read u32 leb128: store alignment
-out/test/spec/exception-handling/binary.wast:540: assert_malformed passed:
-  0000024: error: unable to read u32 leb128: store offset
-out/test/spec/exception-handling/binary.wast:561: assert_malformed passed:
-  000000e: error: unable to read i32 leb128: i32.const value
-out/test/spec/exception-handling/binary.wast:571: assert_malformed passed:
-  000000e: error: unable to read i32 leb128: i32.const value
-out/test/spec/exception-handling/binary.wast:582: assert_malformed passed:
-  000000e: error: unable to read i64 leb128: i64.const value
-out/test/spec/exception-handling/binary.wast:592: assert_malformed passed:
-  000000e: error: unable to read i64 leb128: i64.const value
-out/test/spec/exception-handling/binary.wast:604: assert_malformed passed:
-  000000c: error: unable to read u32 leb128: memory initial page count
-out/test/spec/exception-handling/binary.wast:612: assert_malformed passed:
-  000000c: error: unable to read u32 leb128: memory initial page count
-out/test/spec/exception-handling/binary.wast:620: assert_malformed passed:
-  0000022: error: unable to read u32 leb128: load offset
-out/test/spec/exception-handling/binary.wast:639: assert_malformed passed:
-  0000022: error: unable to read u32 leb128: load offset
-out/test/spec/exception-handling/binary.wast:658: assert_malformed passed:
-  0000021: error: unable to read u32 leb128: load alignment
-out/test/spec/exception-handling/binary.wast:676: assert_malformed passed:
-  0000021: error: unable to read u32 leb128: load alignment
-out/test/spec/exception-handling/binary.wast:695: assert_malformed passed:
-  0000023: error: unable to read u32 leb128: store alignment
-out/test/spec/exception-handling/binary.wast:714: assert_malformed passed:
-  0000023: error: unable to read u32 leb128: store alignment
-out/test/spec/exception-handling/binary.wast:733: assert_malformed passed:
-  0000024: error: unable to read u32 leb128: store offset
-out/test/spec/exception-handling/binary.wast:752: assert_malformed passed:
-  0000024: error: unable to read u32 leb128: store offset
-out/test/spec/exception-handling/binary.wast:774: assert_malformed passed:
-  000000e: error: unable to read i32 leb128: i32.const value
-out/test/spec/exception-handling/binary.wast:784: assert_malformed passed:
-  000000e: error: unable to read i32 leb128: i32.const value
-out/test/spec/exception-handling/binary.wast:794: assert_malformed passed:
-  000000e: error: unable to read i32 leb128: i32.const value
-out/test/spec/exception-handling/binary.wast:804: assert_malformed passed:
-  000000e: error: unable to read i32 leb128: i32.const value
-out/test/spec/exception-handling/binary.wast:815: assert_malformed passed:
-  000000e: error: unable to read i64 leb128: i64.const value
-out/test/spec/exception-handling/binary.wast:825: assert_malformed passed:
-  000000e: error: unable to read i64 leb128: i64.const value
-out/test/spec/exception-handling/binary.wast:835: assert_malformed passed:
-  000000e: error: unable to read i64 leb128: i64.const value
-out/test/spec/exception-handling/binary.wast:845: assert_malformed passed:
-  000000e: error: unable to read i64 leb128: i64.const value
-out/test/spec/exception-handling/binary.wast:857: assert_malformed passed:
+out/test/spec/exception-handling/binary.wast:113: assert_malformed passed:
+  0000019: error: init expression must end with END opcode
+out/test/spec/exception-handling/binary.wast:126: assert_malformed passed:
   0000020: error: memory.grow reserved value must be 0
-out/test/spec/exception-handling/binary.wast:877: assert_malformed passed:
+out/test/spec/exception-handling/binary.wast:146: assert_malformed passed:
   0000020: error: memory.grow reserved value must be 0
-out/test/spec/exception-handling/binary.wast:897: assert_malformed passed:
+out/test/spec/exception-handling/binary.wast:166: assert_malformed passed:
   0000020: error: memory.grow reserved value must be 0
-out/test/spec/exception-handling/binary.wast:916: assert_malformed passed:
+out/test/spec/exception-handling/binary.wast:185: assert_malformed passed:
   0000020: error: memory.grow reserved value must be 0
-out/test/spec/exception-handling/binary.wast:935: assert_malformed passed:
+out/test/spec/exception-handling/binary.wast:204: assert_malformed passed:
   0000020: error: memory.grow reserved value must be 0
-out/test/spec/exception-handling/binary.wast:955: assert_malformed passed:
+out/test/spec/exception-handling/binary.wast:224: assert_malformed passed:
   000001e: error: memory.size reserved value must be 0
-out/test/spec/exception-handling/binary.wast:974: assert_malformed passed:
+out/test/spec/exception-handling/binary.wast:243: assert_malformed passed:
   000001e: error: memory.size reserved value must be 0
-out/test/spec/exception-handling/binary.wast:993: assert_malformed passed:
+out/test/spec/exception-handling/binary.wast:262: assert_malformed passed:
   000001e: error: memory.size reserved value must be 0
-out/test/spec/exception-handling/binary.wast:1011: assert_malformed passed:
+out/test/spec/exception-handling/binary.wast:280: assert_malformed passed:
   000001e: error: memory.size reserved value must be 0
-out/test/spec/exception-handling/binary.wast:1029: assert_malformed passed:
+out/test/spec/exception-handling/binary.wast:298: assert_malformed passed:
   000001e: error: memory.size reserved value must be 0
-out/test/spec/exception-handling/binary.wast:1048: assert_malformed passed:
+out/test/spec/exception-handling/binary.wast:317: assert_malformed passed:
   0000017: error: unable to read u32 leb128: local type count
-out/test/spec/exception-handling/binary.wast:1065: assert_malformed passed:
+out/test/spec/exception-handling/binary.wast:334: assert_malformed passed:
   0000017: error: unable to read u32 leb128: local type count
-out/test/spec/exception-handling/binary.wast:1082: assert_malformed passed:
+out/test/spec/exception-handling/binary.wast:351: assert_malformed passed:
   000001e: error: local count must be <= 0xffffffff
-out/test/spec/exception-handling/binary.wast:1098: assert_malformed passed:
+out/test/spec/exception-handling/binary.wast:367: assert_malformed passed:
   0000030: error: local count must be <= 0xffffffff
-out/test/spec/exception-handling/binary.wast:1132: assert_malformed passed:
+out/test/spec/exception-handling/binary.wast:401: assert_malformed passed:
   0000013: error: function signature count != function body count
-out/test/spec/exception-handling/binary.wast:1142: assert_malformed passed:
+out/test/spec/exception-handling/binary.wast:411: assert_malformed passed:
   000000b: error: function signature count != function body count
-out/test/spec/exception-handling/binary.wast:1151: assert_malformed passed:
+out/test/spec/exception-handling/binary.wast:420: assert_malformed passed:
   0000016: error: function signature count != function body count
-out/test/spec/exception-handling/binary.wast:1162: assert_malformed passed:
+out/test/spec/exception-handling/binary.wast:431: assert_malformed passed:
   0000015: error: function signature count != function body count
-out/test/spec/exception-handling/binary.wast:1185: assert_malformed passed:
+out/test/spec/exception-handling/binary.wast:454: assert_malformed passed:
   000000e: error: data segment count does not equal count in DataCount section
-out/test/spec/exception-handling/binary.wast:1195: assert_malformed passed:
+out/test/spec/exception-handling/binary.wast:464: assert_malformed passed:
   000000e: error: data segment count does not equal count in DataCount section
-out/test/spec/exception-handling/binary.wast:1205: assert_malformed passed:
+out/test/spec/exception-handling/binary.wast:474: assert_malformed passed:
   0000024: error: memory.init requires data count section
-out/test/spec/exception-handling/binary.wast:1227: assert_malformed passed:
+out/test/spec/exception-handling/binary.wast:496: assert_malformed passed:
   000001e: error: data.drop requires data count section
-out/test/spec/exception-handling/binary.wast:1246: assert_malformed passed:
+out/test/spec/exception-handling/binary.wast:515: assert_malformed passed:
   0000024: error: unexpected opcode: 0xf3
-out/test/spec/exception-handling/binary.wast:1272: assert_malformed passed:
+out/test/spec/exception-handling/binary.wast:541: assert_malformed passed:
   0000022: error: table elem type must be a reference type
-out/test/spec/exception-handling/binary.wast:1353: assert_malformed passed:
+out/test/spec/exception-handling/binary.wast:622: assert_malformed passed:
   000000a: error: invalid section size: extends past end
-out/test/spec/exception-handling/binary.wast:1364: assert_malformed passed:
+out/test/spec/exception-handling/binary.wast:633: assert_malformed passed:
   000000e: error: unfinished section (expected end: 0x11)
-out/test/spec/exception-handling/binary.wast:1383: assert_malformed passed:
+out/test/spec/exception-handling/binary.wast:652: assert_malformed passed:
   000000e: error: malformed import kind: 5
-out/test/spec/exception-handling/binary.wast:1393: assert_malformed passed:
+out/test/spec/exception-handling/binary.wast:662: assert_malformed passed:
   000000e: error: malformed import kind: 5
-out/test/spec/exception-handling/binary.wast:1404: assert_malformed passed:
+out/test/spec/exception-handling/binary.wast:673: assert_malformed passed:
   000000e: error: malformed import kind: 5
-out/test/spec/exception-handling/binary.wast:1414: assert_malformed passed:
+out/test/spec/exception-handling/binary.wast:683: assert_malformed passed:
   000000e: error: malformed import kind: 5
-out/test/spec/exception-handling/binary.wast:1425: assert_malformed passed:
+out/test/spec/exception-handling/binary.wast:694: assert_malformed passed:
   000000e: error: malformed import kind: 128
-out/test/spec/exception-handling/binary.wast:1435: assert_malformed passed:
+out/test/spec/exception-handling/binary.wast:704: assert_malformed passed:
   000000e: error: malformed import kind: 128
-out/test/spec/exception-handling/binary.wast:1448: assert_malformed passed:
+out/test/spec/exception-handling/binary.wast:717: assert_malformed passed:
   0000027: error: unable to read u32 leb128: string length
-out/test/spec/exception-handling/binary.wast:1467: assert_malformed passed:
+out/test/spec/exception-handling/binary.wast:736: assert_malformed passed:
   000002b: error: unfinished section (expected end: 0x40)
-out/test/spec/exception-handling/binary.wast:1498: assert_malformed passed:
+out/test/spec/exception-handling/binary.wast:767: assert_malformed passed:
   000000b: error: invalid table count 1, only 0 bytes left in section
-out/test/spec/exception-handling/binary.wast:1508: assert_malformed passed:
+out/test/spec/exception-handling/binary.wast:777: assert_malformed passed:
   000000d: error: tables may not be shared
-out/test/spec/exception-handling/binary.wast:1517: assert_malformed passed:
+out/test/spec/exception-handling/binary.wast:786: assert_malformed passed:
   000000d: error: tables may not be shared
-out/test/spec/exception-handling/binary.wast:1527: assert_malformed passed:
+out/test/spec/exception-handling/binary.wast:796: assert_malformed passed:
   000000d: error: malformed table limits flag: 129
-out/test/spec/exception-handling/binary.wast:1545: assert_malformed passed:
+out/test/spec/exception-handling/binary.wast:814: assert_malformed passed:
   000000b: error: invalid memory count 1, only 0 bytes left in section
-out/test/spec/exception-handling/binary.wast:1555: assert_malformed passed:
+out/test/spec/exception-handling/binary.wast:824: assert_malformed passed:
   000000c: error: memory may not be shared: threads not allowed
-out/test/spec/exception-handling/binary.wast:1563: assert_malformed passed:
+out/test/spec/exception-handling/binary.wast:832: assert_malformed passed:
   000000c: error: memory may not be shared: threads not allowed
-out/test/spec/exception-handling/binary.wast:1572: assert_malformed passed:
+out/test/spec/exception-handling/binary.wast:841: assert_malformed passed:
   000000c: error: malformed memory limits flag: 129
-out/test/spec/exception-handling/binary.wast:1581: assert_malformed passed:
+out/test/spec/exception-handling/binary.wast:850: assert_malformed passed:
   000000c: error: malformed memory limits flag: 129
-out/test/spec/exception-handling/binary.wast:1598: assert_malformed passed:
+out/test/spec/exception-handling/binary.wast:867: assert_malformed passed:
   0000010: error: unable to read i32 leb128: global type
-out/test/spec/exception-handling/binary.wast:1609: assert_malformed passed:
+out/test/spec/exception-handling/binary.wast:878: assert_malformed passed:
   0000010: error: unfinished section (expected end: 0x15)
-out/test/spec/exception-handling/binary.wast:1632: assert_malformed passed:
+out/test/spec/exception-handling/binary.wast:901: assert_malformed passed:
   000001b: error: unable to read u32 leb128: string length
-out/test/spec/exception-handling/binary.wast:1653: assert_malformed passed:
+out/test/spec/exception-handling/binary.wast:922: assert_malformed passed:
   000001b: error: unfinished section (expected end: 0x20)
-out/test/spec/exception-handling/binary.wast:1687: assert_malformed passed:
+out/test/spec/exception-handling/binary.wast:956: assert_malformed passed:
   0000021: error: unable to read u32 leb128: elem segment flags
-out/test/spec/exception-handling/binary.wast:1703: assert_malformed passed:
+out/test/spec/exception-handling/binary.wast:972: assert_malformed passed:
   0000024: error: init expression must end with END opcode
-out/test/spec/exception-handling/binary.wast:1720: assert_malformed passed:
+out/test/spec/exception-handling/binary.wast:989: assert_malformed passed:
   0000021: error: unfinished section (expected end: 0x27)
-out/test/spec/exception-handling/binary.wast:1746: assert_malformed passed:
+out/test/spec/exception-handling/binary.wast:1015: assert_malformed passed:
   0000016: error: unable to read u32 leb128: data segment flags
-out/test/spec/exception-handling/binary.wast:1759: assert_malformed passed:
+out/test/spec/exception-handling/binary.wast:1028: assert_malformed passed:
   0000016: error: unfinished section (expected end: 0x1c)
-out/test/spec/exception-handling/binary.wast:1772: assert_malformed passed:
+out/test/spec/exception-handling/binary.wast:1041: assert_malformed passed:
   0000015: error: unable to read data: data segment data
-out/test/spec/exception-handling/binary.wast:1786: assert_malformed passed:
+out/test/spec/exception-handling/binary.wast:1055: assert_malformed passed:
   000001a: error: unfinished section (expected end: 0x1b)
-out/test/spec/exception-handling/binary.wast:1817: assert_malformed passed:
+out/test/spec/exception-handling/binary.wast:1086: assert_malformed passed:
   0000027: error: function body must end with END opcode
-out/test/spec/exception-handling/binary.wast:1852: assert_malformed passed:
+out/test/spec/exception-handling/binary.wast:1121: assert_malformed passed:
   0000017: error: multiple Start sections
-177/177 tests passed.
+112/112 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/exception-handling/try_catch.txt
+++ b/test/spec/exception-handling/try_catch.txt
@@ -1,37 +1,39 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/proposals/exception-handling/try_catch.wast
-;;; ARGS*: --enable-exceptions
+;;; ARGS*: --enable-exceptions --enable-tail-call
 (;; STDOUT ;;;
-out/test/spec/exception-handling/try_catch.wast:157: assert_trap passed: unreachable executed
-out/test/spec/exception-handling/try_catch.wast:160: assert_trap passed: integer divide by zero
-out/test/spec/exception-handling/try_catch.wast:164: assert_exception passed
-out/test/spec/exception-handling/try_catch.wast:168: assert_exception passed
-out/test/spec/exception-handling/try_catch.wast:214: assert_malformed passed:
+out/test/spec/exception-handling/try_catch.wast:177: assert_trap passed: unreachable executed
+out/test/spec/exception-handling/try_catch.wast:180: assert_trap passed: integer divide by zero
+out/test/spec/exception-handling/try_catch.wast:184: assert_exception passed
+out/test/spec/exception-handling/try_catch.wast:188: assert_exception passed
+out/test/spec/exception-handling/try_catch.wast:211: assert_exception passed
+out/test/spec/exception-handling/try_catch.wast:212: assert_exception passed
+out/test/spec/exception-handling/try_catch.wast:237: assert_malformed passed:
   out/test/spec/exception-handling/try_catch/try_catch.3.wat:1:16: error: unexpected token "catch_all", expected an instr.
   (module (func (catch_all)))
                  ^^^^^^^^^
-out/test/spec/exception-handling/try_catch.wast:219: assert_malformed passed:
+out/test/spec/exception-handling/try_catch.wast:242: assert_malformed passed:
   out/test/spec/exception-handling/try_catch/try_catch.4.wat:1:25: error: unexpected token "catch", expected an instr.
   (module (tag $e) (func (catch $e)))
                           ^^^^^
-out/test/spec/exception-handling/try_catch.wast:224: assert_malformed passed:
+out/test/spec/exception-handling/try_catch.wast:247: assert_malformed passed:
   out/test/spec/exception-handling/try_catch/try_catch.5.wat:1:38: error: multiple catch_all clauses not allowed
   (module (func (try (do) (catch_all) (catch_all))))
                                        ^^^^^^^^^
-out/test/spec/exception-handling/try_catch.wast:230: assert_invalid passed:
+out/test/spec/exception-handling/try_catch.wast:253: assert_invalid passed:
   out/test/spec/exception-handling/try_catch/try_catch.6.wasm:000001b: error: type mismatch in try, expected [i32] but got []
   000001b: error: OnEndExpr callback failed
-out/test/spec/exception-handling/try_catch.wast:232: assert_invalid passed:
+out/test/spec/exception-handling/try_catch.wast:255: assert_invalid passed:
   out/test/spec/exception-handling/try_catch/try_catch.7.wasm:000001d: error: type mismatch in try, expected [i32] but got [i64]
   000001d: error: OnEndExpr callback failed
-out/test/spec/exception-handling/try_catch.wast:234: assert_invalid passed:
+out/test/spec/exception-handling/try_catch.wast:257: assert_invalid passed:
   out/test/spec/exception-handling/try_catch/try_catch.8.wasm:0000023: error: type mismatch at end of try catch, expected [] but got [i32]
   0000023: error: OnEndExpr callback failed
-out/test/spec/exception-handling/try_catch.wast:236: assert_invalid passed:
+out/test/spec/exception-handling/try_catch.wast:259: assert_invalid passed:
   out/test/spec/exception-handling/try_catch/try_catch.9.wasm:0000028: error: type mismatch in try catch, expected [i32] but got [i64]
   0000028: error: OnEndExpr callback failed
-out/test/spec/exception-handling/try_catch.wast:241: assert_invalid passed:
+out/test/spec/exception-handling/try_catch.wast:264: assert_invalid passed:
   out/test/spec/exception-handling/try_catch/try_catch.10.wasm:000001d: error: type mismatch at end of try catch, expected [] but got [i32]
   000001d: error: OnEndExpr callback failed
-38/38 tests passed.
+40/40 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/exception-handling/try_delegate.txt
+++ b/test/spec/exception-handling/try_delegate.txt
@@ -1,30 +1,32 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/proposals/exception-handling/try_delegate.wast
-;;; ARGS*: --enable-exceptions
+;;; ARGS*: --enable-exceptions --enable-tail-call
 (;; STDOUT ;;;
-out/test/spec/exception-handling/try_delegate.wast:125: assert_exception passed
-out/test/spec/exception-handling/try_delegate.wast:128: assert_exception passed
-out/test/spec/exception-handling/try_delegate.wast:130: assert_exception passed
-out/test/spec/exception-handling/try_delegate.wast:138: assert_exception passed
-out/test/spec/exception-handling/try_delegate.wast:139: assert_exception passed
-out/test/spec/exception-handling/try_delegate.wast:144: assert_malformed passed:
+out/test/spec/exception-handling/try_delegate.wast:155: assert_exception passed
+out/test/spec/exception-handling/try_delegate.wast:158: assert_exception passed
+out/test/spec/exception-handling/try_delegate.wast:160: assert_exception passed
+out/test/spec/exception-handling/try_delegate.wast:168: assert_exception passed
+out/test/spec/exception-handling/try_delegate.wast:169: assert_exception passed
+out/test/spec/exception-handling/try_delegate.wast:173: assert_exception passed
+out/test/spec/exception-handling/try_delegate.wast:174: assert_exception passed
+out/test/spec/exception-handling/try_delegate.wast:177: assert_malformed passed:
   out/test/spec/exception-handling/try_delegate/try_delegate.1.wat:1:16: error: unexpected token "delegate", expected an instr.
   (module (func (delegate 0)))
                  ^^^^^^^^
-out/test/spec/exception-handling/try_delegate.wast:149: assert_malformed passed:
+out/test/spec/exception-handling/try_delegate.wast:182: assert_malformed passed:
   out/test/spec/exception-handling/try_delegate/try_delegate.2.wat:1:46: error: unexpected token delegate, expected ).
   (module (tag $e) (func (try (do) (catch $e) (delegate 0))))
                                                ^^^^^^^^
-out/test/spec/exception-handling/try_delegate.wast:154: assert_malformed passed:
+out/test/spec/exception-handling/try_delegate.wast:187: assert_malformed passed:
   out/test/spec/exception-handling/try_delegate/try_delegate.3.wat:1:38: error: unexpected token delegate, expected ).
   (module (func (try (do) (catch_all) (delegate 0))))
                                        ^^^^^^^^
-out/test/spec/exception-handling/try_delegate.wast:159: assert_malformed passed:
+out/test/spec/exception-handling/try_delegate.wast:192: assert_malformed passed:
   out/test/spec/exception-handling/try_delegate/try_delegate.4.wat:1:34: error: unexpected token ")", expected a numeric index or a name (e.g. 12 or $foo).
   (module (func (try (do) (delegate) (delegate 0))))
                                    ^
-out/test/spec/exception-handling/try_delegate.wast:164: assert_invalid passed:
+out/test/spec/exception-handling/try_delegate.wast:197: assert_invalid passed:
   out/test/spec/exception-handling/try_delegate/try_delegate.5.wasm:000001b: error: invalid depth: 2 (max 1)
   000001b: error: OnDelegateExpr callback failed
-21/21 tests passed.
+23/23 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/extended-const/elem.txt
+++ b/test/spec/extended-const/elem.txt
@@ -86,5 +86,5 @@ out/test/spec/extended-const/elem.wast:637: assert_invalid passed:
 out/test/spec/extended-const/elem.wast:646: assert_invalid passed:
   out/test/spec/extended-const/elem/elem.65.wasm:0000030: error: type mismatch at table.init. got externref, expected funcref
   0000030: error: OnTableInitExpr callback failed
-93/93 tests passed.
+96/96 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/float_literals.txt
+++ b/test/spec/float_literals.txt
@@ -153,157 +153,165 @@ out/test/spec/float_literals.wast:352: assert_malformed passed:
   out/test/spec/float_literals/float_literals.39.wat:1:24: error: unexpected token "0x1.0p_+1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const 0x1.0p_+1))
                          ^^^^^^^^^
-out/test/spec/float_literals.wast:357: assert_malformed passed:
-  out/test/spec/float_literals/float_literals.40.wat:1:24: error: unexpected token "_100", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:356: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.40.wat:1:24: error: invalid literal "nan:0x80_0000"
+  (global f32 (f32.const nan:0x80_0000))
+                         ^^^^^^^^^^^^^
+out/test/spec/float_literals.wast:361: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.41.wat:1:24: error: unexpected token "_100", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const _100))
                          ^^^^
-out/test/spec/float_literals.wast:361: assert_malformed passed:
-  out/test/spec/float_literals/float_literals.41.wat:1:24: error: unexpected token "+_100", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:365: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.42.wat:1:24: error: unexpected token "+_100", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const +_100))
                          ^^^^^
-out/test/spec/float_literals.wast:365: assert_malformed passed:
-  out/test/spec/float_literals/float_literals.42.wat:1:24: error: unexpected token "-_100", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:369: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.43.wat:1:24: error: unexpected token "-_100", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const -_100))
                          ^^^^^
-out/test/spec/float_literals.wast:369: assert_malformed passed:
-  out/test/spec/float_literals/float_literals.43.wat:1:24: error: unexpected token "99_", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:373: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.44.wat:1:24: error: unexpected token "99_", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 99_))
                          ^^^
-out/test/spec/float_literals.wast:373: assert_malformed passed:
-  out/test/spec/float_literals/float_literals.44.wat:1:24: error: unexpected token "1__000", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:377: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.45.wat:1:24: error: unexpected token "1__000", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 1__000))
                          ^^^^^^
-out/test/spec/float_literals.wast:377: assert_malformed passed:
-  out/test/spec/float_literals/float_literals.45.wat:1:24: error: unexpected token "_1.0", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:381: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.46.wat:1:24: error: unexpected token "_1.0", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const _1.0))
                          ^^^^
-out/test/spec/float_literals.wast:381: assert_malformed passed:
-  out/test/spec/float_literals/float_literals.46.wat:1:24: error: unexpected token "1.0_", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:385: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.47.wat:1:24: error: unexpected token "1.0_", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 1.0_))
                          ^^^^
-out/test/spec/float_literals.wast:385: assert_malformed passed:
-  out/test/spec/float_literals/float_literals.47.wat:1:24: error: unexpected token "1_.0", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:389: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.48.wat:1:24: error: unexpected token "1_.0", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 1_.0))
                          ^^^^
-out/test/spec/float_literals.wast:389: assert_malformed passed:
-  out/test/spec/float_literals/float_literals.48.wat:1:24: error: unexpected token "1._0", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:393: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.49.wat:1:24: error: unexpected token "1._0", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 1._0))
                          ^^^^
-out/test/spec/float_literals.wast:393: assert_malformed passed:
-  out/test/spec/float_literals/float_literals.49.wat:1:24: error: unexpected token "_1e1", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:397: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.50.wat:1:24: error: unexpected token "_1e1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const _1e1))
                          ^^^^
-out/test/spec/float_literals.wast:397: assert_malformed passed:
-  out/test/spec/float_literals/float_literals.50.wat:1:24: error: unexpected token "1e1_", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:401: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.51.wat:1:24: error: unexpected token "1e1_", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 1e1_))
                          ^^^^
-out/test/spec/float_literals.wast:401: assert_malformed passed:
-  out/test/spec/float_literals/float_literals.51.wat:1:24: error: unexpected token "1_e1", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:405: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.52.wat:1:24: error: unexpected token "1_e1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 1_e1))
                          ^^^^
-out/test/spec/float_literals.wast:405: assert_malformed passed:
-  out/test/spec/float_literals/float_literals.52.wat:1:24: error: unexpected token "1e_1", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:409: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.53.wat:1:24: error: unexpected token "1e_1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 1e_1))
                          ^^^^
-out/test/spec/float_literals.wast:409: assert_malformed passed:
-  out/test/spec/float_literals/float_literals.53.wat:1:24: error: unexpected token "_1.0e1", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:413: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.54.wat:1:24: error: unexpected token "_1.0e1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const _1.0e1))
                          ^^^^^^
-out/test/spec/float_literals.wast:413: assert_malformed passed:
-  out/test/spec/float_literals/float_literals.54.wat:1:24: error: unexpected token "1.0e1_", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:417: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.55.wat:1:24: error: unexpected token "1.0e1_", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 1.0e1_))
                          ^^^^^^
-out/test/spec/float_literals.wast:417: assert_malformed passed:
-  out/test/spec/float_literals/float_literals.55.wat:1:24: error: unexpected token "1.0_e1", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:421: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.56.wat:1:24: error: unexpected token "1.0_e1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 1.0_e1))
                          ^^^^^^
-out/test/spec/float_literals.wast:421: assert_malformed passed:
-  out/test/spec/float_literals/float_literals.56.wat:1:24: error: unexpected token "1.0e_1", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:425: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.57.wat:1:24: error: unexpected token "1.0e_1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 1.0e_1))
                          ^^^^^^
-out/test/spec/float_literals.wast:425: assert_malformed passed:
-  out/test/spec/float_literals/float_literals.57.wat:1:24: error: unexpected token "1.0e+_1", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:429: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.58.wat:1:24: error: unexpected token "1.0e+_1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 1.0e+_1))
                          ^^^^^^^
-out/test/spec/float_literals.wast:429: assert_malformed passed:
-  out/test/spec/float_literals/float_literals.58.wat:1:24: error: unexpected token "1.0e_+1", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:433: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.59.wat:1:24: error: unexpected token "1.0e_+1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 1.0e_+1))
                          ^^^^^^^
-out/test/spec/float_literals.wast:433: assert_malformed passed:
-  out/test/spec/float_literals/float_literals.59.wat:1:24: error: unexpected token "_0x100", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:437: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.60.wat:1:24: error: unexpected token "_0x100", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const _0x100))
                          ^^^^^^
-out/test/spec/float_literals.wast:437: assert_malformed passed:
-  out/test/spec/float_literals/float_literals.60.wat:1:24: error: unexpected token "0_x100", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:441: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.61.wat:1:24: error: unexpected token "0_x100", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 0_x100))
                          ^^^^^^
-out/test/spec/float_literals.wast:441: assert_malformed passed:
-  out/test/spec/float_literals/float_literals.61.wat:1:24: error: unexpected token "0x_100", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:445: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.62.wat:1:24: error: unexpected token "0x_100", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 0x_100))
                          ^^^^^^
-out/test/spec/float_literals.wast:445: assert_malformed passed:
-  out/test/spec/float_literals/float_literals.62.wat:1:24: error: unexpected token "0x00_", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:449: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.63.wat:1:24: error: unexpected token "0x00_", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 0x00_))
                          ^^^^^
-out/test/spec/float_literals.wast:449: assert_malformed passed:
-  out/test/spec/float_literals/float_literals.63.wat:1:24: error: unexpected token "0xff__ffff", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:453: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.64.wat:1:24: error: unexpected token "0xff__ffff", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 0xff__ffff))
                          ^^^^^^^^^^
-out/test/spec/float_literals.wast:453: assert_malformed passed:
-  out/test/spec/float_literals/float_literals.64.wat:1:24: error: unexpected token "0x_1.0", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:457: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.65.wat:1:24: error: unexpected token "0x_1.0", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 0x_1.0))
                          ^^^^^^
-out/test/spec/float_literals.wast:457: assert_malformed passed:
-  out/test/spec/float_literals/float_literals.65.wat:1:24: error: unexpected token "0x1.0_", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:461: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.66.wat:1:24: error: unexpected token "0x1.0_", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 0x1.0_))
                          ^^^^^^
-out/test/spec/float_literals.wast:461: assert_malformed passed:
-  out/test/spec/float_literals/float_literals.66.wat:1:24: error: unexpected token "0x1_.0", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:465: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.67.wat:1:24: error: unexpected token "0x1_.0", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 0x1_.0))
                          ^^^^^^
-out/test/spec/float_literals.wast:465: assert_malformed passed:
-  out/test/spec/float_literals/float_literals.67.wat:1:24: error: unexpected token "0x1._0", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:469: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.68.wat:1:24: error: unexpected token "0x1._0", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 0x1._0))
                          ^^^^^^
-out/test/spec/float_literals.wast:469: assert_malformed passed:
-  out/test/spec/float_literals/float_literals.68.wat:1:24: error: unexpected token "0x_1p1", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:473: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.69.wat:1:24: error: unexpected token "0x_1p1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 0x_1p1))
                          ^^^^^^
-out/test/spec/float_literals.wast:473: assert_malformed passed:
-  out/test/spec/float_literals/float_literals.69.wat:1:24: error: unexpected token "0x1p1_", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:477: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.70.wat:1:24: error: unexpected token "0x1p1_", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 0x1p1_))
                          ^^^^^^
-out/test/spec/float_literals.wast:477: assert_malformed passed:
-  out/test/spec/float_literals/float_literals.70.wat:1:24: error: unexpected token "0x1_p1", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:481: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.71.wat:1:24: error: unexpected token "0x1_p1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 0x1_p1))
                          ^^^^^^
-out/test/spec/float_literals.wast:481: assert_malformed passed:
-  out/test/spec/float_literals/float_literals.71.wat:1:24: error: unexpected token "0x1p_1", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:485: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.72.wat:1:24: error: unexpected token "0x1p_1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 0x1p_1))
                          ^^^^^^
-out/test/spec/float_literals.wast:485: assert_malformed passed:
-  out/test/spec/float_literals/float_literals.72.wat:1:24: error: unexpected token "0x_1.0p1", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:489: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.73.wat:1:24: error: unexpected token "0x_1.0p1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 0x_1.0p1))
                          ^^^^^^^^
-out/test/spec/float_literals.wast:489: assert_malformed passed:
-  out/test/spec/float_literals/float_literals.73.wat:1:24: error: unexpected token "0x1.0p1_", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:493: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.74.wat:1:24: error: unexpected token "0x1.0p1_", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 0x1.0p1_))
                          ^^^^^^^^
-out/test/spec/float_literals.wast:493: assert_malformed passed:
-  out/test/spec/float_literals/float_literals.74.wat:1:24: error: unexpected token "0x1.0_p1", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:497: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.75.wat:1:24: error: unexpected token "0x1.0_p1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 0x1.0_p1))
                          ^^^^^^^^
-out/test/spec/float_literals.wast:497: assert_malformed passed:
-  out/test/spec/float_literals/float_literals.75.wat:1:24: error: unexpected token "0x1.0p_1", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:501: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.76.wat:1:24: error: unexpected token "0x1.0p_1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 0x1.0p_1))
                          ^^^^^^^^
-out/test/spec/float_literals.wast:501: assert_malformed passed:
-  out/test/spec/float_literals/float_literals.76.wat:1:24: error: unexpected token "0x1.0p+_1", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:505: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.77.wat:1:24: error: unexpected token "0x1.0p+_1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 0x1.0p+_1))
                          ^^^^^^^^^
-out/test/spec/float_literals.wast:505: assert_malformed passed:
-  out/test/spec/float_literals/float_literals.77.wat:1:24: error: unexpected token "0x1.0p_+1", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:509: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.78.wat:1:24: error: unexpected token "0x1.0p_+1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 0x1.0p_+1))
                          ^^^^^^^^^
-161/161 tests passed.
+out/test/spec/float_literals.wast:513: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.79.wat:1:24: error: invalid literal "nan:0x10_0000_0000_0000"
+  (global f64 (f64.const nan:0x10_0000_0000_0000))
+                         ^^^^^^^^^^^^^^^^^^^^^^^
+163/163 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/multi-memory/binary.txt
+++ b/test/spec/multi-memory/binary.txt
@@ -68,197 +68,105 @@ out/test/spec/multi-memory/binary.wast:51: assert_malformed passed:
   000000a: error: invalid section code: 129
 out/test/spec/multi-memory/binary.wast:52: assert_malformed passed:
   000000a: error: invalid section code: 255
-out/test/spec/multi-memory/binary.wast:210: assert_malformed passed:
-  000000c: error: unexpected type form (got 0xe0)
-out/test/spec/multi-memory/binary.wast:223: assert_malformed passed:
-  000000c: error: unable to read u32 leb128: memory initial page count
-out/test/spec/multi-memory/binary.wast:233: assert_malformed passed:
-  000000e: error: unable to read i32 leb128: i32.const value
-out/test/spec/multi-memory/binary.wast:243: assert_malformed passed:
-  000000e: error: unable to read i32 leb128: i32.const value
-out/test/spec/multi-memory/binary.wast:254: assert_malformed passed:
-  000000e: error: unable to read i64 leb128: i64.const value
-out/test/spec/multi-memory/binary.wast:264: assert_malformed passed:
-  000000e: error: unable to read i64 leb128: i64.const value
-out/test/spec/multi-memory/binary.wast:276: assert_malformed passed:
-  000000c: error: unable to read u32 leb128: memory initial page count
-out/test/spec/multi-memory/binary.wast:284: assert_malformed passed:
-  000000c: error: unable to read u32 leb128: memory initial page count
-out/test/spec/multi-memory/binary.wast:294: assert_malformed passed:
-  000000e: error: unable to read i32 leb128: i32.const value
-out/test/spec/multi-memory/binary.wast:304: assert_malformed passed:
-  000000e: error: unable to read i32 leb128: i32.const value
-out/test/spec/multi-memory/binary.wast:314: assert_malformed passed:
-  000000e: error: unable to read i32 leb128: i32.const value
-out/test/spec/multi-memory/binary.wast:324: assert_malformed passed:
-  000000e: error: unable to read i32 leb128: i32.const value
-out/test/spec/multi-memory/binary.wast:335: assert_malformed passed:
-  000000e: error: unable to read i64 leb128: i64.const value
-out/test/spec/multi-memory/binary.wast:345: assert_malformed passed:
-  000000e: error: unable to read i64 leb128: i64.const value
-out/test/spec/multi-memory/binary.wast:355: assert_malformed passed:
-  000000e: error: unable to read i64 leb128: i64.const value
-out/test/spec/multi-memory/binary.wast:365: assert_malformed passed:
-  000000e: error: unable to read i64 leb128: i64.const value
-out/test/spec/multi-memory/binary.wast:376: assert_malformed passed:
-  000000e: error: unable to read i64 leb128: i64.const value
-out/test/spec/multi-memory/binary.wast:386: assert_malformed passed:
-  000000e: error: unable to read i64 leb128: i64.const value
-out/test/spec/multi-memory/binary.wast:396: assert_malformed passed:
-  000000e: error: unable to read i64 leb128: i64.const value
-out/test/spec/multi-memory/binary.wast:406: assert_malformed passed:
-  000000e: error: unable to read i64 leb128: i64.const value
-out/test/spec/multi-memory/binary.wast:418: assert_malformed passed:
+out/test/spec/multi-memory/binary.wast:56: assert_malformed passed:
   000001b: error: function body must end with END opcode
-out/test/spec/multi-memory/binary.wast:439: assert_malformed passed:
+out/test/spec/multi-memory/binary.wast:77: assert_malformed passed:
   000001a: error: function body must end with END opcode
-out/test/spec/multi-memory/binary.wast:455: assert_malformed passed:
+out/test/spec/multi-memory/binary.wast:93: assert_malformed passed:
   000001a: error: function body must end with END opcode
-out/test/spec/multi-memory/binary.wast:475: assert_malformed passed:
-  000000c: error: unable to read u32 leb128: memory initial page count
-out/test/spec/multi-memory/binary.wast:483: assert_malformed passed:
-  0000022: error: unable to read u32 leb128: load offset
-out/test/spec/multi-memory/binary.wast:502: assert_malformed passed:
-  0000021: error: unable to read u32 leb128: load alignment
-out/test/spec/multi-memory/binary.wast:521: assert_malformed passed:
-  0000023: error: unable to read u32 leb128: store alignment
-out/test/spec/multi-memory/binary.wast:540: assert_malformed passed:
-  0000024: error: unable to read u32 leb128: store offset
-out/test/spec/multi-memory/binary.wast:561: assert_malformed passed:
-  000000e: error: unable to read i32 leb128: i32.const value
-out/test/spec/multi-memory/binary.wast:571: assert_malformed passed:
-  000000e: error: unable to read i32 leb128: i32.const value
-out/test/spec/multi-memory/binary.wast:582: assert_malformed passed:
-  000000e: error: unable to read i64 leb128: i64.const value
-out/test/spec/multi-memory/binary.wast:592: assert_malformed passed:
-  000000e: error: unable to read i64 leb128: i64.const value
-out/test/spec/multi-memory/binary.wast:604: assert_malformed passed:
-  000000c: error: unable to read u32 leb128: memory initial page count
-out/test/spec/multi-memory/binary.wast:612: assert_malformed passed:
-  000000c: error: unable to read u32 leb128: memory initial page count
-out/test/spec/multi-memory/binary.wast:620: assert_malformed passed:
-  0000022: error: unable to read u32 leb128: load offset
-out/test/spec/multi-memory/binary.wast:639: assert_malformed passed:
-  0000022: error: unable to read u32 leb128: load offset
-out/test/spec/multi-memory/binary.wast:658: assert_malformed passed:
-  0000021: error: unable to read u32 leb128: load alignment
-out/test/spec/multi-memory/binary.wast:676: assert_malformed passed:
-  0000021: error: unable to read u32 leb128: load alignment
-out/test/spec/multi-memory/binary.wast:695: assert_malformed passed:
-  0000023: error: unable to read u32 leb128: store alignment
-out/test/spec/multi-memory/binary.wast:714: assert_malformed passed:
-  0000023: error: unable to read u32 leb128: store alignment
-out/test/spec/multi-memory/binary.wast:733: assert_malformed passed:
-  0000024: error: unable to read u32 leb128: store offset
-out/test/spec/multi-memory/binary.wast:752: assert_malformed passed:
-  0000024: error: unable to read u32 leb128: store offset
-out/test/spec/multi-memory/binary.wast:774: assert_malformed passed:
-  000000e: error: unable to read i32 leb128: i32.const value
-out/test/spec/multi-memory/binary.wast:784: assert_malformed passed:
-  000000e: error: unable to read i32 leb128: i32.const value
-out/test/spec/multi-memory/binary.wast:794: assert_malformed passed:
-  000000e: error: unable to read i32 leb128: i32.const value
-out/test/spec/multi-memory/binary.wast:804: assert_malformed passed:
-  000000e: error: unable to read i32 leb128: i32.const value
-out/test/spec/multi-memory/binary.wast:815: assert_malformed passed:
-  000000e: error: unable to read i64 leb128: i64.const value
-out/test/spec/multi-memory/binary.wast:825: assert_malformed passed:
-  000000e: error: unable to read i64 leb128: i64.const value
-out/test/spec/multi-memory/binary.wast:835: assert_malformed passed:
-  000000e: error: unable to read i64 leb128: i64.const value
-out/test/spec/multi-memory/binary.wast:845: assert_malformed passed:
-  000000e: error: unable to read i64 leb128: i64.const value
-out/test/spec/multi-memory/binary.wast:857: assert_malformed passed:
+out/test/spec/multi-memory/binary.wast:113: assert_malformed passed:
+  0000019: error: init expression must end with END opcode
+out/test/spec/multi-memory/binary.wast:126: assert_malformed passed:
   0000017: error: unable to read u32 leb128: local type count
-out/test/spec/multi-memory/binary.wast:874: assert_malformed passed:
+out/test/spec/multi-memory/binary.wast:143: assert_malformed passed:
   0000017: error: unable to read u32 leb128: local type count
-out/test/spec/multi-memory/binary.wast:891: assert_malformed passed:
+out/test/spec/multi-memory/binary.wast:160: assert_malformed passed:
   000001e: error: local count must be <= 0xffffffff
-out/test/spec/multi-memory/binary.wast:907: assert_malformed passed:
+out/test/spec/multi-memory/binary.wast:176: assert_malformed passed:
   0000030: error: local count must be <= 0xffffffff
-out/test/spec/multi-memory/binary.wast:941: assert_malformed passed:
+out/test/spec/multi-memory/binary.wast:210: assert_malformed passed:
   0000013: error: function signature count != function body count
-out/test/spec/multi-memory/binary.wast:951: assert_malformed passed:
+out/test/spec/multi-memory/binary.wast:220: assert_malformed passed:
   000000b: error: function signature count != function body count
-out/test/spec/multi-memory/binary.wast:960: assert_malformed passed:
+out/test/spec/multi-memory/binary.wast:229: assert_malformed passed:
   0000016: error: function signature count != function body count
-out/test/spec/multi-memory/binary.wast:971: assert_malformed passed:
+out/test/spec/multi-memory/binary.wast:240: assert_malformed passed:
   0000015: error: function signature count != function body count
-out/test/spec/multi-memory/binary.wast:994: assert_malformed passed:
+out/test/spec/multi-memory/binary.wast:263: assert_malformed passed:
   000000e: error: data segment count does not equal count in DataCount section
-out/test/spec/multi-memory/binary.wast:1004: assert_malformed passed:
+out/test/spec/multi-memory/binary.wast:273: assert_malformed passed:
   000000e: error: data segment count does not equal count in DataCount section
-out/test/spec/multi-memory/binary.wast:1014: assert_malformed passed:
+out/test/spec/multi-memory/binary.wast:283: assert_malformed passed:
   0000024: error: memory.init requires data count section
-out/test/spec/multi-memory/binary.wast:1036: assert_malformed passed:
+out/test/spec/multi-memory/binary.wast:305: assert_malformed passed:
   000001e: error: data.drop requires data count section
-out/test/spec/multi-memory/binary.wast:1055: assert_malformed passed:
+out/test/spec/multi-memory/binary.wast:324: assert_malformed passed:
   0000024: error: unexpected opcode: 0xf3
-out/test/spec/multi-memory/binary.wast:1081: assert_malformed passed:
+out/test/spec/multi-memory/binary.wast:350: assert_malformed passed:
   0000022: error: table elem type must be a reference type
-out/test/spec/multi-memory/binary.wast:1162: assert_malformed passed:
+out/test/spec/multi-memory/binary.wast:431: assert_malformed passed:
   000000a: error: invalid section size: extends past end
-out/test/spec/multi-memory/binary.wast:1173: assert_malformed passed:
+out/test/spec/multi-memory/binary.wast:442: assert_malformed passed:
   000000e: error: unfinished section (expected end: 0x11)
-out/test/spec/multi-memory/binary.wast:1192: assert_malformed passed:
+out/test/spec/multi-memory/binary.wast:461: assert_malformed passed:
   000000e: error: invalid import tag kind: exceptions not allowed
-out/test/spec/multi-memory/binary.wast:1202: assert_malformed passed:
+out/test/spec/multi-memory/binary.wast:471: assert_malformed passed:
   000000e: error: invalid import tag kind: exceptions not allowed
-out/test/spec/multi-memory/binary.wast:1213: assert_malformed passed:
+out/test/spec/multi-memory/binary.wast:482: assert_malformed passed:
   000000e: error: malformed import kind: 5
-out/test/spec/multi-memory/binary.wast:1223: assert_malformed passed:
+out/test/spec/multi-memory/binary.wast:492: assert_malformed passed:
   000000e: error: malformed import kind: 5
-out/test/spec/multi-memory/binary.wast:1234: assert_malformed passed:
+out/test/spec/multi-memory/binary.wast:503: assert_malformed passed:
   000000e: error: malformed import kind: 128
-out/test/spec/multi-memory/binary.wast:1244: assert_malformed passed:
+out/test/spec/multi-memory/binary.wast:513: assert_malformed passed:
   000000e: error: malformed import kind: 128
-out/test/spec/multi-memory/binary.wast:1257: assert_malformed passed:
+out/test/spec/multi-memory/binary.wast:526: assert_malformed passed:
   0000027: error: unable to read u32 leb128: string length
-out/test/spec/multi-memory/binary.wast:1276: assert_malformed passed:
+out/test/spec/multi-memory/binary.wast:545: assert_malformed passed:
   000002b: error: unfinished section (expected end: 0x40)
-out/test/spec/multi-memory/binary.wast:1307: assert_malformed passed:
+out/test/spec/multi-memory/binary.wast:576: assert_malformed passed:
   000000b: error: invalid table count 1, only 0 bytes left in section
-out/test/spec/multi-memory/binary.wast:1317: assert_malformed passed:
+out/test/spec/multi-memory/binary.wast:586: assert_malformed passed:
   000000d: error: tables may not be shared
-out/test/spec/multi-memory/binary.wast:1326: assert_malformed passed:
+out/test/spec/multi-memory/binary.wast:595: assert_malformed passed:
   000000d: error: tables may not be shared
-out/test/spec/multi-memory/binary.wast:1336: assert_malformed passed:
+out/test/spec/multi-memory/binary.wast:605: assert_malformed passed:
   000000d: error: malformed table limits flag: 129
-out/test/spec/multi-memory/binary.wast:1354: assert_malformed passed:
+out/test/spec/multi-memory/binary.wast:623: assert_malformed passed:
   000000b: error: invalid memory count 1, only 0 bytes left in section
-out/test/spec/multi-memory/binary.wast:1364: assert_malformed passed:
+out/test/spec/multi-memory/binary.wast:633: assert_malformed passed:
   000000c: error: memory may not be shared: threads not allowed
-out/test/spec/multi-memory/binary.wast:1372: assert_malformed passed:
+out/test/spec/multi-memory/binary.wast:641: assert_malformed passed:
   000000c: error: memory may not be shared: threads not allowed
-out/test/spec/multi-memory/binary.wast:1381: assert_malformed passed:
+out/test/spec/multi-memory/binary.wast:650: assert_malformed passed:
   000000c: error: malformed memory limits flag: 129
-out/test/spec/multi-memory/binary.wast:1390: assert_malformed passed:
+out/test/spec/multi-memory/binary.wast:659: assert_malformed passed:
   000000c: error: malformed memory limits flag: 129
-out/test/spec/multi-memory/binary.wast:1407: assert_malformed passed:
+out/test/spec/multi-memory/binary.wast:676: assert_malformed passed:
   0000010: error: unable to read i32 leb128: global type
-out/test/spec/multi-memory/binary.wast:1418: assert_malformed passed:
+out/test/spec/multi-memory/binary.wast:687: assert_malformed passed:
   0000010: error: unfinished section (expected end: 0x15)
-out/test/spec/multi-memory/binary.wast:1441: assert_malformed passed:
+out/test/spec/multi-memory/binary.wast:710: assert_malformed passed:
   000001b: error: unable to read u32 leb128: string length
-out/test/spec/multi-memory/binary.wast:1462: assert_malformed passed:
+out/test/spec/multi-memory/binary.wast:731: assert_malformed passed:
   000001b: error: unfinished section (expected end: 0x20)
-out/test/spec/multi-memory/binary.wast:1496: assert_malformed passed:
+out/test/spec/multi-memory/binary.wast:765: assert_malformed passed:
   0000021: error: unable to read u32 leb128: elem segment flags
-out/test/spec/multi-memory/binary.wast:1512: assert_malformed passed:
+out/test/spec/multi-memory/binary.wast:781: assert_malformed passed:
   0000024: error: init expression must end with END opcode
-out/test/spec/multi-memory/binary.wast:1529: assert_malformed passed:
+out/test/spec/multi-memory/binary.wast:798: assert_malformed passed:
   0000021: error: unfinished section (expected end: 0x27)
-out/test/spec/multi-memory/binary.wast:1555: assert_malformed passed:
+out/test/spec/multi-memory/binary.wast:824: assert_malformed passed:
   0000016: error: unable to read u32 leb128: data segment flags
-out/test/spec/multi-memory/binary.wast:1568: assert_malformed passed:
+out/test/spec/multi-memory/binary.wast:837: assert_malformed passed:
   0000016: error: unfinished section (expected end: 0x1c)
-out/test/spec/multi-memory/binary.wast:1581: assert_malformed passed:
+out/test/spec/multi-memory/binary.wast:850: assert_malformed passed:
   0000015: error: unable to read data: data segment data
-out/test/spec/multi-memory/binary.wast:1595: assert_malformed passed:
+out/test/spec/multi-memory/binary.wast:864: assert_malformed passed:
   000001a: error: unfinished section (expected end: 0x1b)
-out/test/spec/multi-memory/binary.wast:1626: assert_malformed passed:
+out/test/spec/multi-memory/binary.wast:895: assert_malformed passed:
   0000027: error: function body must end with END opcode
-out/test/spec/multi-memory/binary.wast:1661: assert_malformed passed:
+out/test/spec/multi-memory/binary.wast:930: assert_malformed passed:
   0000017: error: multiple Start sections
-167/167 tests passed.
+102/102 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/multi-memory/memory_copy1.txt
+++ b/test/spec/multi-memory/memory_copy1.txt
@@ -1,0 +1,13 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/multi-memory/memory_copy1.wast
+;;; ARGS*: --enable-multi-memory
+(;; STDOUT ;;;
+copy(i32:10, i32:0, i32:4) =>
+copy(i32:65280, i32:0, i32:256) =>
+copy(i32:65024, i32:65280, i32:256) =>
+copy(i32:65536, i32:0, i32:0) =>
+copy(i32:0, i32:65536, i32:0) =>
+out/test/spec/multi-memory/memory_copy1.wast:37: assert_trap passed: out of bounds memory access: memory.copy out of bound
+out/test/spec/multi-memory/memory_copy1.wast:39: assert_trap passed: out of bounds memory access: memory.copy out of bound
+14/14 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/relaxed-simd/relaxed_laneselect.txt
+++ b/test/spec/relaxed-simd/relaxed_laneselect.txt
@@ -2,5 +2,5 @@
 ;;; STDIN_FILE: third_party/testsuite/proposals/relaxed-simd/relaxed_laneselect.wast
 ;;; ARGS*: --enable-relaxed-simd
 (;; STDOUT ;;;
-11/11 tests passed.
+12/12 tests passed.
 ;;; STDOUT ;;)

--- a/test/wasm2c/spec-multi-output/exception-handling/try_catch.txt
+++ b/test/wasm2c/spec-multi-output/exception-handling/try_catch.txt
@@ -1,6 +1,6 @@
 ;;; TOOL: run-spec-wasm2c
 ;;; STDIN_FILE: third_party/testsuite/proposals/exception-handling/try_catch.wast
-;;; ARGS*: --enable-exceptions --num-outputs=4
+;;; ARGS*: --enable-exceptions --enable-tail-call --num-outputs=4
 (;; STDOUT ;;;
-27/27 tests passed.
+29/29 tests passed.
 ;;; STDOUT ;;)

--- a/test/wasm2c/spec/elem.txt
+++ b/test/wasm2c/spec/elem.txt
@@ -1,5 +1,5 @@
 ;;; TOOL: run-spec-wasm2c
 ;;; STDIN_FILE: third_party/testsuite/elem.wast
 (;; STDOUT ;;;
-37/37 tests passed.
+38/38 tests passed.
 ;;; STDOUT ;;)

--- a/test/wasm2c/spec/exception-handling/try_catch.txt
+++ b/test/wasm2c/spec/exception-handling/try_catch.txt
@@ -1,6 +1,6 @@
 ;;; TOOL: run-spec-wasm2c
 ;;; STDIN_FILE: third_party/testsuite/proposals/exception-handling/try_catch.wast
-;;; ARGS*: --enable-exceptions
+;;; ARGS*: --enable-exceptions --enable-tail-call
 (;; STDOUT ;;;
-27/27 tests passed.
+29/29 tests passed.
 ;;; STDOUT ;;)

--- a/test/wasm2c/spec/exception-handling/try_delegate.txt
+++ b/test/wasm2c/spec/exception-handling/try_delegate.txt
@@ -1,6 +1,6 @@
 ;;; TOOL: run-spec-wasm2c
 ;;; STDIN_FILE: third_party/testsuite/proposals/exception-handling/try_delegate.wast
-;;; ARGS*: --enable-exceptions
+;;; ARGS*: --enable-exceptions --enable-tail-call
 (;; STDOUT ;;;
-15/15 tests passed.
+17/17 tests passed.
 ;;; STDOUT ;;)

--- a/test/wasm2c/spec/extended-const/elem.txt
+++ b/test/wasm2c/spec/extended-const/elem.txt
@@ -2,5 +2,5 @@
 ;;; STDIN_FILE: third_party/testsuite/proposals/extended-const/elem.wast
 ;;; ARGS*: --enable-extended-const
 (;; STDOUT ;;;
-37/37 tests passed.
+38/38 tests passed.
 ;;; STDOUT ;;)

--- a/test/wasm2c/spec/multi-memory/memory_copy1.txt
+++ b/test/wasm2c/spec/multi-memory/memory_copy1.txt
@@ -1,0 +1,6 @@
+;;; TOOL: run-spec-wasm2c
+;;; STDIN_FILE: third_party/testsuite/proposals/multi-memory/memory_copy1.wast
+;;; ARGS*: --enable-multi-memory
+(;; STDOUT ;;;
+8/8 tests passed.
+;;; STDOUT ;;)


### PR DESCRIPTION
Sequenced behind #2272.

This updates the testsuite. The major changes:

- The exception-handling tests now require tail-calls (tbd in #2272).
- There's a new test (memory_copy1 from multi-memory), which required #2294 (now merged).
- The elem tests now use global.get in an elem expr, which required #2288 (now merged).

(The only missing test is relaxed-simd/relaxed_dot_product.txt, which it looks like we believe is going away per #2115.)