### PR TITLE
Flip order of memory indexes on memory.copy per upstream

### DIFF
--- a/include/wabt/binary-reader-logging.h
+++ b/include/wabt/binary-reader-logging.h
@@ -200,7 +200,7 @@ class BinaryReaderLogging : public BinaryReaderDelegate {
   Result OnLocalSetExpr(Index local_index) override;
   Result OnLocalTeeExpr(Index local_index) override;
   Result OnLoopExpr(Type sig_type) override;
-  Result OnMemoryCopyExpr(Index srcmemidx, Index destmemidx) override;
+  Result OnMemoryCopyExpr(Index destmemidx, Index srcmemidx) override;
   Result OnDataDropExpr(Index segment_index) override;
   Result OnMemoryFillExpr(Index memidx) override;
   Result OnMemoryGrowExpr(Index memidx) override;

--- a/include/wabt/binary-reader-nop.h
+++ b/include/wabt/binary-reader-nop.h
@@ -273,7 +273,7 @@ class BinaryReaderNop : public BinaryReaderDelegate {
   Result OnLocalSetExpr(Index local_index) override { return Result::Ok; }
   Result OnLocalTeeExpr(Index local_index) override { return Result::Ok; }
   Result OnLoopExpr(Type sig_type) override { return Result::Ok; }
-  Result OnMemoryCopyExpr(Index srcmemidx, Index destmemidx) override {
+  Result OnMemoryCopyExpr(Index destmemidx, Index srcmemidx) override {
     return Result::Ok;
   }
   Result OnDataDropExpr(Index segment_index) override { return Result::Ok; }

--- a/include/wabt/binary-reader.h
+++ b/include/wabt/binary-reader.h
@@ -269,7 +269,7 @@ class BinaryReaderDelegate {
   virtual Result OnLocalSetExpr(Index local_index) = 0;
   virtual Result OnLocalTeeExpr(Index local_index) = 0;
   virtual Result OnLoopExpr(Type sig_type) = 0;
-  virtual Result OnMemoryCopyExpr(Index srcmemidx, Index destmemidx) = 0;
+  virtual Result OnMemoryCopyExpr(Index destmemidx, Index srcmemidx) = 0;
   virtual Result OnDataDropExpr(Index segment_index) = 0;
   virtual Result OnMemoryFillExpr(Index memidx) = 0;
   virtual Result OnMemoryGrowExpr(Index memidx) = 0;

--- a/include/wabt/ir.h
+++ b/include/wabt/ir.h
@@ -493,15 +493,15 @@ class MemoryExpr : public ExprMixin<TypeEnum> {
 template <ExprType TypeEnum>
 class MemoryBinaryExpr : public ExprMixin<TypeEnum> {
  public:
-  MemoryBinaryExpr(Var srcmemidx,
-                   Var destmemidx,
+  MemoryBinaryExpr(Var destmemidx,
+                   Var srcmemidx,
                    const Location& loc = Location())
       : ExprMixin<TypeEnum>(loc),
-        srcmemidx(srcmemidx),
-        destmemidx(destmemidx) {}
+        destmemidx(destmemidx),
+        srcmemidx(srcmemidx) {}
 
-  Var srcmemidx;
   Var destmemidx;
+  Var srcmemidx;
 };
 
 using DropExpr = ExprMixin<ExprType::Drop>;

--- a/include/wabt/shared-validator.h
+++ b/include/wabt/shared-validator.h
@@ -169,7 +169,7 @@ class SharedValidator {
   Result OnLocalSet(const Location&, Var);
   Result OnLocalTee(const Location&, Var);
   Result OnLoop(const Location&, Type sig_type);
-  Result OnMemoryCopy(const Location&, Var srcmemidx, Var destmemidx);
+  Result OnMemoryCopy(const Location&, Var destmemidx, Var srcmemidx);
   Result OnMemoryFill(const Location&, Var memidx);
   Result OnMemoryGrow(const Location&, Var memidx);
   Result OnMemoryInit(const Location&, Var segment_var, Var memidx);

--- a/include/wabt/type-checker.h
+++ b/include/wabt/type-checker.h
@@ -99,7 +99,7 @@ class TypeChecker {
   Result OnLocalSet(Type);
   Result OnLocalTee(Type);
   Result OnLoop(const TypeVector& param_types, const TypeVector& result_types);
-  Result OnMemoryCopy(const Limits& srclimits, const Limits& dstlimits);
+  Result OnMemoryCopy(const Limits& dstlimits, const Limits& srclimits);
   Result OnDataDrop(Index);
   Result OnMemoryFill(const Limits& limits);
   Result OnMemoryGrow(const Limits& limits);

--- a/src/apply-names.cc
+++ b/src/apply-names.cc
@@ -263,8 +263,8 @@ Result NameApplier::OnDataDropExpr(DataDropExpr* expr) {
 }
 
 Result NameApplier::OnMemoryCopyExpr(MemoryCopyExpr* expr) {
-  CHECK_RESULT(UseNameForMemoryVar(&expr->srcmemidx));
   CHECK_RESULT(UseNameForMemoryVar(&expr->destmemidx));
+  CHECK_RESULT(UseNameForMemoryVar(&expr->srcmemidx));
   return Result::Ok;
 }
 

--- a/src/binary-reader-ir.cc
+++ b/src/binary-reader-ir.cc
@@ -229,7 +229,7 @@ class BinaryReaderIR : public BinaryReaderNop {
   Result OnLocalSetExpr(Index local_index) override;
   Result OnLocalTeeExpr(Index local_index) override;
   Result OnLoopExpr(Type sig_type) override;
-  Result OnMemoryCopyExpr(Index srcmemidx, Index destmemidx) override;
+  Result OnMemoryCopyExpr(Index destmemidx, Index srcmemidx) override;
   Result OnDataDropExpr(Index segment_index) override;
   Result OnMemoryFillExpr(Index memidx) override;
   Result OnMemoryGrowExpr(Index memidx) override;
@@ -1024,9 +1024,9 @@ Result BinaryReaderIR::OnLoopExpr(Type sig_type) {
   return PushLabel(LabelType::Loop, expr_list);
 }
 
-Result BinaryReaderIR::OnMemoryCopyExpr(Index srcmemidx, Index destmemidx) {
+Result BinaryReaderIR::OnMemoryCopyExpr(Index destmemidx, Index srcmemidx) {
   return AppendExpr(std::make_unique<MemoryCopyExpr>(
-      Var(srcmemidx, GetLocation()), Var(destmemidx, GetLocation())));
+      Var(destmemidx, GetLocation()), Var(srcmemidx, GetLocation())));
 }
 
 Result BinaryReaderIR::OnDataDropExpr(Index segment) {

--- a/src/binary-reader-logging.cc
+++ b/src/binary-reader-logging.cc
@@ -811,7 +811,7 @@ DEFINE_LOAD_STORE_OPCODE(OnLoadExpr);
 DEFINE_INDEX_DESC(OnLocalGetExpr, "index")
 DEFINE_INDEX_DESC(OnLocalSetExpr, "index")
 DEFINE_INDEX_DESC(OnLocalTeeExpr, "index")
-DEFINE_INDEX_INDEX(OnMemoryCopyExpr, "src_memory_index", "dest_memory_index")
+DEFINE_INDEX_INDEX(OnMemoryCopyExpr, "dest_memory_index", "src_memory_index")
 DEFINE_INDEX(OnDataDropExpr)
 DEFINE_INDEX(OnMemoryFillExpr)
 DEFINE_INDEX(OnMemoryGrowExpr)

--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -1740,8 +1740,8 @@ Result BinaryReader::ReadInstructions(Offset end_offset, const char* context) {
       }
 
       case Opcode::MemoryCopy: {
-        Index srcmemidx = 0;
         Index destmemidx = 0;
+        Index srcmemidx = 0;
         if (!options_.features.multi_memory_enabled()) {
           uint8_t reserved;
           CHECK_RESULT(ReadU8(&reserved, "reserved memory index"));
@@ -1749,11 +1749,11 @@ Result BinaryReader::ReadInstructions(Offset end_offset, const char* context) {
           CHECK_RESULT(ReadU8(&reserved, "reserved memory index"));
           ERROR_UNLESS(reserved == 0, "reserved value must be 0");
         } else {
-          CHECK_RESULT(ReadMemidx(&srcmemidx, "memory.copy srcmemidx"));
           CHECK_RESULT(ReadMemidx(&destmemidx, "memory.copy destmemindex"));
+          CHECK_RESULT(ReadMemidx(&srcmemidx, "memory.copy srcmemidx"));
         }
-        CALLBACK(OnMemoryCopyExpr, srcmemidx, destmemidx);
-        CALLBACK(OnOpcodeUint32Uint32, srcmemidx, destmemidx);
+        CALLBACK(OnMemoryCopyExpr, destmemidx, srcmemidx);
+        CALLBACK(OnOpcodeUint32Uint32, destmemidx, srcmemidx);
         break;
       }
 

--- a/src/binary-writer.cc
+++ b/src/binary-writer.cc
@@ -893,13 +893,13 @@ void BinaryWriter::WriteExpr(const Func* func, const Expr* expr) {
       WriteOpcode(stream_, Opcode::End);
       break;
     case ExprType::MemoryCopy: {
-      Index srcmemidx =
-          module_->GetMemoryIndex(cast<MemoryCopyExpr>(expr)->srcmemidx);
       Index destmemidx =
           module_->GetMemoryIndex(cast<MemoryCopyExpr>(expr)->destmemidx);
+      Index srcmemidx =
+          module_->GetMemoryIndex(cast<MemoryCopyExpr>(expr)->srcmemidx);
       WriteOpcode(stream_, Opcode::MemoryCopy);
-      WriteU32Leb128(stream_, srcmemidx, "memory.copy srcmemidx");
       WriteU32Leb128(stream_, destmemidx, "memory.copy destmemidx");
+      WriteU32Leb128(stream_, srcmemidx, "memory.copy srcmemidx");
       break;
     }
     case ExprType::DataDrop: {

--- a/src/interp/binary-reader-interp.cc
+++ b/src/interp/binary-reader-interp.cc
@@ -209,7 +209,7 @@ class BinaryReaderInterp : public BinaryReaderNop {
   Result OnLocalSetExpr(Index local_index) override;
   Result OnLocalTeeExpr(Index local_index) override;
   Result OnLoopExpr(Type sig_type) override;
-  Result OnMemoryCopyExpr(Index srcmemidx, Index destmemidx) override;
+  Result OnMemoryCopyExpr(Index destmemidx, Index srcmemidx) override;
   Result OnDataDropExpr(Index segment_index) override;
   Result OnMemoryGrowExpr(Index memidx) override;
   Result OnMemoryFillExpr(Index memidx) override;
@@ -1417,11 +1417,11 @@ Result BinaryReaderInterp::OnAtomicNotifyExpr(Opcode opcode,
   return Result::Ok;
 }
 
-Result BinaryReaderInterp::OnMemoryCopyExpr(Index srcmemidx, Index destmemidx) {
+Result BinaryReaderInterp::OnMemoryCopyExpr(Index destmemidx, Index srcmemidx) {
   CHECK_RESULT(validator_.OnMemoryCopy(GetLocation(),
-                                       Var(srcmemidx, GetLocation()),
-                                       Var(destmemidx, GetLocation())));
-  istream_.Emit(Opcode::MemoryCopy, srcmemidx, destmemidx);
+                                       Var(destmemidx, GetLocation()),
+                                       Var(srcmemidx, GetLocation())));
+  istream_.Emit(Opcode::MemoryCopy, destmemidx, srcmemidx);
   return Result::Ok;
 }
 

--- a/src/resolve-names.cc
+++ b/src/resolve-names.cc
@@ -348,8 +348,8 @@ Result NameResolver::OnLocalTeeExpr(LocalTeeExpr* expr) {
 }
 
 Result NameResolver::OnMemoryCopyExpr(MemoryCopyExpr* expr) {
-  ResolveMemoryVar(&expr->srcmemidx);
   ResolveMemoryVar(&expr->destmemidx);
+  ResolveMemoryVar(&expr->srcmemidx);
   return Result::Ok;
 }
 

--- a/src/shared-validator.cc
+++ b/src/shared-validator.cc
@@ -928,14 +928,14 @@ Result SharedValidator::OnLoop(const Location& loc, Type sig_type) {
 }
 
 Result SharedValidator::OnMemoryCopy(const Location& loc,
-                                     Var srcmemidx,
-                                     Var destmemidx) {
+                                     Var destmemidx,
+                                     Var srcmemidx) {
   Result result = CheckInstr(Opcode::MemoryCopy, loc);
   MemoryType srcmt;
   MemoryType dstmt;
-  result |= CheckMemoryIndex(srcmemidx, &srcmt);
   result |= CheckMemoryIndex(destmemidx, &dstmt);
-  result |= typechecker_.OnMemoryCopy(srcmt.limits, dstmt.limits);
+  result |= CheckMemoryIndex(srcmemidx, &srcmt);
+  result |= typechecker_.OnMemoryCopy(dstmt.limits, srcmt.limits);
   return result;
 }
 

--- a/src/type-checker.cc
+++ b/src/type-checker.cc
@@ -705,15 +705,15 @@ Result TypeChecker::OnLoop(const TypeVector& param_types,
   return result;
 }
 
-Result TypeChecker::OnMemoryCopy(const Limits& src_limits,
-                                 const Limits& dst_limits) {
+Result TypeChecker::OnMemoryCopy(const Limits& dst_limits,
+                                 const Limits& src_limits) {
   Limits size_limits = src_limits;
   // The memory64 proposal specifies that the type of the size argument should
   // be the mimimum of the two memory types.
   if (src_limits.is_64 && !dst_limits.is_64) {
     size_limits = dst_limits;
   }
-  return CheckOpcode3(Opcode::MemoryCopy, &src_limits, &dst_limits,
+  return CheckOpcode3(Opcode::MemoryCopy, &dst_limits, &src_limits,
                       &size_limits);
 }
 

--- a/src/validator.cc
+++ b/src/validator.cc
@@ -414,7 +414,7 @@ Result Validator::EndLoopExpr(LoopExpr* expr) {
 
 Result Validator::OnMemoryCopyExpr(MemoryCopyExpr* expr) {
   result_ |=
-      validator_.OnMemoryCopy(expr->loc, expr->srcmemidx, expr->destmemidx);
+      validator_.OnMemoryCopy(expr->loc, expr->destmemidx, expr->srcmemidx);
   return Result::Ok;
 }
 

--- a/src/wast-parser.cc
+++ b/src/wast-parser.cc
@@ -2076,11 +2076,11 @@ Result WastParser::ParseMemoryExpr(Location loc,
 template <typename T>
 Result WastParser::ParseMemoryBinaryExpr(Location loc,
                                          std::unique_ptr<Expr>* out_expr) {
-  Var srcmemidx;
   Var destmemidx;
-  CHECK_RESULT(ParseMemidx(loc, &srcmemidx));
+  Var srcmemidx;
   CHECK_RESULT(ParseMemidx(loc, &destmemidx));
-  out_expr->reset(new T(srcmemidx, destmemidx, loc));
+  CHECK_RESULT(ParseMemidx(loc, &srcmemidx));
+  out_expr->reset(new T(destmemidx, srcmemidx, loc));
   return Result::Ok;
 }
 

--- a/src/wat-writer.cc
+++ b/src/wat-writer.cc
@@ -784,7 +784,7 @@ Result WatWriter::ExprVisitorDelegate::EndLoopExpr(LoopExpr* expr) {
 
 Result WatWriter::ExprVisitorDelegate::OnMemoryCopyExpr(MemoryCopyExpr* expr) {
   writer_->WritePutsSpace(Opcode::MemoryCopy_Opcode.GetName());
-  writer_->WriteTwoMemoryVarsUnlessBothZero(expr->srcmemidx, expr->destmemidx,
+  writer_->WriteTwoMemoryVarsUnlessBothZero(expr->destmemidx, expr->srcmemidx,
                                             NextChar::Space);
   writer_->WriteNewline(NO_FORCE_NEWLINE);
   return Result::Ok;


### PR DESCRIPTION
The multi-memory proposal flipped the order of memory indexes on memory.copy (https://github.com/WebAssembly/multi-memory/pull/29). This will be necessary to update the testsuite (#2287).
