### PR TITLE
wasm2c: Fix handling of locals in setjmp targets

### DIFF
--- a/test/regress/wasm2c-ehv3-setjmp-volatile.txt
+++ b/test/regress/wasm2c-ehv3-setjmp-volatile.txt
@@ -1,0 +1,25 @@
+;;; TOOL: run-spec-wasm2c
+;;; ARGS*: --enable-exceptions
+;;; NOTE: ref: issue-2469
+(module
+  (tag $e0)
+  (func $longjmp-bait (throw $e0))
+  (func (export "setjmp-bait") (param $return-early i32) (result i32)
+    (local $value i32)
+    (try $try
+      (do
+        (br_if $try (local.get $return-early))
+        (local.set $value (i32.const 1))
+        (call $longjmp-bait)
+      )
+      (catch $e0)
+    )
+    (local.get $value)
+  )
+)
+
+(assert_return (invoke "setjmp-bait" (i32.const 1)) (i32.const 0))
+(assert_return (invoke "setjmp-bait" (i32.const 0)) (i32.const 1))
+(;; STDOUT ;;;
+2/2 tests passed.
+;;; STDOUT ;;)


### PR DESCRIPTION
It is UB to read local variables after a call to `setjmp` returns, if those variables have been modified between `setjmp` and `longjmp`, unless they're marked as `volatile`. This marks them as `volatile`.

Closes #2469 