### PR TITLE
clang-format-diff: fix failing CI for newly pushed branches

### DIFF
--- a/scripts/clang-format-diff.sh
+++ b/scripts/clang-format-diff.sh
@@ -5,12 +5,23 @@ set -o pipefail
 
 if [ -n "$1" ]; then
   BRANCH="$1"
+elif [ "$CI" != "true" ]; then
+  echo "Please specify a base branch in the command line"
+  exit 1
 elif [ -n "$GITHUB_EVENT_BEFORE" ] && [ "push" = "$GITHUB_EVENT_NAME" ]; then
   BRANCH="$GITHUB_EVENT_BEFORE"
 elif [ -n "$GITHUB_BASE_REF" ]; then
   BRANCH="origin/$GITHUB_BASE_REF"
-else
+elif git symbolic-ref -q HEAD; then # check if we're in a branch
   BRANCH="@{upstream}"
+else
+  # in a detached HEAD.
+  # default to origin/main, this is a "last resort" to make this script do the
+  # right thing, and is only really here so it works when pushing a new branch,
+  # with the caveat that it assumes the base branch to be called "main".
+  # (this has been the case with wabt for a while. may fail if the repo lacks a
+  # "main" branch for some reason.)
+  BRANCH="origin/main"
 fi
 
 MERGE_BASE=$(git merge-base $BRANCH HEAD)


### PR DESCRIPTION
Don't try to find upstream in detached HEAD

HEAD is detached for new branches.

- - -

This is only really relevant when creating a new branch (e.g. in a fork, before submitting a PR) but it's been bothering us *forever* so we decided to fix it.

Before: https://github.com/SoniEx2/wasm2kotlin/actions/runs/7830157694/job/21363568601

After: https://github.com/SoniEx2/wasm2kotlin/actions/runs/7830660258/job/21365229032