### PR TITLE
Fix emscripten build warning and add missing export

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
       run: |
         docker run -di --name emscripten -v $(pwd):/src emscripten/emsdk:latest bash
         docker exec emscripten emcc -v
-        docker exec emscripten emcmake cmake -B emscripten -DWERROR=ON -DBUILD_TESTS=OFF
+        docker exec emscripten emcmake cmake -B emscripten -DWERROR=ON
         docker exec -w /src/emscripten emscripten make -j $(nproc)
         
   wasi:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
         docker run -di --name emscripten -v $(pwd):/src emscripten/emsdk:latest bash
         docker exec emscripten emcc -v
         docker exec emscripten emcmake cmake -B emscripten -DWERROR=ON -DBUILD_TESTS=OFF
-        docker exec emscripten bash -c "cd /src/emscripten && make -j $(nproc)"
+        docker exec -w /src/emscripten emscripten make -j $(nproc)
         
   wasi:
     name: wasi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,8 +78,9 @@ jobs:
       run: |
         docker run -di --name emscripten -v $(pwd):/src emscripten/emsdk:latest bash
         docker exec emscripten emcc -v
-        docker exec emscripten emcmake cmake .
-        docker exec emscripten make -j 2 VERBOSE=1
+        docker exec emscripten emcmake cmake -B emscripten -DWERROR=ON -DBUILD_TESTS=OFF
+        docker exec emscripten bash -c "cd /src/emscripten && make -j $(nproc)"
+        
   wasi:
     name: wasi
     runs-on: ubuntu-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -823,6 +823,7 @@ if (EMSCRIPTEN)
     -sMODULARIZE=1
     -sEXPORT_NAME=WabtModule
     -sWASM=0
+    -sEXPORTED_RUNTIME_METHODS=writeAsciiToMemory
     -Oz
   )
   string(REPLACE ";" " " LIBWABT_LINK_FLAGS_STR "${LIBWABT_LINK_FLAGS}")

--- a/src/c-writer.cc
+++ b/src/c-writer.cc
@@ -1633,7 +1633,7 @@ void CWriter::SerializeFuncType(const FuncType& func_type,
     *next_byte++ = MangleType(func_type.GetResultType(i));
   }
 
-  assert(next_byte - mangled_signature == len);
+  assert(next_byte - mangled_signature == static_cast<ptrdiff_t>(len));
 
   // step 4: SHA-256 the whole string
   sha256({mangled_signature, len}, serialized_type);

--- a/wasm2c/wasm-rt-impl.c
+++ b/wasm2c/wasm-rt-impl.c
@@ -148,6 +148,7 @@ static void os_cleanup_signal_handler(void) {
 #endif
 
 #else
+#if WASM_RT_USE_MMAP
 static void* os_mmap(size_t size) {
   int map_prot = PROT_NONE;
   int map_flags = MAP_ANONYMOUS | MAP_PRIVATE;
@@ -168,6 +169,7 @@ static int os_mprotect(void* addr, size_t size) {
 static void os_print_last_error(const char* msg) {
   perror(msg);
 }
+#endif
 
 #if WASM_RT_INSTALL_SIGNAL_HANDLER
 static void os_signal_handler(int sig, siginfo_t* si, void* unused) {


### PR DESCRIPTION
1. Fix wabtjs bug that missing `writeAsciiToMemory` built by new version emcc
2. Refine the code quality and CI of wabtjs
2.1: Add warning as error in emcc build
2.2 Port the test cases from https://github.com/AssemblyScript/wabt.js/tree/main/tests