### PR TITLE
Avoid creating temporary vector copies when checking signature

### DIFF
--- a/include/wabt/type-checker.h
+++ b/include/wabt/type-checker.h
@@ -18,6 +18,7 @@
 #define WABT_TYPE_CHECKER_H_
 
 #include <functional>
+#include <type_traits>
 #include <vector>
 
 #include "wabt/common.h"
@@ -182,6 +183,9 @@ class TypeChecker {
 
   template <typename... Args>
   void PrintStackIfFailed(Result result, const char* desc, Args... args) {
+    // Assert all args are Type or Type::Enum. If it's a TypeVector then
+    // PrintStackIfFailedV() should be used instead.
+    static_assert((std::is_constructible_v<Type, Args> && ...));
     // Minor optimization, check result before constructing the vector to pass
     // to the other overload of PrintStackIfFailed.
     if (Failed(result)) {

--- a/src/type-checker.cc
+++ b/src/type-checker.cc
@@ -254,7 +254,7 @@ Result TypeChecker::CheckSignature(const TypeVector& sig, const char* desc) {
   for (size_t i = 0; i < sig.size(); ++i) {
     result |= PeekAndCheckType(sig.size() - i - 1, sig[i]);
   }
-  PrintStackIfFailed(result, desc, sig);
+  PrintStackIfFailedV(result, desc, sig, /*is_end=*/false);
   return result;
 }
 


### PR DESCRIPTION
I was doing some local bench marking and found a significant amount of wasm-validate's time came from copying (and then destroying) temporary vectors here. [Currently `CheckSignature()` is calling `PrintStackIfFailed()`]((https://github.com/WebAssembly/wabt/blob/65b61e0a3fde8c4fc82cee53bd5cdd0959b6ffa6/src/type-checker.cc#L257)) and passing `sig` (which is already a `TypeVector), whic creates a copy. This change eliminates the unnecessary vector copy and adds a static assertion that should prevent this from happening again.