### PR TITLE
write invalid names using `@name` annotation

### DIFF
--- a/include/wabt/wast-parser.h
+++ b/include/wabt/wast-parser.h
@@ -164,7 +164,7 @@ class WastParser {
   Result ParseTableModuleField(Module*);
 
   Result ParseCustomSectionAnnotation(Module*);
-  bool PeekIsCustom();
+  bool PeekIsAnnotation(const char* name);
 
   Result ParseExportDesc(Export*);
   Result ParseInlineExports(ModuleFieldList*, ExternalKind);

--- a/src/wast-parser.cc
+++ b/src/wast-parser.cc
@@ -608,7 +608,7 @@ TokenType WastParser::Peek(size_t n) {
       }
       if ((options_->features.code_metadata_enabled() &&
            cur.text().find("metadata.code.") == 0) ||
-          cur.text() == "custom") {
+          cur.text() == "custom" || cur.text() == "name") {
         tokens_.push_back(cur);
         continue;
       }
@@ -762,6 +762,13 @@ Result WastParser::ErrorIfLpar(const std::vector<std::string>& expected,
 
 bool WastParser::ParseBindVarOpt(std::string* name) {
   WABT_TRACE(ParseBindVarOpt);
+  if (PeekIsAnnotation("name")) {
+    // Should be the @name
+    Consume();
+    CHECK_RESULT(ParseQuotedText(name));
+    EXPECT(Rpar);
+    return true;
+  }
   if (!PeekMatch(TokenType::Var)) {
     return false;
   }
@@ -1174,7 +1181,7 @@ Result WastParser::ParseModule(std::unique_ptr<Module>* out_module) {
       auto module_command = cast<ScriptModuleCommand>(std::move(command));
       *module = std::move(module_command->module);
     }
-  } else if (IsModuleField(PeekPair()) || PeekIsCustom()) {
+  } else if (IsModuleField(PeekPair()) || PeekIsAnnotation("custom")) {
     // Parse an inline module (i.e. one with no surrounding (module)).
     CHECK_RESULT(ParseModuleFieldList(module.get()));
   } else if (PeekMatch(TokenType::Eof)) {
@@ -1200,7 +1207,7 @@ Result WastParser::ParseScript(std::unique_ptr<Script>* out_script) {
   // Don't consume the Lpar yet, even though it is required. This way the
   // sub-parser functions (e.g. ParseFuncModuleField) can consume it and keep
   // the parsing structure more regular.
-  if (IsModuleField(PeekPair()) || PeekIsCustom()) {
+  if (IsModuleField(PeekPair()) || PeekIsAnnotation("custom")) {
     // Parse an inline module (i.e. one with no surrounding (module)).
     auto command = std::make_unique<ModuleCommand>();
     command->module.loc = GetLocation();
@@ -1273,17 +1280,17 @@ Result WastParser::ParseCustomSectionAnnotation(Module* module) {
   return Result::Ok;
 }
 
-bool WastParser::PeekIsCustom() {
+bool WastParser::PeekIsAnnotation(const char* name) {
   // If IsLparAnn succeeds, tokens_.front() must have text, as it is an LparAnn
   // token.
   return options_->features.annotations_enabled() && IsLparAnn(PeekPair()) &&
-         tokens_.front().text() == "custom";
+         tokens_.front().text() == name;
 }
 
 Result WastParser::ParseModuleFieldList(Module* module) {
   WABT_TRACE(ParseModuleFieldList);
-  while (IsModuleField(PeekPair()) || PeekIsCustom()) {
-    if (PeekIsCustom()) {
+  while (IsModuleField(PeekPair()) || PeekIsAnnotation("custom")) {
+    if (PeekIsAnnotation("custom")) {
       CHECK_RESULT(ParseCustomSectionAnnotation(module));
       continue;
     }
@@ -3589,7 +3596,7 @@ Result WastParser::ParseScriptModule(
       auto tsm = std::make_unique<TextScriptModule>();
       tsm->module.name = name;
       tsm->module.loc = loc;
-      if (IsModuleField(PeekPair()) || PeekIsCustom()) {
+      if (IsModuleField(PeekPair()) || PeekIsAnnotation("custom")) {
         CHECK_RESULT(ParseModuleFieldList(&tsm->module));
       } else if (!PeekMatch(TokenType::Rpar)) {
         ConsumeIfLpar();

--- a/src/wat-writer.cc
+++ b/src/wat-writer.cc
@@ -164,6 +164,7 @@ class WatWriter : ModuleContext {
   void WriteTypeEntry(const TypeEntry& type);
   void WriteField(const Field& field);
   void WriteStartFunction(const Var& start);
+  void WriteOpenAnnotation(const char* name);
   void WriteCustom(const Custom& custom);
 
   class ExprVisitorDelegate;
@@ -284,6 +285,11 @@ void WatWriter::WriteOpen(const char* name, NextChar next_char) {
   Indent();
 }
 
+void WatWriter::WriteOpenAnnotation(const char* name) {
+  WriteOpen("@", NextChar::None);
+  WritePutsSpace(name);
+}
+
 void WatWriter::WriteOpenNewline(const char* name) {
   WriteOpen(name, NextChar::Newline);
 }
@@ -319,10 +325,9 @@ void WatWriter::WriteName(std::string_view str, NextChar next_char) {
       str.begin(), str.end(), [](uint8_t c) { return !s_valid_name_chars[c]; });
 
   if (has_invalid_chars) {
-    std::string valid_str;
-    std::transform(str.begin(), str.end(), std::back_inserter(valid_str),
-                   [](uint8_t c) { return s_valid_name_chars[c] ? c : '_'; });
-    WriteDataWithNextChar(valid_str.data(), valid_str.length());
+    WriteOpenAnnotation("name");
+    WriteQuotedData(str.data(), str.length());
+    WriteCloseSpace();
   } else {
     WriteDataWithNextChar(str.data(), str.length());
   }
@@ -1615,7 +1620,7 @@ void WatWriter::WriteStartFunction(const Var& start) {
 }
 
 void WatWriter::WriteCustom(const Custom& custom) {
-  WriteOpenSpace("@custom");
+  WriteOpenAnnotation("custom");
   WriteQuotedString(custom.name, NextChar::Space);
   WriteQuotedData(custom.data.data(), custom.data.size());
   WriteCloseNewline();

--- a/test/binary/invalid-name.txt
+++ b/test/binary/invalid-name.txt
@@ -20,6 +20,6 @@ section("name") {
 (;; STDOUT ;;;
 (module
   (type (;0;) (func (result i32)))
-  (func $hi_hello_hey (type 0) (result i32)
+  (func (@name "$hi hello hey") (type 0) (result i32)
     i32.const 42))
 ;;; STDOUT ;;)

--- a/test/parse/all-features.txt
+++ b/test/parse/all-features.txt
@@ -11,7 +11,7 @@
   (tag $e)
 
   ;; annotations
-  (func $f (@name "func") (result i32)
+  (func (@name "$f") (result i32)
     (i32.const 0))
 
   (func (result i32)

--- a/test/roundtrip/invalid-name.txt
+++ b/test/roundtrip/invalid-name.txt
@@ -1,0 +1,13 @@
+;;; TOOL: run-roundtrip
+;;; ARGS: --stdout --no-check --enable-annotations --debug-names
+(module
+  (type (;0;) (func (result i32)))
+  (func (@name "$hi hello hey") (type 0) (result i32)
+    i32.const 42))
+(;; STDOUT ;;;
+(module
+  (type (;0;) (func (result i32)))
+  (func (@name "$hi hello hey") (type 0) (result i32)
+    i32.const 42)
+  (@custom "name" "\01\0f\01\00\0chi hello hey\02\03\01\00\00"))
+;;; STDOUT ;;)


### PR DESCRIPTION
Following up #2284, a few commits were reverted related to the `@name` annotation so that the PR would focus on a single addition. This PR makes use of the `@name` annotation when writing names containing invalid characters in the text format (see WebAssembly/spec#617).

Let me know if there's anything else I should add!