### PR TITLE
fallback to pthreads if threads aren't available

### DIFF
--- a/wasm2c/wasm-rt.h
+++ b/wasm2c/wasm-rt.h
@@ -58,23 +58,19 @@ extern "C" {
 #endif
 
 /**
- * Apple and Windows devices don't implement the C11 threads.h. We use pthreads
- * on Apple devices, and CriticalSection APIs for Windows.
+ * Many devices don't implement the C11 threads.h. We use CriticalSection APIs
+ * for Windows and pthreads everywhere else.
  */
 #ifdef WASM_RT_C11_AVAILABLE
 
-#ifdef __APPLE__
-#include <pthread.h>
-#define WASM_RT_MUTEX pthread_mutex_t
-#define WASM_RT_USE_PTHREADS 1
-#elif defined(_WIN32)
+#if defined(_WIN32)
 #include <windows.h>
 #define WASM_RT_MUTEX CRITICAL_SECTION
 #define WASM_RT_USE_CRITICALSECTION 1
 #else
-#include <threads.h>
-#define WASM_RT_MUTEX mtx_t
-#define WASM_RT_USE_C11THREADS 1
+#include <pthread.h>
+#define WASM_RT_MUTEX pthread_mutex_t
+#define WASM_RT_USE_PTHREADS 1
 #endif
 
 #endif

--- a/wasm2c/wasm-rt.h
+++ b/wasm2c/wasm-rt.h
@@ -67,7 +67,7 @@ extern "C" {
 #include <windows.h>
 #define WASM_RT_MUTEX CRITICAL_SECTION
 #define WASM_RT_USE_CRITICALSECTION 1
-#elif defined(__STDC_NO_THREADS__)
+#elif defined(__APPLE__) || defined(__STDC_NO_THREADS__)
 #include <pthread.h>
 #define WASM_RT_MUTEX pthread_mutex_t
 #define WASM_RT_USE_PTHREADS 1

--- a/wasm2c/wasm-rt.h
+++ b/wasm2c/wasm-rt.h
@@ -59,7 +59,7 @@ extern "C" {
 
 /**
  * Many devices don't implement the C11 threads.h. We use CriticalSection APIs
- * for Windows and pthreads everywhere else.
+ * for Windows and pthreads on other platforms where threads are not available.
  */
 #ifdef WASM_RT_C11_AVAILABLE
 
@@ -67,10 +67,14 @@ extern "C" {
 #include <windows.h>
 #define WASM_RT_MUTEX CRITICAL_SECTION
 #define WASM_RT_USE_CRITICALSECTION 1
-#else
+#elif defined(__STDC_NO_THREADS__)
 #include <pthread.h>
 #define WASM_RT_MUTEX pthread_mutex_t
 #define WASM_RT_USE_PTHREADS 1
+#else
+#include <threads.h>
+#define WASM_RT_MUTEX mtx_t
+#define WASM_RT_USE_C11THREADS 1
 #endif
 
 #endif


### PR DESCRIPTION
glibc was slow to implement threads, whereas pthreads are much more readily available. I'm on a platform where my glibc is old enough that it doesn't have threads.h and I'm unable to upgrade, but everything works find if I just use pthreads.