### PR TITLE
wasm2c runtime: refactor handling of alternate stack (NFC)

### DIFF
--- a/wasm2c/wasm-rt-impl.c
+++ b/wasm2c/wasm-rt-impl.c
@@ -251,10 +251,9 @@ static void os_disable_and_deallocate_altstack(void) {
 static void os_install_signal_handler(void) {
   struct sigaction sa;
   memset(&sa, '\0', sizeof(sa));
-#if WASM_RT_USE_STACK_DEPTH_COUNT
   sa.sa_flags = SA_SIGINFO;
-#else
-  sa.sa_flags = SA_SIGINFO | SA_ONSTACK;
+#if !WASM_RT_USE_STACK_DEPTH_COUNT
+  sa.sa_flags |= SA_ONSTACK;
 #endif
   sigemptyset(&sa.sa_mask);
   sa.sa_sigaction = os_signal_handler;

--- a/wasm2c/wasm-rt-impl.c
+++ b/wasm2c/wasm-rt-impl.c
@@ -42,14 +42,14 @@
 static bool g_signal_handler_installed = false;
 #ifdef _WIN32
 static void* g_sig_handler_handle = 0;
-#else
-static char* g_alt_stack = 0;
 #endif
 #endif
 
 #if WASM_RT_USE_STACK_DEPTH_COUNT
 WASM_RT_THREAD_LOCAL uint32_t wasm_rt_call_stack_depth;
 WASM_RT_THREAD_LOCAL uint32_t wasm_rt_saved_call_stack_depth;
+#elif WASM_RT_INSTALL_SIGNAL_HANDLER
+static WASM_RT_THREAD_LOCAL void* g_alt_stack = NULL;
 #endif
 
 WASM_RT_THREAD_LOCAL wasm_rt_jmp_buf g_wasm_rt_jmp_buf;
@@ -172,14 +172,41 @@ static void os_signal_handler(int sig, siginfo_t* si, void* unused) {
   }
 }
 
-static void os_install_signal_handler(void) {
-  /* Use alt stack to handle SIGSEGV from stack overflow */
+static bool os_has_altstack_installed() {
+  /* check for altstack already in place */
+  stack_t ss;
+  if (sigaltstack(NULL, &ss) != 0) {
+    perror("sigaltstack failed");
+    abort();
+  }
+
+  return !(ss.ss_flags & SS_DISABLE);
+}
+
+/* Use alt stack to handle SIGSEGV from stack overflow */
+static void os_allocate_and_install_altstack(void) {
+  /* verify altstack not already allocated */
+#ifndef NDEBUG
+  if (g_alt_stack) {
+    fprintf(
+        stderr,
+        "wasm-rt error: tried to re-allocate thread-local alternate stack\n");
+    abort();
+  }
+
+  /* We could check and warn if an altstack is already installed, but some
+   * sanitizers install their own altstack, so this warning would fire
+   * spuriously and break the test outputs. */
+#endif
+
+  /* allocate altstack */
   g_alt_stack = malloc(SIGSTKSZ);
   if (g_alt_stack == NULL) {
     perror("malloc failed");
     abort();
   }
 
+  /* install altstack */
   stack_t ss;
   ss.ss_sp = g_alt_stack;
   ss.ss_flags = 0;
@@ -188,10 +215,16 @@ static void os_install_signal_handler(void) {
     perror("sigaltstack failed");
     abort();
   }
+}
 
+static void os_install_signal_handler(void) {
   struct sigaction sa;
   memset(&sa, '\0', sizeof(sa));
+#if WASM_RT_USE_STACK_DEPTH_COUNT
+  sa.sa_flags = SA_SIGINFO;
+#else
   sa.sa_flags = SA_SIGINFO | SA_ONSTACK;
+#endif
   sigemptyset(&sa.sa_mask);
   sa.sa_sigaction = os_signal_handler;
 
@@ -200,6 +233,41 @@ static void os_install_signal_handler(void) {
     perror("sigaction failed");
     abort();
   }
+}
+
+static void os_disable_and_deallocate_altstack(void) {
+  /* in debug build, verify altstack allocated */
+#ifndef NDEBUG
+  if (!g_alt_stack) {
+    fprintf(stderr, "wasm-rt error: alternate stack is NULL\n");
+    abort();
+  }
+#endif
+
+  /* verify altstack was still in place */
+  stack_t ss;
+  if (sigaltstack(NULL, &ss) != 0) {
+    perror("sigaltstack failed");
+    abort();
+  }
+
+  if ((!g_alt_stack) || (ss.ss_flags & SS_DISABLE) ||
+      (ss.ss_sp != g_alt_stack) || (ss.ss_size != SIGSTKSZ)) {
+#ifndef NDEBUG
+    fprintf(stderr,
+            "wasm-rt warning: alternate stack was modified unexpectedly\n");
+#endif
+    return;
+  }
+
+  /* disable and free */
+  ss.ss_flags = SS_DISABLE;
+  if (sigaltstack(&ss, NULL) != 0) {
+    perror("sigaltstack failed");
+    abort();
+  }
+  assert(!os_has_altstack_installed());
+  free(g_alt_stack);
 }
 
 static void os_cleanup_signal_handler(void) {
@@ -211,13 +279,6 @@ static void os_cleanup_signal_handler(void) {
     perror("sigaction failed");
     abort();
   }
-
-  if (sigaltstack(NULL, NULL) != 0) {
-    perror("sigaltstack failed");
-    abort();
-  }
-
-  free(g_alt_stack);
 }
 #endif
 
@@ -227,12 +288,21 @@ void wasm_rt_init(void) {
 #if WASM_RT_INSTALL_SIGNAL_HANDLER
   if (!g_signal_handler_installed) {
     g_signal_handler_installed = true;
+#if !WASM_RT_USE_STACK_DEPTH_COUNT
+    os_allocate_and_install_altstack();
+#endif
     os_install_signal_handler();
   }
 #endif
+  assert(wasm_rt_is_initialized());
 }
 
 bool wasm_rt_is_initialized(void) {
+#if !WASM_RT_USE_STACK_DEPTH_COUNT
+  if (!os_has_altstack_installed()) {
+    return false;
+  }
+#endif
 #if WASM_RT_INSTALL_SIGNAL_HANDLER
   return g_signal_handler_installed;
 #else
@@ -241,8 +311,15 @@ bool wasm_rt_is_initialized(void) {
 }
 
 void wasm_rt_free(void) {
+  if (!wasm_rt_is_initialized()) {
+    fprintf(stderr, "wasm_rt_free: wasm runtime not initialized.\n");
+    return;
+  }
 #if WASM_RT_INSTALL_SIGNAL_HANDLER
   os_cleanup_signal_handler();
+#if !WASM_RT_USE_STACK_DEPTH_COUNT
+  os_disable_and_deallocate_altstack();
+#endif
   g_signal_handler_installed = false;
 #endif
 }


### PR DESCRIPTION
Split out from #2332.

This makes the `g_alt_stack` variable thread-local and splits out the internal routines that handle allocation/installation. This will make it a smaller change to add the per-thread initialization API in #2332.