### PR TITLE
Bump version to 1.0.36

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@
 #
 
 cmake_minimum_required(VERSION 3.16)
-project(WABT LANGUAGES C CXX VERSION 1.0.35)
+project(WABT LANGUAGES C CXX VERSION 1.0.36)
 
 include(GNUInstallDirs)
 


### PR DESCRIPTION
With #2447 merged, Halide would like to depend on a version of WABT with this fix in place.

Would you be willing to cut a release as version 1.0.36?

Thanks!

ATTN @steven-johnson 