### PR TITLE
build ubuntu release assets on ubuntu 20.04

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-12, windows-latest]
+        os: [ubuntu-20.04, macos-12, windows-latest]
     defaults:
       run:
         shell: bash
@@ -29,7 +29,7 @@ jobs:
 
     - name: install ninja (linux)
       run: sudo apt-get install ninja-build
-      if: matrix.os == 'ubuntu-latest'
+      if: startsWith(matrix.os, 'ubuntu-')
 
     - name: install ninja (osx)
       run: brew install ninja


### PR DESCRIPTION
binaries built on 22.04 require glibc 2.34 and thus are incompatible with 20.04, which is still supported.