### PR TITLE
Version 1.0.34

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@
 #
 
 cmake_minimum_required(VERSION 3.16)
-project(WABT LANGUAGES C CXX VERSION 1.0.33)
+project(WABT LANGUAGES C CXX VERSION 1.0.34)
 
 include(GNUInstallDirs)
 


### PR DESCRIPTION
Major changes since 1.0.33:

- Parse & write custom-section annotations (#2284)
- Partial wasm2c support for the threads proposal (#2233)
- wasm2c support for the tail-call proposal (#2272)
- Update multi-memory support to match upstream proposal (#2294)
- wasm-opcodecnt renamed to wasm-stats (#2298)
- wasm2c fixes for MIPS (#2274)
- Support global.get in constant expressions (#2288)
- Better spec-compliant parsing on some edge cases (#2247, #2248, #2251, #2252)
- Improved parsing and validation for memory64 (#2253, #2255, #2256)