### PR TITLE
Raise parse error on NaN in i32 and i64 literals

### DIFF
--- a/src/wast-parser.cc
+++ b/src/wast-parser.cc
@@ -2781,7 +2781,8 @@ Result WastParser::ParseConst(Const* const_, ConstType const_type) {
     case Opcode::I32Const: {
       auto token = Consume();
       if (!token.HasLiteral()) {
-        return Result::Error;
+        result = Result::Error;
+        break;
       }
       auto sv = token.literal().text;
       uint32_t u32;
@@ -2793,7 +2794,8 @@ Result WastParser::ParseConst(Const* const_, ConstType const_type) {
     case Opcode::I64Const: {
       auto token = Consume();
       if (!token.HasLiteral()) {
-        return Result::Error;
+        result = Result::Error;
+        break;
       }
       auto sv = token.literal().text;
       uint64_t u64;

--- a/test/spec/i32.txt
+++ b/test/spec/i32.txt
@@ -260,5 +260,13 @@ out/test/spec/i32.wast:975: assert_invalid passed:
 out/test/spec/i32.wast:976: assert_invalid passed:
   out/test/spec/i32/i32.83.wasm:0000020: error: type mismatch in i32.ne, expected [i32, i32] but got [i64, f32]
   0000020: error: OnCompareExpr callback failed
+out/test/spec/i32.wast:979: assert_malformed passed:
+  out/test/spec/i32/i32.84.wat:1:31: error: invalid literal "nan:arithmetic"
+  (func (result i32) (i32.const nan:arithmetic))
+                                ^^^^^^^^^^^^^^
+out/test/spec/i32.wast:983: assert_malformed passed:
+  out/test/spec/i32/i32.85.wat:1:31: error: invalid literal "nan:canonical"
+  (func (result i32) (i32.const nan:canonical))
+                                ^^^^^^^^^^^^^
 460/460 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/i64.txt
+++ b/test/spec/i64.txt
@@ -98,5 +98,13 @@ out/test/spec/i64.wast:484: assert_invalid passed:
 out/test/spec/i64.wast:485: assert_invalid passed:
   out/test/spec/i64/i64.29.wasm:0000020: error: type mismatch in i64.ne, expected [i64, i64] but got [i32, f32]
   0000020: error: OnCompareExpr callback failed
+out/test/spec/i64.wast:488: assert_malformed passed:
+  out/test/spec/i64/i64.30.wat:1:31: error: invalid literal "nan:arithmetic"
+  (func (result i64) (i64.const nan:arithmetic))
+                                ^^^^^^^^^^^^^^
+out/test/spec/i64.wast:492: assert_malformed passed:
+  out/test/spec/i64/i64.31.wat:1:31: error: invalid literal "nan:canonical"
+  (func (result i64) (i64.const nan:canonical))
+                                ^^^^^^^^^^^^^
 416/416 tests passed.
 ;;; STDOUT ;;)


### PR DESCRIPTION
Previously, the parser would return result::Error, but would not populate an error message.