### PR TITLE
wasm2c: Segue support for CPUs without wrgsbase instructions

### DIFF
--- a/src/c-writer.cc
+++ b/src/c-writer.cc
@@ -2449,17 +2449,17 @@ bool CWriter::IsSingleUnsharedMemory() {
 void CWriter::InstallSegueBase(Memory* memory, bool save_old_value) {
   NonIndented([&] { Write("#if WASM_RT_USE_SEGUE", Newline()); });
   if (save_old_value) {
-    Write("uintptr_t segue_saved_base = WASM_RT_SEGUE_READ_BASE();", Newline());
+    Write("void* segue_saved_base = wasm_rt_segue_read_base();", Newline());
   }
   auto primary_memory =
       ExternalInstanceRef(ModuleFieldType::Memory, memory->name);
-  Write("WASM_RT_SEGUE_WRITE_BASE(", primary_memory, ".data);", Newline());
+  Write("wasm_rt_segue_write_base(", primary_memory, ".data);", Newline());
   NonIndented([&] { Write("#endif", Newline()); });
 }
 
 void CWriter::RestoreSegueBase() {
   NonIndented([&] { Write("#if WASM_RT_USE_SEGUE", Newline()); });
-  Write("WASM_RT_SEGUE_WRITE_BASE(segue_saved_base);", Newline());
+  Write("wasm_rt_segue_write_base(segue_saved_base);", Newline());
   NonIndented([&] { Write("#endif", Newline()); });
 }
 

--- a/test/wasm2c/add.txt
+++ b/test/wasm2c/add.txt
@@ -99,11 +99,16 @@ u32 w2c_test_add(w2c_test*, u32, u32);
 //     for accessing pointers, and supports memcpy on pointers with custom
 //     "address namespaces". GCC does not support the memcpy requirement, so
 //     this leaves only clang for now.
-// (5) The OS doesn't replace the segment register on context switch which
+// (5) The OS provides a way to query if (rd|wr)gsbase is allowed by the kernel
+// or the implementation has to use a syscall for this.
+// (6) The OS doesn't replace the segment register on context switch which
 //     eliminates windows for now
+//
+// While more OS can be supported in the future, we only support linux for now
 #if WASM_RT_ALLOW_SEGUE && !WABT_BIG_ENDIAN &&                               \
     (defined(__x86_64__) || defined(_M_X64)) && IS_SINGLE_UNSHARED_MEMORY && \
-    __clang__ && __has_builtin(__builtin_ia32_wrgsbase64) && !defined(_WIN32)
+    __clang__ && __has_builtin(__builtin_ia32_wrgsbase64) &&                 \
+    !defined(_WIN32) && defined(__linux__)
 #define WASM_RT_USE_SEGUE 1
 #else
 #define WASM_RT_USE_SEGUE 0
@@ -112,9 +117,20 @@ u32 w2c_test_add(w2c_test*, u32, u32);
 
 #if WASM_RT_USE_SEGUE
 // POSIX uses FS for TLS, GS is free
-#define WASM_RT_SEGUE_READ_BASE() __builtin_ia32_rdgsbase64()
-#define WASM_RT_SEGUE_WRITE_BASE(base) \
-  __builtin_ia32_wrgsbase64((uintptr_t)base)
+static inline void* wasm_rt_segue_read_base() {
+  if (wasm_rt_fsgsbase_inst_supported) {
+    return (void*)__builtin_ia32_rdgsbase64();
+  } else {
+    return wasm_rt_syscall_get_segue_base();
+  }
+}
+static inline void wasm_rt_segue_write_base(void* base) {
+  if (wasm_rt_fsgsbase_inst_supported) {
+    __builtin_ia32_wrgsbase64((uintptr_t)base);
+  } else {
+    wasm_rt_syscall_set_segue_base(base);
+  }
+}
 #define MEM_ADDR_MEMOP(mem, addr, n) ((uint8_t __seg_gs*)(uintptr_t)addr)
 #else
 #define MEM_ADDR_MEMOP(mem, addr, n) MEM_ADDR(mem, addr, n)
@@ -170,7 +186,7 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
 #if WASM_RT_USE_SEGUE && WASM_RT_SANITY_CHECKS
 #include <stdio.h>
 #define WASM_RT_CHECK_BASE(mem)                                               \
-  if (((uintptr_t)((mem)->data)) != ((uintptr_t)WASM_RT_SEGUE_READ_BASE())) { \
+  if (((uintptr_t)((mem)->data)) != ((uintptr_t)wasm_rt_segue_read_base())) { \
     puts("Segment register mismatch\n");                                      \
     abort();                                                                  \
   }

--- a/test/wasm2c/check-imports.txt
+++ b/test/wasm2c/check-imports.txt
@@ -123,11 +123,16 @@ extern const u8 wasm2c_test_is64_env_0x5F_linear_memory;
 //     for accessing pointers, and supports memcpy on pointers with custom
 //     "address namespaces". GCC does not support the memcpy requirement, so
 //     this leaves only clang for now.
-// (5) The OS doesn't replace the segment register on context switch which
+// (5) The OS provides a way to query if (rd|wr)gsbase is allowed by the kernel
+// or the implementation has to use a syscall for this.
+// (6) The OS doesn't replace the segment register on context switch which
 //     eliminates windows for now
+//
+// While more OS can be supported in the future, we only support linux for now
 #if WASM_RT_ALLOW_SEGUE && !WABT_BIG_ENDIAN &&                               \
     (defined(__x86_64__) || defined(_M_X64)) && IS_SINGLE_UNSHARED_MEMORY && \
-    __clang__ && __has_builtin(__builtin_ia32_wrgsbase64) && !defined(_WIN32)
+    __clang__ && __has_builtin(__builtin_ia32_wrgsbase64) &&                 \
+    !defined(_WIN32) && defined(__linux__)
 #define WASM_RT_USE_SEGUE 1
 #else
 #define WASM_RT_USE_SEGUE 0
@@ -136,9 +141,20 @@ extern const u8 wasm2c_test_is64_env_0x5F_linear_memory;
 
 #if WASM_RT_USE_SEGUE
 // POSIX uses FS for TLS, GS is free
-#define WASM_RT_SEGUE_READ_BASE() __builtin_ia32_rdgsbase64()
-#define WASM_RT_SEGUE_WRITE_BASE(base) \
-  __builtin_ia32_wrgsbase64((uintptr_t)base)
+static inline void* wasm_rt_segue_read_base() {
+  if (wasm_rt_fsgsbase_inst_supported) {
+    return (void*)__builtin_ia32_rdgsbase64();
+  } else {
+    return wasm_rt_syscall_get_segue_base();
+  }
+}
+static inline void wasm_rt_segue_write_base(void* base) {
+  if (wasm_rt_fsgsbase_inst_supported) {
+    __builtin_ia32_wrgsbase64((uintptr_t)base);
+  } else {
+    wasm_rt_syscall_set_segue_base(base);
+  }
+}
 #define MEM_ADDR_MEMOP(mem, addr, n) ((uint8_t __seg_gs*)(uintptr_t)addr)
 #else
 #define MEM_ADDR_MEMOP(mem, addr, n) MEM_ADDR(mem, addr, n)
@@ -194,7 +210,7 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
 #if WASM_RT_USE_SEGUE && WASM_RT_SANITY_CHECKS
 #include <stdio.h>
 #define WASM_RT_CHECK_BASE(mem)                                               \
-  if (((uintptr_t)((mem)->data)) != ((uintptr_t)WASM_RT_SEGUE_READ_BASE())) { \
+  if (((uintptr_t)((mem)->data)) != ((uintptr_t)wasm_rt_segue_read_base())) { \
     puts("Segment register mismatch\n");                                      \
     abort();                                                                  \
   }
@@ -809,12 +825,12 @@ void wasm2c_test_instantiate(w2c_test* instance, struct w2c_env* w2c_env_instanc
   init_tables(instance);
   init_memories(instance);
 #if WASM_RT_USE_SEGUE
-  uintptr_t segue_saved_base = WASM_RT_SEGUE_READ_BASE();
-  WASM_RT_SEGUE_WRITE_BASE((*instance->w2c_env_0x5F_linear_memory).data);
+  void* segue_saved_base = wasm_rt_segue_read_base();
+  wasm_rt_segue_write_base((*instance->w2c_env_0x5F_linear_memory).data);
 #endif
   init_elem_instances(instance);
 #if WASM_RT_USE_SEGUE
-  WASM_RT_SEGUE_WRITE_BASE(segue_saved_base);
+  wasm_rt_segue_write_base(segue_saved_base);
 #endif
 }
 

--- a/test/wasm2c/export-names.txt
+++ b/test/wasm2c/export-names.txt
@@ -123,11 +123,16 @@ void w2c_test_0xE20x9D0xA40xEF0xB80x8F(w2c_test*);
 //     for accessing pointers, and supports memcpy on pointers with custom
 //     "address namespaces". GCC does not support the memcpy requirement, so
 //     this leaves only clang for now.
-// (5) The OS doesn't replace the segment register on context switch which
+// (5) The OS provides a way to query if (rd|wr)gsbase is allowed by the kernel
+// or the implementation has to use a syscall for this.
+// (6) The OS doesn't replace the segment register on context switch which
 //     eliminates windows for now
+//
+// While more OS can be supported in the future, we only support linux for now
 #if WASM_RT_ALLOW_SEGUE && !WABT_BIG_ENDIAN &&                               \
     (defined(__x86_64__) || defined(_M_X64)) && IS_SINGLE_UNSHARED_MEMORY && \
-    __clang__ && __has_builtin(__builtin_ia32_wrgsbase64) && !defined(_WIN32)
+    __clang__ && __has_builtin(__builtin_ia32_wrgsbase64) &&                 \
+    !defined(_WIN32) && defined(__linux__)
 #define WASM_RT_USE_SEGUE 1
 #else
 #define WASM_RT_USE_SEGUE 0
@@ -136,9 +141,20 @@ void w2c_test_0xE20x9D0xA40xEF0xB80x8F(w2c_test*);
 
 #if WASM_RT_USE_SEGUE
 // POSIX uses FS for TLS, GS is free
-#define WASM_RT_SEGUE_READ_BASE() __builtin_ia32_rdgsbase64()
-#define WASM_RT_SEGUE_WRITE_BASE(base) \
-  __builtin_ia32_wrgsbase64((uintptr_t)base)
+static inline void* wasm_rt_segue_read_base() {
+  if (wasm_rt_fsgsbase_inst_supported) {
+    return (void*)__builtin_ia32_rdgsbase64();
+  } else {
+    return wasm_rt_syscall_get_segue_base();
+  }
+}
+static inline void wasm_rt_segue_write_base(void* base) {
+  if (wasm_rt_fsgsbase_inst_supported) {
+    __builtin_ia32_wrgsbase64((uintptr_t)base);
+  } else {
+    wasm_rt_syscall_set_segue_base(base);
+  }
+}
 #define MEM_ADDR_MEMOP(mem, addr, n) ((uint8_t __seg_gs*)(uintptr_t)addr)
 #else
 #define MEM_ADDR_MEMOP(mem, addr, n) MEM_ADDR(mem, addr, n)
@@ -194,7 +210,7 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
 #if WASM_RT_USE_SEGUE && WASM_RT_SANITY_CHECKS
 #include <stdio.h>
 #define WASM_RT_CHECK_BASE(mem)                                               \
-  if (((uintptr_t)((mem)->data)) != ((uintptr_t)WASM_RT_SEGUE_READ_BASE())) { \
+  if (((uintptr_t)((mem)->data)) != ((uintptr_t)wasm_rt_segue_read_base())) { \
     puts("Segment register mismatch\n");                                      \
     abort();                                                                  \
   }
@@ -780,60 +796,60 @@ static void init_memories(w2c_test* instance) {
 /* export: '' */
 void w2c_test_(w2c_test* instance) {
 #if WASM_RT_USE_SEGUE
-  uintptr_t segue_saved_base = WASM_RT_SEGUE_READ_BASE();
-  WASM_RT_SEGUE_WRITE_BASE((*instance->w2c_0x5Cmodule_import0x200x2A0x2F).data);
+  void* segue_saved_base = wasm_rt_segue_read_base();
+  wasm_rt_segue_write_base((*instance->w2c_0x5Cmodule_import0x200x2A0x2F).data);
 #endif
   w2c_test__0(instance);
 #if WASM_RT_USE_SEGUE
-  WASM_RT_SEGUE_WRITE_BASE(segue_saved_base);
+  wasm_rt_segue_write_base(segue_saved_base);
 #endif
 }
 
 /* export: '*\2F' */
 void w2c_test_0x2A0x2F(w2c_test* instance) {
 #if WASM_RT_USE_SEGUE
-  uintptr_t segue_saved_base = WASM_RT_SEGUE_READ_BASE();
-  WASM_RT_SEGUE_WRITE_BASE((*instance->w2c_0x5Cmodule_import0x200x2A0x2F).data);
+  void* segue_saved_base = wasm_rt_segue_read_base();
+  wasm_rt_segue_write_base((*instance->w2c_0x5Cmodule_import0x200x2A0x2F).data);
 #endif
   w2c_test__0(instance);
 #if WASM_RT_USE_SEGUE
-  WASM_RT_SEGUE_WRITE_BASE(segue_saved_base);
+  wasm_rt_segue_write_base(segue_saved_base);
 #endif
 }
 
 /* export: '\3F\3F\2F' */
 void w2c_test_0x3F0x3F0x2F(w2c_test* instance) {
 #if WASM_RT_USE_SEGUE
-  uintptr_t segue_saved_base = WASM_RT_SEGUE_READ_BASE();
-  WASM_RT_SEGUE_WRITE_BASE((*instance->w2c_0x5Cmodule_import0x200x2A0x2F).data);
+  void* segue_saved_base = wasm_rt_segue_read_base();
+  wasm_rt_segue_write_base((*instance->w2c_0x5Cmodule_import0x200x2A0x2F).data);
 #endif
   w2c_test__0(instance);
 #if WASM_RT_USE_SEGUE
-  WASM_RT_SEGUE_WRITE_BASE(segue_saved_base);
+  wasm_rt_segue_write_base(segue_saved_base);
 #endif
 }
 
 /* export: '\0A' */
 void w2c_test_0x0A(w2c_test* instance) {
 #if WASM_RT_USE_SEGUE
-  uintptr_t segue_saved_base = WASM_RT_SEGUE_READ_BASE();
-  WASM_RT_SEGUE_WRITE_BASE((*instance->w2c_0x5Cmodule_import0x200x2A0x2F).data);
+  void* segue_saved_base = wasm_rt_segue_read_base();
+  wasm_rt_segue_write_base((*instance->w2c_0x5Cmodule_import0x200x2A0x2F).data);
 #endif
   w2c_test__0(instance);
 #if WASM_RT_USE_SEGUE
-  WASM_RT_SEGUE_WRITE_BASE(segue_saved_base);
+  wasm_rt_segue_write_base(segue_saved_base);
 #endif
 }
 
 /* export: '\E2\9D\A4\EF\B8\8F' */
 void w2c_test_0xE20x9D0xA40xEF0xB80x8F(w2c_test* instance) {
 #if WASM_RT_USE_SEGUE
-  uintptr_t segue_saved_base = WASM_RT_SEGUE_READ_BASE();
-  WASM_RT_SEGUE_WRITE_BASE((*instance->w2c_0x5Cmodule_import0x200x2A0x2F).data);
+  void* segue_saved_base = wasm_rt_segue_read_base();
+  wasm_rt_segue_write_base((*instance->w2c_0x5Cmodule_import0x200x2A0x2F).data);
 #endif
   w2c_test__0(instance);
 #if WASM_RT_USE_SEGUE
-  WASM_RT_SEGUE_WRITE_BASE(segue_saved_base);
+  wasm_rt_segue_write_base(segue_saved_base);
 #endif
 }
 
@@ -850,11 +866,11 @@ void wasm2c_test_instantiate(w2c_test* instance, struct w2c_0x5Cmodule* w2c_0x5C
   init_instance_import(instance, w2c_0x5Cmodule_instance);
   init_memories(instance);
 #if WASM_RT_USE_SEGUE
-  uintptr_t segue_saved_base = WASM_RT_SEGUE_READ_BASE();
-  WASM_RT_SEGUE_WRITE_BASE((*instance->w2c_0x5Cmodule_import0x200x2A0x2F).data);
+  void* segue_saved_base = wasm_rt_segue_read_base();
+  wasm_rt_segue_write_base((*instance->w2c_0x5Cmodule_import0x200x2A0x2F).data);
 #endif
 #if WASM_RT_USE_SEGUE
-  WASM_RT_SEGUE_WRITE_BASE(segue_saved_base);
+  wasm_rt_segue_write_base(segue_saved_base);
 #endif
 }
 

--- a/test/wasm2c/hello.txt
+++ b/test/wasm2c/hello.txt
@@ -131,11 +131,16 @@ void w2c_test_0x5Fstart(w2c_test*);
 //     for accessing pointers, and supports memcpy on pointers with custom
 //     "address namespaces". GCC does not support the memcpy requirement, so
 //     this leaves only clang for now.
-// (5) The OS doesn't replace the segment register on context switch which
+// (5) The OS provides a way to query if (rd|wr)gsbase is allowed by the kernel
+// or the implementation has to use a syscall for this.
+// (6) The OS doesn't replace the segment register on context switch which
 //     eliminates windows for now
+//
+// While more OS can be supported in the future, we only support linux for now
 #if WASM_RT_ALLOW_SEGUE && !WABT_BIG_ENDIAN &&                               \
     (defined(__x86_64__) || defined(_M_X64)) && IS_SINGLE_UNSHARED_MEMORY && \
-    __clang__ && __has_builtin(__builtin_ia32_wrgsbase64) && !defined(_WIN32)
+    __clang__ && __has_builtin(__builtin_ia32_wrgsbase64) &&                 \
+    !defined(_WIN32) && defined(__linux__)
 #define WASM_RT_USE_SEGUE 1
 #else
 #define WASM_RT_USE_SEGUE 0
@@ -144,9 +149,20 @@ void w2c_test_0x5Fstart(w2c_test*);
 
 #if WASM_RT_USE_SEGUE
 // POSIX uses FS for TLS, GS is free
-#define WASM_RT_SEGUE_READ_BASE() __builtin_ia32_rdgsbase64()
-#define WASM_RT_SEGUE_WRITE_BASE(base) \
-  __builtin_ia32_wrgsbase64((uintptr_t)base)
+static inline void* wasm_rt_segue_read_base() {
+  if (wasm_rt_fsgsbase_inst_supported) {
+    return (void*)__builtin_ia32_rdgsbase64();
+  } else {
+    return wasm_rt_syscall_get_segue_base();
+  }
+}
+static inline void wasm_rt_segue_write_base(void* base) {
+  if (wasm_rt_fsgsbase_inst_supported) {
+    __builtin_ia32_wrgsbase64((uintptr_t)base);
+  } else {
+    wasm_rt_syscall_set_segue_base(base);
+  }
+}
 #define MEM_ADDR_MEMOP(mem, addr, n) ((uint8_t __seg_gs*)(uintptr_t)addr)
 #else
 #define MEM_ADDR_MEMOP(mem, addr, n) MEM_ADDR(mem, addr, n)
@@ -202,7 +218,7 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
 #if WASM_RT_USE_SEGUE && WASM_RT_SANITY_CHECKS
 #include <stdio.h>
 #define WASM_RT_CHECK_BASE(mem)                                               \
-  if (((uintptr_t)((mem)->data)) != ((uintptr_t)WASM_RT_SEGUE_READ_BASE())) { \
+  if (((uintptr_t)((mem)->data)) != ((uintptr_t)wasm_rt_segue_read_base())) { \
     puts("Segment register mismatch\n");                                      \
     abort();                                                                  \
   }
@@ -817,12 +833,12 @@ wasm_rt_memory_t* w2c_test_memory(w2c_test* instance) {
 /* export: '_start' */
 void w2c_test_0x5Fstart(w2c_test* instance) {
 #if WASM_RT_USE_SEGUE
-  uintptr_t segue_saved_base = WASM_RT_SEGUE_READ_BASE();
-  WASM_RT_SEGUE_WRITE_BASE(instance->w2c_memory.data);
+  void* segue_saved_base = wasm_rt_segue_read_base();
+  wasm_rt_segue_write_base(instance->w2c_memory.data);
 #endif
   w2c_test_0x5Fstart_0(instance);
 #if WASM_RT_USE_SEGUE
-  WASM_RT_SEGUE_WRITE_BASE(segue_saved_base);
+  wasm_rt_segue_write_base(segue_saved_base);
 #endif
 }
 
@@ -836,13 +852,13 @@ void wasm2c_test_instantiate(w2c_test* instance, struct w2c_wasi__snapshot__prev
   init_tables(instance);
   init_memories(instance);
 #if WASM_RT_USE_SEGUE
-  uintptr_t segue_saved_base = WASM_RT_SEGUE_READ_BASE();
-  WASM_RT_SEGUE_WRITE_BASE(instance->w2c_memory.data);
+  void* segue_saved_base = wasm_rt_segue_read_base();
+  wasm_rt_segue_write_base(instance->w2c_memory.data);
 #endif
   init_elem_instances(instance);
   init_data_instances(instance);
 #if WASM_RT_USE_SEGUE
-  WASM_RT_SEGUE_WRITE_BASE(segue_saved_base);
+  wasm_rt_segue_write_base(segue_saved_base);
 #endif
 }
 

--- a/test/wasm2c/minimal.txt
+++ b/test/wasm2c/minimal.txt
@@ -93,11 +93,16 @@ wasm_rt_func_type_t wasm2c_test_get_func_type(uint32_t param_count, uint32_t res
 //     for accessing pointers, and supports memcpy on pointers with custom
 //     "address namespaces". GCC does not support the memcpy requirement, so
 //     this leaves only clang for now.
-// (5) The OS doesn't replace the segment register on context switch which
+// (5) The OS provides a way to query if (rd|wr)gsbase is allowed by the kernel
+// or the implementation has to use a syscall for this.
+// (6) The OS doesn't replace the segment register on context switch which
 //     eliminates windows for now
+//
+// While more OS can be supported in the future, we only support linux for now
 #if WASM_RT_ALLOW_SEGUE && !WABT_BIG_ENDIAN &&                               \
     (defined(__x86_64__) || defined(_M_X64)) && IS_SINGLE_UNSHARED_MEMORY && \
-    __clang__ && __has_builtin(__builtin_ia32_wrgsbase64) && !defined(_WIN32)
+    __clang__ && __has_builtin(__builtin_ia32_wrgsbase64) &&                 \
+    !defined(_WIN32) && defined(__linux__)
 #define WASM_RT_USE_SEGUE 1
 #else
 #define WASM_RT_USE_SEGUE 0
@@ -106,9 +111,20 @@ wasm_rt_func_type_t wasm2c_test_get_func_type(uint32_t param_count, uint32_t res
 
 #if WASM_RT_USE_SEGUE
 // POSIX uses FS for TLS, GS is free
-#define WASM_RT_SEGUE_READ_BASE() __builtin_ia32_rdgsbase64()
-#define WASM_RT_SEGUE_WRITE_BASE(base) \
-  __builtin_ia32_wrgsbase64((uintptr_t)base)
+static inline void* wasm_rt_segue_read_base() {
+  if (wasm_rt_fsgsbase_inst_supported) {
+    return (void*)__builtin_ia32_rdgsbase64();
+  } else {
+    return wasm_rt_syscall_get_segue_base();
+  }
+}
+static inline void wasm_rt_segue_write_base(void* base) {
+  if (wasm_rt_fsgsbase_inst_supported) {
+    __builtin_ia32_wrgsbase64((uintptr_t)base);
+  } else {
+    wasm_rt_syscall_set_segue_base(base);
+  }
+}
 #define MEM_ADDR_MEMOP(mem, addr, n) ((uint8_t __seg_gs*)(uintptr_t)addr)
 #else
 #define MEM_ADDR_MEMOP(mem, addr, n) MEM_ADDR(mem, addr, n)
@@ -164,7 +180,7 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
 #if WASM_RT_USE_SEGUE && WASM_RT_SANITY_CHECKS
 #include <stdio.h>
 #define WASM_RT_CHECK_BASE(mem)                                               \
-  if (((uintptr_t)((mem)->data)) != ((uintptr_t)WASM_RT_SEGUE_READ_BASE())) { \
+  if (((uintptr_t)((mem)->data)) != ((uintptr_t)wasm_rt_segue_read_base())) { \
     puts("Segment register mismatch\n");                                      \
     abort();                                                                  \
   }

--- a/test/wasm2c/tail-calls.txt
+++ b/test/wasm2c/tail-calls.txt
@@ -123,11 +123,16 @@ void wasm_tailcall_w2c_test_tailcaller(void **instance_ptr, void *tail_call_stac
 //     for accessing pointers, and supports memcpy on pointers with custom
 //     "address namespaces". GCC does not support the memcpy requirement, so
 //     this leaves only clang for now.
-// (5) The OS doesn't replace the segment register on context switch which
+// (5) The OS provides a way to query if (rd|wr)gsbase is allowed by the kernel
+// or the implementation has to use a syscall for this.
+// (6) The OS doesn't replace the segment register on context switch which
 //     eliminates windows for now
+//
+// While more OS can be supported in the future, we only support linux for now
 #if WASM_RT_ALLOW_SEGUE && !WABT_BIG_ENDIAN &&                               \
     (defined(__x86_64__) || defined(_M_X64)) && IS_SINGLE_UNSHARED_MEMORY && \
-    __clang__ && __has_builtin(__builtin_ia32_wrgsbase64) && !defined(_WIN32)
+    __clang__ && __has_builtin(__builtin_ia32_wrgsbase64) &&                 \
+    !defined(_WIN32) && defined(__linux__)
 #define WASM_RT_USE_SEGUE 1
 #else
 #define WASM_RT_USE_SEGUE 0
@@ -136,9 +141,20 @@ void wasm_tailcall_w2c_test_tailcaller(void **instance_ptr, void *tail_call_stac
 
 #if WASM_RT_USE_SEGUE
 // POSIX uses FS for TLS, GS is free
-#define WASM_RT_SEGUE_READ_BASE() __builtin_ia32_rdgsbase64()
-#define WASM_RT_SEGUE_WRITE_BASE(base) \
-  __builtin_ia32_wrgsbase64((uintptr_t)base)
+static inline void* wasm_rt_segue_read_base() {
+  if (wasm_rt_fsgsbase_inst_supported) {
+    return (void*)__builtin_ia32_rdgsbase64();
+  } else {
+    return wasm_rt_syscall_get_segue_base();
+  }
+}
+static inline void wasm_rt_segue_write_base(void* base) {
+  if (wasm_rt_fsgsbase_inst_supported) {
+    __builtin_ia32_wrgsbase64((uintptr_t)base);
+  } else {
+    wasm_rt_syscall_set_segue_base(base);
+  }
+}
 #define MEM_ADDR_MEMOP(mem, addr, n) ((uint8_t __seg_gs*)(uintptr_t)addr)
 #else
 #define MEM_ADDR_MEMOP(mem, addr, n) MEM_ADDR(mem, addr, n)
@@ -194,7 +210,7 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
 #if WASM_RT_USE_SEGUE && WASM_RT_SANITY_CHECKS
 #include <stdio.h>
 #define WASM_RT_CHECK_BASE(mem)                                               \
-  if (((uintptr_t)((mem)->data)) != ((uintptr_t)WASM_RT_SEGUE_READ_BASE())) { \
+  if (((uintptr_t)((mem)->data)) != ((uintptr_t)wasm_rt_segue_read_base())) { \
     puts("Segment register mismatch\n");                                      \
     abort();                                                                  \
   }

--- a/wasm2c/wasm-rt.h
+++ b/wasm2c/wasm-rt.h
@@ -294,6 +294,27 @@ extern WASM_RT_THREAD_LOCAL uint32_t wasm_rt_call_stack_depth;
 
 #endif
 
+#if WASM_RT_USE_SEGUE || WASM_RT_ALLOW_SEGUE
+/**
+ * The segue optimization uses x86 segments to point to a linear memory. If
+ * used, the runtime must query whether it can use the fast userspace wrgsbase
+ * instructions or whether it must invoke syscalls to set the segment base,
+ * depending on the supported CPU features. The result of this query is saved in
+ * this variable.
+ */
+extern bool wasm_rt_fsgsbase_inst_supported;
+/**
+ * If fast userspace wrgsbase instructions don't exist, the runtime most provide
+ * a function that invokes the OS' underlying syscall to set the segment base.
+ */
+void wasm_rt_syscall_set_segue_base(void* base);
+/**
+ * If fast userspace rdgsbase instructions don't exist, the runtime most provide
+ * a function that invokes the OS' underlying syscall to get the segment base.
+ */
+void* wasm_rt_syscall_get_segue_base();
+#endif
+
 #if defined(_MSC_VER)
 #define WASM_RT_NO_RETURN __declspec(noreturn)
 #else


### PR DESCRIPTION
For older CPUs (older than Ivybridge on Intel), the segment registers had to be set using system calls rather than userspace instructions. Update the segue implementation to fallback to system calls if userspace instructions are not supported.