### PR TITLE
Add MacOS ARM64 Support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,11 +30,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-12, windows-latest]
+        os: [ubuntu-latest, macos-12, windows-latest, flyci-macos-large-latest-m1]
     steps:
     - uses: actions/setup-python@v1
       with:
         python-version: '3.x'
+        architecture: ${{ (matrix.os == 'flyci-macos-large-latest-m1' && 'arm64') || 'x64' }}
     - uses: actions/checkout@v1
       with:
         submodules: true
@@ -43,7 +44,7 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
     - name: install ninja (osx)
       run: brew install ninja
-      if: matrix.os == 'macos-12'
+      if: matrix.os == 'macos-12' || matrix.os == 'flyci-macos-large-latest-m1'
     - name: install ninja (win)
       run: choco install ninja
       if: matrix.os == 'windows-latest'


### PR DESCRIPTION
Add MacOS ARM64 support using FlyCI's MacOS runners:
https://github.com/WebAssembly/wabt/issues/2366

As per @keithw's [comment](https://github.com/WebAssembly/wabt/issues/2366#issuecomment-1910858259), the tests are not passing and the want contributors may consider accepting the PR.

## FlyCI App Install Instructions

Please note that the FlyCI ARM64 jobs will not be picked up until the [FlyCI GitHub app](https://github.com/apps/flyci-prod) is installed on this repository. 

1. Go to the [FlyCI GitHub app](https://github.com/apps/flyci-prod) and install it. 
2. Configure the app and give it permissions for this repository (and any other repository that you would like to run MacOS jobs using FlyCI's runners).