### PR TITLE
fix: null-defer about data and elem in wasm-interp

### DIFF
--- a/include/wabt/interp/interp.h
+++ b/include/wabt/interp/interp.h
@@ -1163,12 +1163,12 @@ class Thread {
   RunResult DoStore(Instr, Trap::Ptr* out_trap);
 
   RunResult DoMemoryInit(Instr, Trap::Ptr* out_trap);
-  RunResult DoDataDrop(Instr);
+  RunResult DoDataDrop(Instr, Trap::Ptr* out_trap);
   RunResult DoMemoryCopy(Instr, Trap::Ptr* out_trap);
   RunResult DoMemoryFill(Instr, Trap::Ptr* out_trap);
 
   RunResult DoTableInit(Instr, Trap::Ptr* out_trap);
-  RunResult DoElemDrop(Instr);
+  RunResult DoElemDrop(Instr, Trap::Ptr* out_trap);
   RunResult DoTableCopy(Instr, Trap::Ptr* out_trap);
   RunResult DoTableGet(Instr, Trap::Ptr* out_trap);
   RunResult DoTableSet(Instr, Trap::Ptr* out_trap);

--- a/src/interp/interp.cc
+++ b/src/interp/interp.cc
@@ -2085,10 +2085,9 @@ RunResult Thread::DoReinterpret() {
 RunResult Thread::DoMemoryInit(Instr instr, Trap::Ptr* out_trap) {
   Memory::Ptr memory{store_, inst_->memories()[instr.imm_u32x2.fst]};
   TRAP_IF(inst_->datas().size() <= instr.imm_u32x2.snd,
-      StringPrintf("out of bounds data access: access at %u "
-                    ">= max value %" PRIu64,
-                    instr.imm_u32x2.snd,
-                    inst_->datas().size()));
+          StringPrintf("out of bounds data access: access at %u "
+                       ">= max value %zu",
+                       instr.imm_u32x2.snd, inst_->datas().size()));
   auto&& data = inst_->datas()[instr.imm_u32x2.snd];
   auto size = Pop<u32>();
   auto src = Pop<u32>();
@@ -2100,10 +2099,9 @@ RunResult Thread::DoMemoryInit(Instr instr, Trap::Ptr* out_trap) {
 
 RunResult Thread::DoDataDrop(Instr instr, Trap::Ptr* out_trap) {
   TRAP_IF(inst_->datas().size() <= instr.imm_u32,
-      StringPrintf("out of bounds data access: access at %u "
-                    ">= max value %" PRIu64,
-                    instr.imm_u32,
-                    inst_->datas().size()));
+          StringPrintf("out of bounds data access: access at %u "
+                       ">= max value %zu",
+                       instr.imm_u32, inst_->datas().size()));
   inst_->datas()[instr.imm_u32].Drop();
   return RunResult::Ok;
 }
@@ -2133,10 +2131,9 @@ RunResult Thread::DoMemoryFill(Instr instr, Trap::Ptr* out_trap) {
 RunResult Thread::DoTableInit(Instr instr, Trap::Ptr* out_trap) {
   Table::Ptr table{store_, inst_->tables()[instr.imm_u32x2.fst]};
   TRAP_IF(inst_->elems().size() <= instr.imm_u32x2.snd,
-    StringPrintf("out of bounds elem access: access at %u "
-                  ">= max value %" PRIu64,
-                  instr.imm_u32x2.snd,
-                  inst_->elems().size()));
+          StringPrintf("out of bounds elem access: access at %u "
+                       ">= max value %zu",
+                       instr.imm_u32x2.snd, inst_->elems().size()));
   auto&& elem = inst_->elems()[instr.imm_u32x2.snd];
   auto size = Pop<u32>();
   auto src = Pop<u32>();
@@ -2148,10 +2145,9 @@ RunResult Thread::DoTableInit(Instr instr, Trap::Ptr* out_trap) {
 
 RunResult Thread::DoElemDrop(Instr instr, Trap::Ptr* out_trap) {
   TRAP_IF(inst_->elems().size() <= instr.imm_u32,
-    StringPrintf("out of bounds elem access: access at %u "
-                  ">= max value %" PRIu64,
-                  instr.imm_u32,
-                  inst_->elems().size()));
+          StringPrintf("out of bounds elem access: access at %u "
+                       ">= max value %zu",
+                       instr.imm_u32, inst_->elems().size()));
   inst_->elems()[instr.imm_u32].Drop();
   return RunResult::Ok;
 }


### PR DESCRIPTION
fix some null-defer case about data and elem.

- issue: [2431](https://github.com/WebAssembly/wabt/issues/2431)