### PR TITLE
wasm2c: Fix f64 harness

### DIFF
--- a/test/harness-windows/wasm2c/floating_point.txt
+++ b/test/harness-windows/wasm2c/floating_point.txt
@@ -1,0 +1,24 @@
+;;; TOOL: run-spec-wasm2c
+;;; ERROR: 1
+;;; PLATFORMS: Windows
+(module
+  (func (export "f32") (param $x f32) (result f32) (local.get $x))
+  (func (export "f64") (param $x f64) (result f64) (local.get $x))
+)
+(assert_return (invoke "f32" (f32.const 0.0)) (f32.const 123.4))
+(assert_return (invoke "f32" (f32.const 123.4)) (f32.const 0.0))
+(assert_return (invoke "f64" (f64.const 0.0)) (f64.const 123.4))
+(assert_return (invoke "f64" (f64.const 123.4)) (f64.const 0.0))
+(;; STDERR ;;;
+Error running "'out/test/harness-windows/wasm2c/floating_point\floating_point.exe'" (1):
+0/4 tests passed.
+
+out/test/harness-windows/wasm2c/floating_point\floating_point-main.c:384: assertion failed: in w2c_floating__point__0__wasm_f32(&floating__point__0__wasm_instance, 0.f): expected 123.400002, got 0.
+out/test/harness-windows/wasm2c/floating_point\floating_point-main.c:387: assertion failed: in w2c_floating__point__0__wasm_f32(&floating__point__0__wasm_instance, 123.400002f): expected 0, got 123.400002.
+out/test/harness-windows/wasm2c/floating_point\floating_point-main.c:390: assertion failed: in w2c_floating__point__0__wasm_f64(&floating__point__0__wasm_instance, 0.0000000000000000): expected 123.40000000000001, got 0.
+out/test/harness-windows/wasm2c/floating_point\floating_point-main.c:393: assertion failed: in w2c_floating__point__0__wasm_f64(&floating__point__0__wasm_instance, 123.40000000000001): expected 0, got 123.40000000000001.
+
+;;; STDERR ;;)
+(;; STDOUT ;;;
+0/4 tests passed.
+;;; STDOUT ;;)

--- a/test/harness/wasm2c/floating_point.txt
+++ b/test/harness/wasm2c/floating_point.txt
@@ -1,0 +1,24 @@
+;;; TOOL: run-spec-wasm2c
+;;; ERROR: 1
+;;; NOT-PLATFORMS: Windows
+(module
+  (func (export "f32") (param $x f32) (result f32) (local.get $x))
+  (func (export "f64") (param $x f64) (result f64) (local.get $x))
+)
+(assert_return (invoke "f32" (f32.const 0.0)) (f32.const 123.4))
+(assert_return (invoke "f32" (f32.const 123.4)) (f32.const 0.0))
+(assert_return (invoke "f64" (f64.const 0.0)) (f64.const 123.4))
+(assert_return (invoke "f64" (f64.const 123.4)) (f64.const 0.0))
+(;; STDERR ;;;
+Error running "out/test/harness/wasm2c/floating_point/floating_point" (1):
+0/4 tests passed.
+
+out/test/harness/wasm2c/floating_point/floating_point-main.c:384: assertion failed: in w2c_floating__point__0__wasm_f32(&floating__point__0__wasm_instance, 0.f): expected 123.400002, got 0.
+out/test/harness/wasm2c/floating_point/floating_point-main.c:387: assertion failed: in w2c_floating__point__0__wasm_f32(&floating__point__0__wasm_instance, 123.400002f): expected 0, got 123.400002.
+out/test/harness/wasm2c/floating_point/floating_point-main.c:390: assertion failed: in w2c_floating__point__0__wasm_f64(&floating__point__0__wasm_instance, 0.0000000000000000): expected 123.40000000000001, got 0.
+out/test/harness/wasm2c/floating_point/floating_point-main.c:393: assertion failed: in w2c_floating__point__0__wasm_f64(&floating__point__0__wasm_instance, 123.40000000000001): expected 0, got 123.40000000000001.
+
+;;; STDERR ;;)
+(;; STDOUT ;;;
+0/4 tests passed.
+;;; STDOUT ;;)

--- a/test/run-spec-wasm2c.py
+++ b/test/run-spec-wasm2c.py
@@ -84,7 +84,7 @@ def F64ToC(f64_bits):
     elif f64_bits == F64_SIGN_BIT:
         return '-0.0'
     else:
-        return '%#.17gL' % ReinterpretF64(f64_bits)
+        return '%#.17g' % ReinterpretF64(f64_bits)
 
 
 def MangleType(t):


### PR DESCRIPTION
Old output:

```text
out/test/harness/wasm2c/floating_point\floating_point-main.c:384: assertion failed: in w2c_floating__point__0__wasm_f32(&floating__point__0__wasm_instance, 0.f): expected 123.400002, got 0.
out/test/harness/wasm2c/floating_point\floating_point-main.c:387: assertion failed: in w2c_floating__point__0__wasm_f32(&floating__point__0__wasm_instance, 123.400002f): expected 0, got 123.400002.
out/test/harness/wasm2c/floating_point\floating_point-main.c:390: assertion failed: in w2c_floating__point__0__wasm_f64(&floating__point__0__wasm_instance, 0.0000000000000000L): expected 0, got 6.9218011802898607e-310.
out/test/harness/wasm2c/floating_point\floating_point-main.c:393: assertion failed: in w2c_floating__point__0__wasm_f64(&floating__point__0__wasm_instance, 123.40000000000001L): expected 123.40000000000001, got 6.9218011802898607e-310.
```

(Note how wrong this output is!)