### PR TITLE
Fix error message for ref.is_null

### DIFF
--- a/src/type-checker.cc
+++ b/src/type-checker.cc
@@ -30,7 +30,14 @@ std::string TypesToString(const TypeVector& types,
   }
 
   for (size_t i = 0; i < types.size(); ++i) {
-    result += types[i].GetName();
+    Type ty = types[i];
+    // NOTE: Reference (and GetName) is also used by (e.g.) objdump, which does
+    // not apply validation. do this here so as to not break that.
+    if (ty == Type::Reference && ty.GetReferenceIndex() == kInvalidIndex) {
+      result += "reference";
+    } else {
+      result += types[i].GetName();
+    }
     if (i < types.size() - 1) {
       result += ", ";
     }

--- a/src/type-checker.cc
+++ b/src/type-checker.cc
@@ -812,18 +812,10 @@ Result TypeChecker::OnRefNullExpr(Type type) {
 Result TypeChecker::OnRefIsNullExpr() {
   Type type;
   Result result = PeekType(0, &type);
-  if (!(type == Type::Any || type.IsRef())) {
-    TypeVector actual;
-    if (Succeeded(result)) {
-      actual.push_back(type);
-    }
-    std::string message =
-        "type mismatch in ref.is_null, expected reference but got " +
-        TypesToString(actual);
-    PrintError("%s", message.c_str());
-    result = Result::Error;
+  if (!type.IsRef()) {
+    type = Type::Reference;
   }
-  result |= DropTypes(1);
+  result |= PopAndCheck1Type(type, "ref.is_null");
   PushType(Type::I32);
   return result;
 }

--- a/test/spec/ref_is_null.txt
+++ b/test/spec/ref_is_null.txt
@@ -4,10 +4,10 @@
 init(externref:1) =>
 deinit() =>
 out/test/spec/ref_is_null.wast:52: assert_invalid passed:
-  out/test/spec/ref_is_null/ref_is_null.1.wasm:000001b: error: type mismatch in ref.is_null, expected [(ref -1)] but got [i32]
+  out/test/spec/ref_is_null/ref_is_null.1.wasm:000001b: error: type mismatch in ref.is_null, expected [reference] but got [i32]
   000001b: error: OnRefIsNullExpr callback failed
 out/test/spec/ref_is_null.wast:56: assert_invalid passed:
-  out/test/spec/ref_is_null/ref_is_null.2.wasm:0000018: error: type mismatch in ref.is_null, expected [(ref -1)] but got []
+  out/test/spec/ref_is_null/ref_is_null.2.wasm:0000018: error: type mismatch in ref.is_null, expected [reference] but got []
   0000018: error: OnRefIsNullExpr callback failed
 16/16 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/ref_is_null.txt
+++ b/test/spec/ref_is_null.txt
@@ -4,9 +4,10 @@
 init(externref:1) =>
 deinit() =>
 out/test/spec/ref_is_null.wast:52: assert_invalid passed:
-  out/test/spec/ref_is_null/ref_is_null.1.wasm:000001b: error: type mismatch in ref.is_null, expected reference but got [i32]
+  out/test/spec/ref_is_null/ref_is_null.1.wasm:000001b: error: type mismatch in ref.is_null, expected [(ref -1)] but got [i32]
   000001b: error: OnRefIsNullExpr callback failed
 out/test/spec/ref_is_null.wast:56: assert_invalid passed:
+  out/test/spec/ref_is_null/ref_is_null.2.wasm:0000018: error: type mismatch in ref.is_null, expected [(ref -1)] but got []
   0000018: error: OnRefIsNullExpr callback failed
 16/16 tests passed.
 ;;; STDOUT ;;)


### PR DESCRIPTION
Fixes #2453 in a bit of a silly way. (Conveniently, we already have tests for this, but nobody noticed they were broken.)