### PR TITLE
[wasm2c] Add '-Wno-array-bounds' when building wasm2c output

### DIFF
--- a/test/run-spec-wasm2c.py
+++ b/test/run-spec-wasm2c.py
@@ -460,6 +460,7 @@ def Compile(cc, c_filename, out_dir, *cflags):
         # (GCC also requires '-fsignaling-nans')
         args += ['-c', c_filename, '-o', o_filename, '-O2',
                  '-Wall', '-Werror', '-Wno-unused',
+                 '-Wno-array-bounds',
                  '-Wno-ignored-optimization-argument',
                  '-Wno-tautological-constant-out-of-range-compare',
                  '-Wno-infinite-recursion',


### PR DESCRIPTION
We are seeing some (spurious?) warning from gcc 12.2.

I've been seeing them locally, but they started to show up in CI as part of #2292.