### PR TITLE
Fix compiling wasm2c's runtime library with Android NDK(macro definition conflicts with sysroot)

### DIFF
--- a/wasm2c/wasm-rt-mem-impl-helper.inc
+++ b/wasm2c/wasm-rt-mem-impl-helper.inc
@@ -67,7 +67,7 @@ void MEMORY_API_NAME(wasm_rt_allocate_memory)(MEMORY_TYPE* memory,
                                               uint64_t initial_pages,
                                               uint64_t max_pages,
                                               bool is64) {
-  uint64_t byte_length = initial_pages * PAGE_SIZE;
+  uint64_t byte_length = initial_pages * WASM_PAGE_SIZE;
   memory->size = byte_length;
   memory->pages = initial_pages;
   memory->max_pages = max_pages;
@@ -103,9 +103,9 @@ static uint64_t MEMORY_API_NAME(grow_memory_impl)(MEMORY_TYPE* memory,
   if (new_pages < old_pages || new_pages > memory->max_pages) {
     return (uint64_t)-1;
   }
-  uint64_t old_size = old_pages * PAGE_SIZE;
-  uint64_t new_size = new_pages * PAGE_SIZE;
-  uint64_t delta_size = delta * PAGE_SIZE;
+  uint64_t old_size = old_pages * WASM_PAGE_SIZE;
+  uint64_t new_size = new_pages * WASM_PAGE_SIZE;
+  uint64_t delta_size = delta * WASM_PAGE_SIZE;
 #if WASM_RT_USE_MMAP
   MEMORY_CELL_TYPE new_data = memory->data;
   int ret = os_mprotect((void*)(new_data + old_size), delta_size);

--- a/wasm2c/wasm-rt-mem-impl.c
+++ b/wasm2c/wasm-rt-mem-impl.c
@@ -25,7 +25,7 @@
 #include <sys/mman.h>
 #endif
 
-#define PAGE_SIZE 65536
+#define WASM_PAGE_SIZE 65536
 
 #ifdef WASM_RT_GROW_FAILED_HANDLER
 extern void WASM_RT_GROW_FAILED_HANDLER();
@@ -144,7 +144,7 @@ static uint64_t get_alloc_size_for_mmap(uint64_t max_pages, bool is64) {
   return max_size;
 #else
   if (max_pages != 0) {
-    const uint64_t max_size = max_pages * PAGE_SIZE;
+    const uint64_t max_size = max_pages * WASM_PAGE_SIZE;
     return max_size;
   }
 
@@ -175,4 +175,4 @@ static uint64_t get_alloc_size_for_mmap(uint64_t max_pages, bool is64) {
 #undef WIN_MEMORY_LOCK_VAR_INIT
 #undef WIN_MEMORY_LOCK_AQUIRE
 #undef WIN_MEMORY_LOCK_RELEASE
-#undef PAGE_SIZE
+#undef WASM_PAGE_SIZE


### PR DESCRIPTION
Building wasm2c'c wasm_rt with the Android NDK results in the following error
```
third_party/wabt/wasm2c/wasm-rt-mem-impl.c:28:9: error: 'PAGE_SIZE' macro redefined [-Werror,-Wmacro-redefined]
#define PAGE_SIZE 65536
        ^
third_party/android/ndk/stable/toolchains/llvm/prebuilt/linux-x86_64/bin/../real-bin/../sysroot/usr/include/sys/user.h:37:9: note: previous definition is here
#define PAGE_SIZE 4096
        ^
1 error generated.
```

This PR fixes that. 