### PR TITLE
Hash-pin GitHub Actions, add dependabot to keep them up-to-date

### DIFF
--- a/.github/actions/release-archive/action.yml
+++ b/.github/actions/release-archive/action.yml
@@ -25,13 +25,13 @@ runs:
         echo "::set-output name=shasum::$SHASUM"
 
     - name: upload tarball to CI
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
       with:
         name: ${{ steps.archive.outputs.tarball }}
         path: ./${{ steps.archive.outputs.tarball }}
 
     - name: upload tarball to release
-      uses: svenstaro/upload-release-action@v2
+      uses: svenstaro/upload-release-action@1beeb572c19a9242f4361f4cee78f8e0d9aec5df # v2.7.0
       if: ${{ inputs.upload_to_release }}
       with:
         file: ./${{ steps.archive.outputs.tarball }}
@@ -39,7 +39,7 @@ runs:
         tag: ${{ github.ref }}
 
     - name: upload shasum
-      uses: svenstaro/upload-release-action@v2
+      uses: svenstaro/upload-release-action@1beeb572c19a9242f4361f4cee78f8e0d9aec5df # v2.7.0
       if: ${{ inputs.upload_to_release }}
       with:
         file: ./${{ steps.archive.outputs.shasum }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+  - package-ecosystem: "github-actions"
+    directory: "/.github/actions/release-archive"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,8 @@ jobs:
       with:
         python-version: '3.x'
     - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+      with:
+        fetch-depth: 0
     - name: install tools
       run: |
         pip3 install flake8==3.7.8

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,10 +13,10 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/setup-python@v1
+    - uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4.7.0
       with:
         python-version: '3.x'
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
     - name: install tools
       run: |
         pip3 install flake8==3.7.8
@@ -32,10 +32,10 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-12, windows-latest]
     steps:
-    - uses: actions/setup-python@v1
+    - uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4.7.0
       with:
         python-version: '3.x'
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
       with:
         submodules: true
     - name: install ninja (linux)
@@ -71,7 +71,7 @@ jobs:
     name: emscripten
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
       with:
         submodules: true
     - name: build
@@ -84,7 +84,7 @@ jobs:
     name: wasi
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
         with:
           submodules: true
       - name: build-tools
@@ -108,10 +108,10 @@ jobs:
         sanitizer: [asan, ubsan, fuzz]
         type: [debug, release]
     steps:
-    - uses: actions/setup-python@v1
+    - uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4.7.0
       with:
         python-version: '3.x'
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
       with:
         submodules: true
     - run: sudo apt-get install ninja-build
@@ -126,10 +126,10 @@ jobs:
       CC: "clang" # used by the wasm2c tests
       WASM2C_CFLAGS: "-march=x86-64-v2 -fsanitize=address -DWASM_RT_USE_MMAP=0"
     steps:
-    - uses: actions/setup-python@v1
+    - uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4.7.0
       with:
         python-version: '3.x'
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
       with:
         submodules: true
     - run: sudo apt-get install ninja-build
@@ -140,10 +140,10 @@ jobs:
     name: min-cmake
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
       with:
         submodules: true
-    - uses: actions/setup-python@v1
+    - uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4.7.0
       with:
         python-version: '3.x'
     - name: Install Ninja

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -20,10 +20,10 @@ jobs:
       run:
         shell: bash
     steps:
-    - uses: actions/setup-python@v1
+    - uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4.7.0
       with:
         python-version: '3.x'
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
       with:
         submodules: true
 
@@ -66,7 +66,7 @@ jobs:
   build-wasi:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
       with:
         submodules: true
 

--- a/.github/workflows/build_source_release.yml
+++ b/.github/workflows/build_source_release.yml
@@ -14,11 +14,11 @@ jobs:
     name: build
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/setup-python@v1
+    - uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4.7.0
       with:
         python-version: '3.x'
 
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
       with:
         submodules: true
 
@@ -38,7 +38,7 @@ jobs:
         echo "::set-output name=shasum::$SHASUM"
 
     - name: upload tarball
-      uses: svenstaro/upload-release-action@v2
+      uses: svenstaro/upload-release-action@1beeb572c19a9242f4361f4cee78f8e0d9aec5df # v2.7.0
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
         file: ./${{ steps.archive.outputs.tarball }}
@@ -46,7 +46,7 @@ jobs:
         tag: ${{ github.ref }}
 
     - name: upload shasum
-      uses: svenstaro/upload-release-action@v2
+      uses: svenstaro/upload-release-action@1beeb572c19a9242f4361f4cee78f8e0d9aec5df # v2.7.0
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
         file: ./${{ steps.archive.outputs.shasum }}

--- a/.github/workflows/wabt-cifuzz.yml
+++ b/.github/workflows/wabt-cifuzz.yml
@@ -15,7 +15,7 @@ jobs:
         oss-fuzz-project-name: 'wabt'
         fuzz-seconds: 300
     - name: Upload Crash
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
       if: failure() && steps.build.outcome == 'success'
       with:
         name: artifacts


### PR DESCRIPTION
Fixes #2290.

This PR hash-pins all workflow GitHub Actions to protect the project from supply-chain threats. This includes the Actions used by the local `release-archive` Action.

The hashes (and corresponding version comments) will be updated by dependabot, which this PR also adds. I've configured dependabot to use the new grouped updates feature, so it'll send a single PR updating all GitHub Actions at once.

Or, well, if `actions/upload-artifact` and `svenstaro/release-upload-action` have new versions, it'll be two PRs: one for the `release-archive` Action and one for the workflows.