### PR TITLE
Fix Features of wabt.post.js can't work in strict mode

### DIFF
--- a/src/wabt.post.js
+++ b/src/wabt.post.js
@@ -95,7 +95,7 @@ function allocateCString(s) {
 /// Features
 function Features(obj) {
   this.addr = Module._wabt_new_features();
-  for ([f, v] of Object.entries(FEATURES)) {
+  for (var [f, v] of Object.entries(FEATURES)) {
     this[f] = booleanOrDefault(obj[f], v);
   }
 }


### PR DESCRIPTION
`for ([f, v] of Object.entries(FEATURES))` leads to `ReferenceError: f is not defined` in `use strict`. 
Fix it