### PR TITLE
[wasm-objdump] set function types for correct params+locals indexing

### DIFF
--- a/src/binary-reader-objdump.cc
+++ b/src/binary-reader-objdump.cc
@@ -519,6 +519,8 @@ class BinaryReaderObjdumpDisassemble : public BinaryReaderObjdumpBase {
 
   std::string BlockSigToString(Type type) const;
 
+  Result OnFunction(Index index, Index sig_index) override;
+
   Result BeginFunctionBody(Index index, Offset size) override;
   Result EndFunctionBody(Index index) override;
 
@@ -937,6 +939,12 @@ Result BinaryReaderObjdumpDisassemble::OnEndExpr() {
     indent_level--;
   }
   LogOpcode(0, nullptr);
+  return Result::Ok;
+}
+
+Result BinaryReaderObjdumpDisassemble::OnFunction(Index index,
+                                                  Index sig_index) {
+  objdump_state_->function_types[index] = sig_index;
   return Result::Ok;
 }
 

--- a/test/dump/noncanon-leb128-opcode.txt
+++ b/test/dump/noncanon-leb128-opcode.txt
@@ -19,7 +19,7 @@ noncanon-leb128-opcode.0.wasm:	file format wasm 0x1
 Code Disassembly:
 
 00002d func[0] <main>:
- 00002e: 03 7e                      | local[0..2] type=i64
+ 00002e: 03 7e                      | local[1..3] type=i64
  000030: 20 00                      | local.get 0
  000032: 41 d6 49                   | i32.const 4294960342
  000035: 02 7f                      | block i32


### PR DESCRIPTION
`wasm-objdump --disassemble` has different treatment of locals than `--details` because it doesn't collect function types so it can properly work out how many params the function has and therefore the index number of the local.

`test/dump/noncanon-leb128-opcode.txt` demonstrates this nicely as can be seen in here. The `--details` of that test module looks like this:

```
noncanon-leb128-opcode.0.wasm:     file format wasm 0x1

Section Details:

Type[2]:
 - type[0] () -> i32
 - type[1] (i32) -> i32
Function[1]:
 - func[0] sig=1 <main>
Table[1]:
 - table[0] type=funcref initial=1 max=9
Export[1]:
 - func[0] <main> -> "main"
Code[1]:
 - func[0] size=37 <main>
```

so `"main"` has `sig=1`, i.e. it takes 1 parameter, `(i32) -> i32`. But because `--disassemble` mode doesn't collect function types, it defaults all functions to sig=0, so calculation of `locals[X]` always looks at the first type definition to figure out the number of parameters. In this case it's zero parameters but this is arbitrary and depends on what the first type is. I have other examples if that helps.

---

Further details of how this happens:

* Enter a function and figure out the initial `local_index_` based on the signature look-up to find the number of params: https://github.com/WebAssembly/wabt/blob/e97a1cbe920b96174c59ee347969eaf42d4116f0/src/binary-reader-objdump.cc#L943-L959
* `local[%d]` uses, and increments `local_index_`: https://github.com/WebAssembly/wabt/blob/e97a1cbe920b96174c59ee347969eaf42d4116f0/src/binary-reader-objdump.cc#L619-L649