### PR TITLE
Initialize const variable with user provided default constructor

### DIFF
--- a/wasm2c/wasm-rt.h
+++ b/wasm2c/wasm-rt.h
@@ -279,7 +279,7 @@ typedef struct {
 } wasm_rt_funcref_t;
 
 /** Default (null) value of a funcref */
-static const wasm_rt_funcref_t wasm_rt_funcref_null_value;
+static const wasm_rt_funcref_t wasm_rt_funcref_null_value = {NULL, NULL, NULL};
 
 /** The type of an external reference (opaque to WebAssembly). */
 typedef void* wasm_rt_externref_t;

--- a/wasm2c/wasm-rt.h
+++ b/wasm2c/wasm-rt.h
@@ -279,7 +279,7 @@ typedef struct {
 } wasm_rt_funcref_t;
 
 /** Default (null) value of a funcref */
-static const wasm_rt_funcref_t wasm_rt_funcref_null_value = {NULL, NULL, NULL};
+static const wasm_rt_funcref_t wasm_rt_funcref_null_value = {};
 
 /** The type of an external reference (opaque to WebAssembly). */
 typedef void* wasm_rt_externref_t;


### PR DESCRIPTION
Fixes error:
default initialization of an object of const type 'const wasm_rt_funcref_t' without a user-provided default constructor