### PR TITLE
Fix wasm-rt-impl defines nesting

### DIFF
--- a/wasm2c/wasm-rt-impl.c
+++ b/wasm2c/wasm-rt-impl.c
@@ -293,12 +293,12 @@ void wasm_rt_init(void) {
 }
 
 bool wasm_rt_is_initialized(void) {
+#if WASM_RT_INSTALL_SIGNAL_HANDLER
 #if !WASM_RT_USE_STACK_DEPTH_COUNT
   if (!os_has_altstack_installed()) {
     return false;
   }
 #endif
-#if WASM_RT_INSTALL_SIGNAL_HANDLER
   return g_signal_handler_installed;
 #else
   return true;


### PR DESCRIPTION
This PR fixes the nesting order of `WASM_RT_INSTALL_SIGNAL_HANDLER` and `WASM_RT_USE_STACK_DEPTH_COUNT` in `wasm_rt_is_intialized` to match the rest of the file.

Before this PR, we were getting an `undefined reference` error:
```
rlbox_wasm2c_sandbox/build/_deps/mod_wasm2c-src/wasm2c/wasm-rt-impl.c:297:8: warning: implicit declaration of function ‘os_has_altstack_installed’ [-Wimplicit-function-declaration]
  297 |   if (!os_has_altstack_installed()) {
      |        ^~~~~~~~~~~~~~~~~~~~~~~~~
```