### PR TITLE
wasm2c: Add macro and tests to allow disabling stack exhaustion checks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -172,7 +172,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       USE_NINJA: "1"
-      WASM2C_CFLAGS: "-DWASM_RT_USE_MMAP=1 -DWASM_RT_SKIP_SIGNAL_RECOVERY=1 -DWASM2C_TEST_EMBEDDER_SIGNAL_HANDLING"
+      WASM2C_CFLAGS: "-DWASM_RT_USE_MMAP=1 -DWASM_RT_SKIP_SIGNAL_RECOVERY=1 -DWASM_RT_NONCONFORMING_UNCHECKED_STACK_EXHAUSTION=1 -DWASM2C_TEST_EMBEDDER_SIGNAL_HANDLING"
     steps:
     - uses: actions/setup-python@v1
       with:
@@ -182,5 +182,5 @@ jobs:
         submodules: true
     - run: sudo apt-get install ninja-build
     - run: make clang-debug
-    - name: tests (excluding memory64)
-      run: ./test/run-tests.py --exclude-dir memory64
+    - name: tests (wasm2c tests excluding memory64)
+      run: ./test/run-tests.py wasm2c --exclude-dir memory64


### PR DESCRIPTION
(Continued from https://github.com/WebAssembly/wabt/pull/2354)

This PR adds an macro `WASM_RT_NONCONFORMING_STACK_UNCHECKED` to allow the embedder to unsafely remove all stack checks from wasm2c. This would mean the embedder is not conformant with the Wasm spec. This configuration is useful for embedders like RLBox which are unlikely to be affected by stack exhaustion, and don't want to pay performance penalties for this. The wasm2c build in CI that uses rlbox flags has been correspondingly updated to capture this.