### PR TITLE
wast2json: Support outputting negative numbers for v128 values

### DIFF
--- a/include/wabt/ir.h
+++ b/include/wabt/ir.h
@@ -156,6 +156,16 @@ struct Const {
   void set_externref(uintptr_t x) { From(Type::ExternRef, x); }
   void set_null(Type type) { From<uintptr_t>(type, kRefNullBits); }
 
+  bool is_negative(int lane = 0) const {
+    return lane < 16 && is_negative_[lane];
+  }
+
+  void set_is_negative(int lane, bool is_negative) {
+    if (lane < 16) {
+      is_negative_[lane] = is_negative;
+    }
+  }
+
   bool is_expected_nan(int lane = 0) const {
     return expected_nan(lane) != ExpectedNan::None;
   }
@@ -198,6 +208,9 @@ struct Const {
   Type type_;
   Type lane_type_;  // Only valid if type_ == Type::V128.
   v128 data_;
+  // Used for wast2json, we need to know if a number is negative to prefix it
+  // properly.
+  bool is_negative_[16];
   ExpectedNan nan_[4];
 };
 using ConstVector = std::vector<Const>;

--- a/src/binary-writer-spec.cc
+++ b/src/binary-writer-spec.cc
@@ -216,7 +216,7 @@ void BinaryWriterSpec::WriteConst(const Const& const_) {
       WriteString("i32");
       WriteSeparator();
       WriteKey("value");
-      json_stream_->Writef("\"%u\"", const_.u32());
+      json_stream_->Writef("\"%" PRIu32 "\"", const_.u32());
       break;
 
     case Type::I64:
@@ -266,22 +266,50 @@ void BinaryWriterSpec::WriteConst(const Const& const_) {
       json_stream_->Writef("[");
 
       for (int lane = 0; lane < const_.lane_count(); ++lane) {
+        auto negative_char = const_.is_negative(lane) ? "-" : "";
         switch (const_.lane_type()) {
           case Type::I8:
-            json_stream_->Writef("\"%u\"", const_.v128_lane<uint8_t>(lane));
+            if (const_.is_negative(lane)) {
+              auto converted = UINT8_MAX - const_.v128_lane<uint8_t>(lane) + 1;
+              json_stream_->Writef("\"-%" PRIu8 "\"", converted);
+
+            } else {
+              json_stream_->Writef("\"%s%" PRIu8 "\"", negative_char,
+                                   const_.v128_lane<uint8_t>(lane));
+            }
             break;
 
           case Type::I16:
-            json_stream_->Writef("\"%u\"", const_.v128_lane<uint16_t>(lane));
+            if (const_.is_negative(lane)) {
+              auto converted =
+                  UINT16_MAX - const_.v128_lane<uint16_t>(lane) + 1;
+              json_stream_->Writef("\"-%" PRIu16 "\"", converted);
+            } else {
+              json_stream_->Writef("\"%" PRIu16 "\"",
+                                   const_.v128_lane<uint16_t>(lane));
+            }
             break;
 
           case Type::I32:
-            json_stream_->Writef("\"%u\"", const_.v128_lane<uint32_t>(lane));
+            if (const_.is_negative(lane)) {
+              auto converted =
+                  UINT32_MAX - const_.v128_lane<uint32_t>(lane) + 1;
+              json_stream_->Writef("\"-%" PRIu32 "\"", converted);
+            } else {
+              json_stream_->Writef("\"%s%" PRIu32 "\"", negative_char,
+                                   const_.v128_lane<uint32_t>(lane));
+            }
             break;
 
           case Type::I64:
-            json_stream_->Writef("\"%" PRIu64 "\"",
-                                 const_.v128_lane<uint64_t>(lane));
+            if (const_.is_negative(lane)) {
+              auto converted =
+                  UINT64_MAX - const_.v128_lane<uint64_t>(lane) + 1;
+              json_stream_->Writef("\"-%" PRIu64 "\"", converted);
+            } else {
+              json_stream_->Writef("\"%s%" PRIu64 "\"", negative_char,
+                                   const_.v128_lane<uint64_t>(lane));
+            }
             break;
 
           case Type::F32:

--- a/src/wast-parser.cc
+++ b/src/wast-parser.cc
@@ -2644,6 +2644,8 @@ Result WastParser::ParseSimdV128Const(Const* const_,
     if (integer) {
       std::string_view sv = Consume().literal().text;
 
+      const_->set_is_negative(lane, sv[0] == '-');
+
       switch (lane_count) {
         case 16: {
           uint8_t value = 0;


### PR DESCRIPTION
wast2json doesn't generate correct values for v128 arrays when negative numbers are in the .wast file.

-1 will become 65535 for i16. This corrects that.

Difference is easily visible in the `simd_iNxM_arith` tests