### PR TITLE
WastParser: tighten parsing of folded `if`

### DIFF
--- a/test/dump/br-loop-inner.txt
+++ b/test/dump/br-loop-inner.txt
@@ -4,9 +4,9 @@
   (func
     (block $exit (loop $cont
       (if (i32.const 1)
-        (br $exit))
+        (then (br $exit)))
       (if (i32.const 2)
-        (br $cont))))))
+        (then (br $cont)))))))
 (;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION

--- a/test/parse/expr/bad-if-no-then.txt
+++ b/test/parse/expr/bad-if-no-then.txt
@@ -2,7 +2,7 @@
 ;;; ERROR: 1
 (module (func (if (i32.const 0))))
 (;; STDERR ;;;
-out/test/parse/expr/bad-if-no-then.txt:3:32: error: unexpected token ")", expected then block (e.g. (then ...)).
+out/test/parse/expr/bad-if-no-then.txt:3:32: error: unexpected token ), expected (.
 (module (func (if (i32.const 0))))
                                ^
 ;;; STDERR ;;)

--- a/test/regress/regress-23.txt
+++ b/test/regress/regress-23.txt
@@ -4,17 +4,6 @@
 ;; This regression test makes sure that the end_loc of `if` blocks is properly
 ;; set when using the folded format.
 
-;; if/else shorthand format, error in true branch.
-(func (result i32)
-  (if (result i32)
-    (i32.const 0)
-    (block
-      (unreachable)
-    )
-    (i32.const 0)
-  )
-)
-
 ;; if/else with `then`/`else` keywords, error in true branch.
 (func (result i32)
   (if (result i32)
@@ -26,17 +15,6 @@
     )
     (else
       (i32.const 0)
-    )
-  )
-)
-
-;; if/else shorthand format, error in false branch.
-(func (result i32)
-  (if (result i32)
-    (i32.const 0)
-    (i32.const 0)
-    (block
-      (unreachable)
     )
   )
 )
@@ -56,16 +34,10 @@
   )
 )
 (;; STDERR ;;;
-out/test/regress/regress-23.txt:13:5: error: type mismatch in `if true` branch, expected [i32] but got []
-    )
-    ^
-out/test/regress/regress-23.txt:25:7: error: type mismatch in `if true` branch, expected [i32] but got []
+out/test/regress/regress-23.txt:14:7: error: type mismatch in `if true` branch, expected [i32] but got []
       )
       ^
-out/test/regress/regress-23.txt:41:3: error: type mismatch in `if false` branch, expected [i32] but got []
-  )
-  ^
-out/test/regress/regress-23.txt:56:3: error: type mismatch in `if false` branch, expected [i32] but got []
+out/test/regress/regress-23.txt:34:3: error: type mismatch in `if false` branch, expected [i32] but got []
   )
   ^
 ;;; STDERR ;;)


### PR DESCRIPTION
This makes the `then` block mandatory per the spec, and parses multiple foldedinstrs in the `if` predicate (exercised by the new if.wast test -- we'll need this to update the testsuite submodule).

Closes #2347 