### PR TITLE
Fix implicit br return

### DIFF
--- a/include/wabt/decompiler-ast.h
+++ b/include/wabt/decompiler-ast.h
@@ -217,8 +217,12 @@ struct AST {
         return;
       }
       case ExprType::Br: {
-        InsertNode(NodeType::Expr, ExprType::Br, &e, 0).u.lt =
-            mc.GetLabel(cast<BrExpr>(&e)->var)->label_type;
+        LabelType lt = mc.GetLabel(cast<BrExpr>(&e)->var)->label_type;
+        if (lt == LabelType::Func) {
+          InsertNode(NodeType::Expr, ExprType::Return, &e, arity.nargs);
+          return;
+        }
+        InsertNode(NodeType::Expr, ExprType::Br, &e, 0).u.lt = lt;
         return;
       }
       case ExprType::BrIf: {

--- a/test/decompile/br_return.txt
+++ b/test/decompile/br_return.txt
@@ -1,0 +1,12 @@
+;;; TOOL: run-wasm-decompile
+
+(module
+  (func $f (result i32) i32.const 10 br 0)
+)
+
+(;; STDOUT ;;;
+function f_a():int {
+  return 10
+}
+
+;;; STDOUT ;;)


### PR DESCRIPTION
An in-progress fix for #2304. For now, I believe it's working for any `br` depth. However, I'm not really sure how to handle the `br_if` case. Should it be replaced with an `if` and then a `return`? If so, I couldn't really find a way to create a new `IfExpr` and compile that on the fly. Maybe someone with more experience with the decompiler source code has a good way to do it.