### PR TITLE
wasm2c EH: Move away from alloca

### DIFF
--- a/wasm2c/wasm-rt-exceptions-impl.c
+++ b/wasm2c/wasm-rt-exceptions-impl.c
@@ -20,10 +20,8 @@
 
 #include <string.h>
 
-#define MAX_EXCEPTION_SIZE 256
-
 static WASM_RT_THREAD_LOCAL wasm_rt_tag_t g_active_exception_tag;
-static WASM_RT_THREAD_LOCAL uint8_t g_active_exception[MAX_EXCEPTION_SIZE];
+static WASM_RT_THREAD_LOCAL uint8_t g_active_exception[WASM_EXN_MAX_SIZE];
 static WASM_RT_THREAD_LOCAL uint32_t g_active_exception_size;
 
 static WASM_RT_THREAD_LOCAL wasm_rt_jmp_buf* g_unwind_target;
@@ -31,7 +29,7 @@ static WASM_RT_THREAD_LOCAL wasm_rt_jmp_buf* g_unwind_target;
 void wasm_rt_load_exception(const wasm_rt_tag_t tag,
                             uint32_t size,
                             const void* values) {
-  if (size > MAX_EXCEPTION_SIZE) {
+  if (size > WASM_EXN_MAX_SIZE) {
     wasm_rt_trap(WASM_RT_TRAP_EXHAUSTION);
   }
 

--- a/wasm2c/wasm-rt-exceptions.h
+++ b/wasm2c/wasm-rt-exceptions.h
@@ -70,6 +70,9 @@ uint32_t wasm_rt_exception_size(void);
  */
 void* wasm_rt_exception(void);
 
+/**
+ * Maximum size of an exception.
+ */
 #define WASM_EXN_MAX_SIZE 256
 
 #ifdef __cplusplus

--- a/wasm2c/wasm-rt-exceptions.h
+++ b/wasm2c/wasm-rt-exceptions.h
@@ -70,6 +70,8 @@ uint32_t wasm_rt_exception_size(void);
  */
 void* wasm_rt_exception(void);
 
+#define WASM_EXN_MAX_SIZE 256
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Move away from `alloca`.

EHv4 `exnrefs` can be stored in locals and globals and passed around, `alloca` isn't particularly compatible with this. While this change doesn't introduce `exnref`, it paves the way for doing so.

Split from #2470 