### PR TITLE
wasm-interp: Handle refs_ correctly

### DIFF
--- a/include/wabt/opcode.def
+++ b/include/wabt/opcode.def
@@ -235,6 +235,9 @@ WABT_OPCODE(___,  ___,  ___,  ___,  0,  0,    0xe3, InterpData, "data", "")
 WABT_OPCODE(___,  ___,  ___,  ___,  0,  0,    0xe4, InterpDropKeep, "drop_keep", "")
 WABT_OPCODE(___,  ___,  ___,  ___,  0,  0,    0xe5, InterpCatchDrop, "catch_drop", "")
 WABT_OPCODE(___,  ___,  ___,  ___,  0,  0,    0xe6, InterpAdjustFrameForReturnCall, "adjust_frame_for_return_call", "")
+WABT_OPCODE(___,  ___,  ___,  ___,  0,  0,    0xe7, InterpGlobalGetRef, "global.get.ref", "")
+WABT_OPCODE(___,  ___,  ___,  ___,  0,  0,    0xe9, InterpLocalGetRef, "local.get.ref", "")
+WABT_OPCODE(___,  ___,  ___,  ___,  0,  0,    0xea, InterpMarkRef, "mark_ref", "")
 
 /* Saturating float-to-int opcodes (--enable-saturating-float-to-int) */
 WABT_OPCODE(I32,  F32,  ___,  ___,  0,  0xfc, 0x00, I32TruncSatF32S, "i32.trunc_sat_f32_s", "")

--- a/src/interp/interp.cc
+++ b/src/interp/interp.cc
@@ -1492,9 +1492,7 @@ RunResult Thread::StepInternal(Trap::Ptr* out_trap) {
 
     case O::InterpAlloca:
       values_.resize(values_.size() + instr.imm_u32);
-      // refs_ doesn't need to be updated; We may be allocating space for
-      // references, but they will be initialized to null, so it is OK if we
-      // don't mark them.
+      // refs_ will be marked in InterpMarkRef.
       break;
 
     case O::InterpBrUnless:

--- a/src/interp/interp.cc
+++ b/src/interp/interp.cc
@@ -1131,7 +1131,7 @@ T WABT_VECTORCALL Thread::Pop() {
 }
 
 Value Thread::Pop() {
-  if (!refs_.empty() && refs_.back() >= values_.size()) {
+  if (!refs_.empty() && refs_.back() >= values_.size() - 1) {
     refs_.pop_back();
   }
   auto value = values_.back();

--- a/src/interp/interp.cc
+++ b/src/interp/interp.cc
@@ -1511,13 +1511,23 @@ RunResult Thread::StepInternal(Trap::Ptr* out_trap) {
       auto drop = instr.imm_u32x2.fst;
       auto keep = instr.imm_u32x2.snd;
       // Shift kept refs down.
-      for (auto iter = refs_.rbegin(); iter != refs_.rend(); ++iter) {
+      auto iter = refs_.rbegin();
+      for (; iter != refs_.rend(); ++iter) {
         if (*iter >= values_.size() - keep) {
           *iter -= drop;
         } else {
           break;
         }
       }
+      // Find dropped refs.
+      auto drop_iter = iter;
+      for (; drop_iter != refs_.rend(); ++drop_iter) {
+        if (*iter < values_.size() - keep - drop) {
+          break;
+        }
+      }
+      // Erase dropped refs.
+      refs_.erase(drop_iter.base(), iter.base());
       std::move(values_.end() - keep, values_.end(),
                 values_.end() - drop - keep);
       values_.resize(values_.size() - drop);

--- a/src/interp/istream.cc
+++ b/src/interp/istream.cc
@@ -515,6 +515,9 @@ Instr Istream::Read(Offset* offset) const {
 
     case Opcode::GlobalGet:
     case Opcode::LocalGet:
+    case Opcode::InterpLocalGetRef:
+    case Opcode::InterpGlobalGetRef:
+    case Opcode::InterpMarkRef:
     case Opcode::MemorySize:
     case Opcode::TableSize:
     case Opcode::DataDrop:


### PR DESCRIPTION
This fills in some TODOs, and cleans up some other issues, relevant for GC later on.

We tried our best to make this efficient, hence the custom wabt opcodes.