### PR TITLE
decompiler.cc: fix vector oob when if has empty then

### DIFF
--- a/src/decompiler.cc
+++ b/src/decompiler.cc
@@ -527,7 +527,10 @@ struct Decompiler {
           ifs.precedence = Precedence::If;
           return std::move(ifs);
         } else {
-          auto s = cat("if (", ifs.v[0], ") { ", thenp.v[0], " }");
+          auto s = cat("if (", ifs.v[0], ") {");
+          if (!thenp.v.empty())
+            s += cat(" ", thenp.v[0], " ");
+          s += "}";
           if (elsep)
             s += cat(" else { ", elsep->v[0], " }");
           return Value{{std::move(s)}, Precedence::If};

--- a/test/decompile/basic.txt
+++ b/test/decompile/basic.txt
@@ -105,6 +105,10 @@
     i32.const 0  ;; fi
     call_indirect
     i32.const 0
+    if
+    else
+    end
+    i32.const 0
   )
   (func $g (param) (result) (local i32)
     ;; This is rare, but requires special handling: uses of local outside scope
@@ -183,6 +187,7 @@ export function f(a:int, b:int):int {
   nop;
   is_null(null);
   call_indirect(0);
+  if (0) {}
   return 0;
 }
 


### PR DESCRIPTION
Previously, wasm-decompile would either hit an assertion or just plain out crash (depending on how you compiled it) when decompiling wasm that has an if statement with an empty then