### PR TITLE
wasm2c runtime: fix mis-nesting of def'n of os_has_altstack_installed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -167,3 +167,19 @@ jobs:
       run: cmake --build out --target run-c-api-tests
     - name: tests
       run: cmake --build out --target run-tests
+  build-rlbox:
+    name: rlbox
+    runs-on: ubuntu-latest
+    env:
+      USE_NINJA: "1"
+      WASM2C_CFLAGS: "-DWASM_RT_USE_MMAP=1 -DWASM_RT_SKIP_SIGNAL_RECOVERY=1 -DWASM_RT_USE_STACK_DEPTH_COUNT=0 -DWASM2C_TEST_EMBEDDER_SIGNAL_HANDLING"
+    steps:
+    - uses: actions/setup-python@v1
+      with:
+        python-version: '3.x'
+    - uses: actions/checkout@v1
+      with:
+        submodules: true
+    - run: sudo apt-get install ninja-build
+    - run: make clang-debug
+    - run: make test-clang-debug

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -182,4 +182,4 @@ jobs:
         submodules: true
     - run: sudo apt-get install ninja-build
     - run: make clang-debug
-    - run: make test-clang-debug
+    - run: ./test/run-tests.py --exclude-dir memory64

--- a/test/run-tests.py
+++ b/test/run-tests.py
@@ -928,7 +928,10 @@ def main(args):
                         action='store_true')
     parser.add_argument('patterns', metavar='pattern', nargs='*',
                         help='test patterns.')
+    parser.add_argument('--exclude-dir', action='append', default=[],
+                        help='directory to exclude.')
     options = parser.parse_args(args)
+    exclude_dirs = options.exclude_dir
 
     if options.jobs != 1:
         if options.fail_fast:
@@ -937,7 +940,6 @@ def main(args):
             parser.error('--stop-interactive only works with -j1')
 
     if options.patterns:
-        exclude_dirs = []
         pattern_re = '|'.join(
             fnmatch.translate('*%s*' % p) for p in options.patterns)
     else:
@@ -945,7 +947,7 @@ def main(args):
         # By default, exclude wasi tests because WASI support is not include
         # by int the build by default.
         # TODO(sbc): Find some way to detect the WASI support.
-        exclude_dirs = ['wasi']
+        exclude_dirs += ['wasi']
 
     test_names = FindTestFiles('.txt', pattern_re, exclude_dirs)
 

--- a/wasm2c/wasm-rt-impl.c
+++ b/wasm2c/wasm-rt-impl.c
@@ -25,7 +25,8 @@
 #include <stdlib.h>
 #include <string.h>
 
-#if WASM_RT_INSTALL_SIGNAL_HANDLER && !defined(_WIN32)
+#if (WASM_RT_INSTALL_SIGNAL_HANDLER || !WASM_RT_USE_STACK_DEPTH_COUNT) && \
+    !defined(_WIN32)
 #include <signal.h>
 #include <unistd.h>
 #endif
@@ -163,6 +164,19 @@ static void os_print_last_error(const char* msg) {
   perror(msg);
 }
 
+#if !WASM_RT_USE_STACK_DEPTH_COUNT
+static bool os_has_altstack_installed() {
+  /* check for altstack already in place */
+  stack_t ss;
+  if (sigaltstack(NULL, &ss) != 0) {
+    perror("sigaltstack failed");
+    abort();
+  }
+
+  return !(ss.ss_flags & SS_DISABLE);
+}
+#endif
+
 #if WASM_RT_INSTALL_SIGNAL_HANDLER
 static void os_signal_handler(int sig, siginfo_t* si, void* unused) {
   if (si->si_code == SEGV_ACCERR) {
@@ -174,17 +188,6 @@ static void os_signal_handler(int sig, siginfo_t* si, void* unused) {
 
 #if !WASM_RT_USE_STACK_DEPTH_COUNT
 /* These routines set up an altstack to handle SIGSEGV from stack overflow. */
-static bool os_has_altstack_installed() {
-  /* check for altstack already in place */
-  stack_t ss;
-  if (sigaltstack(NULL, &ss) != 0) {
-    perror("sigaltstack failed");
-    abort();
-  }
-
-  return !(ss.ss_flags & SS_DISABLE);
-}
-
 static void os_allocate_and_install_altstack(void) {
   /* verify altstack not already allocated */
   assert(!g_alt_stack &&

--- a/wasm2c/wasm-rt.h
+++ b/wasm2c/wasm-rt.h
@@ -202,7 +202,7 @@ extern WASM_RT_THREAD_LOCAL uint32_t wasm_rt_call_stack_depth;
 #define WASM_RT_NO_RETURN __attribute__((noreturn))
 #endif
 
-#if defined(__APPLE__) && WASM_RT_INSTALL_SIGNAL_HANDLER
+#if defined(__APPLE__) && !WASM_RT_USE_STACK_DEPTH_COUNT
 #define WASM_RT_MERGED_OOB_AND_EXHAUSTION_TRAPS 1
 #else
 #define WASM_RT_MERGED_OOB_AND_EXHAUSTION_TRAPS 0
@@ -218,7 +218,7 @@ typedef enum {
   WASM_RT_TRAP_UNREACHABLE,        /** Unreachable instruction executed. */
   WASM_RT_TRAP_CALL_INDIRECT,      /** Invalid call_indirect, for any reason. */
   WASM_RT_TRAP_UNCAUGHT_EXCEPTION, /* Exception thrown and not caught. */
-  WASM_RT_TRAP_UNALIGNED, /** Unaligned atomic instruction executed. */
+  WASM_RT_TRAP_UNALIGNED,          /** Unaligned atomic instruction executed. */
 #if WASM_RT_MERGED_OOB_AND_EXHAUSTION_TRAPS
   WASM_RT_TRAP_EXHAUSTION = WASM_RT_TRAP_OOB,
 #else
@@ -354,7 +354,8 @@ typedef struct {
   jmp_buf buffer;
 } wasm_rt_jmp_buf;
 
-#if WASM_RT_INSTALL_SIGNAL_HANDLER && !defined(_WIN32)
+#if (WASM_RT_INSTALL_SIGNAL_HANDLER || (!WASM_RT_USE_STACK_DEPTH_COUNT)) && \
+    !defined(_WIN32)
 #define WASM_RT_SETJMP_SETBUF(buf) sigsetjmp(buf, 1)
 #else
 #define WASM_RT_SETJMP_SETBUF(buf) setjmp(buf)
@@ -363,7 +364,8 @@ typedef struct {
 #define WASM_RT_SETJMP(buf) \
   ((buf).initialized = true, WASM_RT_SETJMP_SETBUF((buf).buffer))
 
-#if WASM_RT_INSTALL_SIGNAL_HANDLER && !defined(_WIN32)
+#if (WASM_RT_INSTALL_SIGNAL_HANDLER || (!WASM_RT_USE_STACK_DEPTH_COUNT)) && \
+    !defined(_WIN32)
 #define WASM_RT_LONGJMP_UNCHECKED(buf, val) siglongjmp(buf, val)
 #else
 #define WASM_RT_LONGJMP_UNCHECKED(buf, val) longjmp(buf, val)


### PR DESCRIPTION
@wrv This closes #2339 a different way (defining `os_has_altstack_installed` even if `WASM_RT_INSTALL_SIGNAL_HANDLER` isn't set). wdyt?