### PR TITLE
Update ID for tag name subsection

### DIFF
--- a/include/wabt/binary.h
+++ b/include/wabt/binary.h
@@ -89,12 +89,8 @@ enum class NameSectionSubsection {
   Global = 7,
   ElemSegment = 8,
   DataSegment = 9,
-  // tag names are yet part of the extended-name-section proposal (because it
-  // only deals with naming things that are in the spec already).  However, we
-  // include names for Tags in wabt using this enum value on the basis that tags
-  // can only exist when exceptions are enabled and that engines should ignore
-  // unknown name types.
-  Tag = 10,
+  Field = 10,
+  Tag = 11,
 
   First = Module,
   Last = Tag,

--- a/src/binary-reader-ir.cc
+++ b/src/binary-reader-ir.cc
@@ -1588,6 +1588,7 @@ Result BinaryReaderIR::OnNameEntry(NameSectionSubsection type,
     case NameSectionSubsection::Local:
     case NameSectionSubsection::Module:
     case NameSectionSubsection::Label:
+    case NameSectionSubsection::Field:
       break;
     case NameSectionSubsection::Type:
       SetTypeName(index, name);

--- a/src/binary.cc
+++ b/src/binary.cc
@@ -54,6 +54,7 @@ const char* NameSubsectionName[] = {
     "global",
     "elemseg",
     "dataseg",
+    "field",
     "tag",
 };
 // clang-format on

--- a/test/dump/extended-names.txt
+++ b/test/dump/extended-names.txt
@@ -338,7 +338,7 @@
 0000128: 05                                        ; string length
 0000129: 6461 7461 31                             data1  ; elem name 0
 0000125: 08                                        ; FIXUP subsection size
-000012e: 0a                                        ; name subsection type
+000012e: 0b                                        ; name subsection type
 000012f: 00                                        ; subsection size (guess)
 0000130: 02                                        ; num names
 0000131: 00                                        ; elem index


### PR DESCRIPTION
The tag name subsection currently has the speculative ID of 10. However, the extended-name-section proposal has now been updated to use an ID of 11 for the tag name section. This updates the NameSectionSubsection enum accordingly, as well as adding a field name section with the ID of 10.