### PR TITLE
Align release workflow with CI, for Apple Silicon

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-12, windows-latest]
+        os: [ubuntu-20.04, macos-12, macos-14, windows-latest]
     defaults:
       run:
         shell: bash
     steps:
-    - uses: actions/setup-python@v1
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - uses: actions/checkout@v1
@@ -33,7 +33,7 @@ jobs:
 
     - name: install ninja (osx)
       run: brew install ninja
-      if: matrix.os == 'macos-12'
+      if: matrix.os == 'macos-12' || matrix.os == 'macos-14'
 
     - name: install ninja (win)
       run: choco install ninja


### PR DESCRIPTION
follow up to #2406, just copied the changes from the CI workflow over to the release workflow.