### PR TITLE
Fix call_ref on empty stack

### DIFF
--- a/src/type-checker.cc
+++ b/src/type-checker.cc
@@ -522,21 +522,14 @@ Result TypeChecker::OnCallIndirect(const TypeVector& param_types,
 
 Result TypeChecker::OnIndexedFuncRef(Index* out_index) {
   Type type;
-  CHECK_RESULT(PeekType(0, &type));
-  Result result = Result::Ok;
-  if (!(type == Type::Any || type.IsReferenceWithIndex())) {
-    TypeVector actual;
-    actual.push_back(type);
-    std::string message =
-        "type mismatch in call_ref, expected reference but got " +
-        TypesToString(actual);
-    PrintError("%s", message.c_str());
-    result = Result::Error;
+  Result result = PeekType(0, &type);
+  if (!type.IsReferenceWithIndex()) {
+    type = Type::Reference;
   }
+  result |= PopAndCheck1Type(type, "call_ref");
   if (Succeeded(result)) {
     *out_index = type.GetReferenceIndex();
   }
-  result |= DropTypes(1);
   return result;
 }
 

--- a/test/typecheck/bad-callref-empty.txt
+++ b/test/typecheck/bad-callref-empty.txt
@@ -1,0 +1,14 @@
+;;; TOOL: wat2wasm
+;;; ARGS: --enable-function-references
+;;; ERROR: 1
+(module
+  (func (export "main")
+    (call_ref
+    )
+  )
+)
+(;; STDERR ;;;
+out/test/typecheck/bad-callref-empty.txt:6:6: error: type mismatch in call_ref, expected [reference] but got []
+    (call_ref
+     ^^^^^^^^
+;;; STDERR ;;)

--- a/test/typecheck/bad-callref-int32.txt
+++ b/test/typecheck/bad-callref-int32.txt
@@ -9,7 +9,7 @@
   )
 )
 (;; STDERR ;;;
-out/test/typecheck/bad-callref-int32.txt:6:6: error: type mismatch in call_ref, expected reference but got [i32]
+out/test/typecheck/bad-callref-int32.txt:6:6: error: type mismatch in call_ref, expected [reference] but got [... i32]
     (call_ref (i32.const 10)
      ^^^^^^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-callref-null.txt
+++ b/test/typecheck/bad-callref-null.txt
@@ -9,7 +9,7 @@
   )
 )
 (;; STDERR ;;;
-out/test/typecheck/bad-callref-null.txt:6:6: error: type mismatch in call_ref, expected reference but got [funcref]
+out/test/typecheck/bad-callref-null.txt:6:6: error: type mismatch in call_ref, expected [reference] but got [... funcref]
     (call_ref (i32.const 10)
      ^^^^^^^^
 ;;; STDERR ;;)


### PR DESCRIPTION
Same issue as #2471 but for `call_ref`.

We don't believe there's a prior issue for this.