### PR TITLE
Test harness: parse and ignore UPSTREAM tag

### DIFF
--- a/test/run-tests.py
+++ b/test/run-tests.py
@@ -492,7 +492,7 @@ class TestInfo(object):
             self.skip = True
         elif key == 'VERBOSE-ARGS':
             self.GetLastCommand().AppendVerboseArgs(value)
-        elif key in ['TODO', 'NOTE']:
+        elif key in ['TODO', 'NOTE', 'UPSTREAM']:
             pass
         elif key == 'TOOL':
             self.SetTool(value)


### PR DESCRIPTION
This is a funny idea we have, but it'd help a lot with maintenance if we could tag certain tests with an UPSTREAM: [commit ID] tag and then automatically check those tags against the testsuite. An initial step would be to parse such tag, but simply ignore it for now.

The idea being, wabt doesn't track the latest version of the testsuite all the time, yet wabt regularly upstreams regressions to the testsuite. For deduplication reasons, it'd be nice if we could automatically check the testsuite version and see if the local copy of the tests is no longer needed.

Thoughts?