### PR TITLE
rename typeof

### DIFF
--- a/src/c-writer.cc
+++ b/src/c-writer.cc
@@ -431,8 +431,8 @@ class CWriter {
   void Spill(const TypeVector&);
   void Unspill(const TypeVector&);
 
-  template <typename Vars, typename TypeOf, typename ToDo>
-  void WriteVarsByType(const Vars&, const TypeOf&, const ToDo&);
+  template <typename Vars, typename TypeOfFunc, typename ToDo>
+  void WriteVarsByType(const Vars&, const TypeOfFunc&, const ToDo&);
 
   template <typename sources>
   void Spill(const TypeVector&, const sources& src);
@@ -2955,16 +2955,16 @@ void CWriter::Write(const Func& func) {
   FinishFunction();
 }
 
-template <typename Vars, typename TypeOf, typename ToDo>
+template <typename Vars, typename TypeOfFunc, typename ToDo>
 void CWriter::WriteVarsByType(const Vars& vars,
-                              const TypeOf& typeof,
+                              const TypeOfFunc& typeoffunc,
                               const ToDo& todo) {
   for (Type type : {Type::I32, Type::I64, Type::F32, Type::F64, Type::V128,
                     Type::FuncRef, Type::ExternRef}) {
     Index var_index = 0;
     size_t count = 0;
     for (const auto& var : vars) {
-      if (typeof(var) == type) {
+      if (typeoffunc(var) == type) {
         if (count == 0) {
           Write(type, " ");
           Indent(4);

--- a/src/c-writer.cc
+++ b/src/c-writer.cc
@@ -431,8 +431,8 @@ class CWriter {
   void Spill(const TypeVector&);
   void Unspill(const TypeVector&);
 
-  template <typename Vars, typename TypeOfFunc, typename ToDo>
-  void WriteVarsByType(const Vars&, const TypeOfFunc&, const ToDo&);
+  template <typename Vars, typename TypeOf, typename ToDo>
+  void WriteVarsByType(const Vars&, const TypeOf&, const ToDo&);
 
   template <typename sources>
   void Spill(const TypeVector&, const sources& src);
@@ -2955,9 +2955,9 @@ void CWriter::Write(const Func& func) {
   FinishFunction();
 }
 
-template <typename Vars, typename TypeOfFunc, typename ToDo>
+template <typename Vars, typename TypeOf, typename ToDo>
 void CWriter::WriteVarsByType(const Vars& vars,
-                              const TypeOfFunc& typeoffunc,
+                              const TypeOf& typeoffunc,
                               const ToDo& todo) {
   for (Type type : {Type::I32, Type::I64, Type::F32, Type::F64, Type::V128,
                     Type::FuncRef, Type::ExternRef}) {


### PR DESCRIPTION
While typeof is not a standard c++ keyword, it is in the gnu dialect (i.e. -std=gnu++17). Simply renaming typeof to typeoffunc and TypeOf to TypeOfFunc lets wabt be built with either dialect.