### PR TITLE
wasm2c: Cleanup of handling of WASM_RT_USE_SEGUE macro

### DIFF
--- a/src/c-writer.cc
+++ b/src/c-writer.cc
@@ -2506,7 +2506,8 @@ bool CWriter::IsSingleUnsharedMemory() {
 }
 
 void CWriter::InstallSegueBase(Memory* memory, bool save_old_value) {
-  NonIndented([&] { Write("#if WASM_RT_USE_SEGUE", Newline()); });
+  NonIndented(
+      [&] { Write("#if WASM_RT_USE_SEGUE_FOR_THIS_MODULE", Newline()); });
   if (save_old_value) {
     NonIndented([&] { Write("#if !WASM_RT_SEGUE_FREE_SEGMENT", Newline()); });
     Write("void* segue_saved_base = wasm_rt_segue_read_base();", Newline());
@@ -2520,7 +2521,9 @@ void CWriter::InstallSegueBase(Memory* memory, bool save_old_value) {
 
 void CWriter::RestoreSegueBase() {
   NonIndented([&] {
-    Write("#if WASM_RT_USE_SEGUE && !WASM_RT_SEGUE_FREE_SEGMENT", Newline());
+    Write(
+        "#if WASM_RT_USE_SEGUE_FOR_THIS_MODULE && !WASM_RT_SEGUE_FREE_SEGMENT",
+        Newline());
   });
   Write("wasm_rt_segue_write_base(segue_saved_base);", Newline());
   NonIndented([&] { Write("#endif", Newline()); });

--- a/src/prebuilt/wasm2c_source_declarations.cc
+++ b/src/prebuilt/wasm2c_source_declarations.cc
@@ -40,62 +40,22 @@ R"w2c_template(#define MEM_ADDR(mem, addr, n) &(mem)->data[addr]
 R"w2c_template(#endif
 )w2c_template"
 R"w2c_template(
-#ifndef WASM_RT_USE_SEGUE
+// We can only use Segue for this module if it uses a single unshared imported
 )w2c_template"
-R"w2c_template(// Memory functions can use the segue optimization if allowed. The segue
+R"w2c_template(// or exported memory
 )w2c_template"
-R"w2c_template(// optimization uses x86 segments to point to a linear memory. We use this
+R"w2c_template(#if WASM_RT_USE_SEGUE && IS_SINGLE_UNSHARED_MEMORY
 )w2c_template"
-R"w2c_template(// optimization when:
-)w2c_template"
-R"w2c_template(//
-)w2c_template"
-R"w2c_template(// (1) Segue is allowed using WASM_RT_ALLOW_SEGUE
-)w2c_template"
-R"w2c_template(// (2) on x86_64 without WABT_BIG_ENDIAN enabled
-)w2c_template"
-R"w2c_template(// (3) the Wasm module uses a single unshared imported or exported memory
-)w2c_template"
-R"w2c_template(// (4) the compiler supports: intrinsics for (rd|wr)gsbase, "address namespaces"
-)w2c_template"
-R"w2c_template(//     for accessing pointers, and supports memcpy on pointers with custom
-)w2c_template"
-R"w2c_template(//     "address namespaces". GCC does not support the memcpy requirement, so
-)w2c_template"
-R"w2c_template(//     this leaves only clang for now.
-)w2c_template"
-R"w2c_template(// (5) The OS provides a way to query if (rd|wr)gsbase is allowed by the kernel
-)w2c_template"
-R"w2c_template(// or the implementation has to use a syscall for this.
-)w2c_template"
-R"w2c_template(// (6) The OS doesn't replace the segment register on context switch which
-)w2c_template"
-R"w2c_template(//     eliminates windows for now
-)w2c_template"
-R"w2c_template(//
-)w2c_template"
-R"w2c_template(// While more OS can be supported in the future, we only support linux for now
-)w2c_template"
-R"w2c_template(#if WASM_RT_ALLOW_SEGUE && !WABT_BIG_ENDIAN &&                               \
-)w2c_template"
-R"w2c_template(    (defined(__x86_64__) || defined(_M_X64)) && IS_SINGLE_UNSHARED_MEMORY && \
-)w2c_template"
-R"w2c_template(    __clang__ && __has_builtin(__builtin_ia32_wrgsbase64) &&                 \
-)w2c_template"
-R"w2c_template(    !defined(_WIN32) && defined(__linux__)
-)w2c_template"
-R"w2c_template(#define WASM_RT_USE_SEGUE 1
+R"w2c_template(#define WASM_RT_USE_SEGUE_FOR_THIS_MODULE 1
 )w2c_template"
 R"w2c_template(#else
 )w2c_template"
-R"w2c_template(#define WASM_RT_USE_SEGUE 0
-)w2c_template"
-R"w2c_template(#endif
+R"w2c_template(#define WASM_RT_USE_SEGUE_FOR_THIS_MODULE 0
 )w2c_template"
 R"w2c_template(#endif
 )w2c_template"
 R"w2c_template(
-#if WASM_RT_USE_SEGUE
+#if WASM_RT_USE_SEGUE_FOR_THIS_MODULE
 )w2c_template"
 R"w2c_template(// POSIX uses FS for TLS, GS is free
 )w2c_template"
@@ -234,7 +194,7 @@ R"w2c_template(    TRAP(OOB);
 R"w2c_template(#endif
 )w2c_template"
 R"w2c_template(
-#if WASM_RT_USE_SEGUE && WASM_RT_SANITY_CHECKS
+#if WASM_RT_USE_SEGUE_FOR_THIS_MODULE && WASM_RT_SANITY_CHECKS
 )w2c_template"
 R"w2c_template(#include <stdio.h>
 )w2c_template"

--- a/src/template/wasm2c.declarations.c
+++ b/src/template/wasm2c.declarations.c
@@ -20,35 +20,15 @@
 #define MEM_ADDR(mem, addr, n) &(mem)->data[addr]
 #endif
 
-#ifndef WASM_RT_USE_SEGUE
-// Memory functions can use the segue optimization if allowed. The segue
-// optimization uses x86 segments to point to a linear memory. We use this
-// optimization when:
-//
-// (1) Segue is allowed using WASM_RT_ALLOW_SEGUE
-// (2) on x86_64 without WABT_BIG_ENDIAN enabled
-// (3) the Wasm module uses a single unshared imported or exported memory
-// (4) the compiler supports: intrinsics for (rd|wr)gsbase, "address namespaces"
-//     for accessing pointers, and supports memcpy on pointers with custom
-//     "address namespaces". GCC does not support the memcpy requirement, so
-//     this leaves only clang for now.
-// (5) The OS provides a way to query if (rd|wr)gsbase is allowed by the kernel
-// or the implementation has to use a syscall for this.
-// (6) The OS doesn't replace the segment register on context switch which
-//     eliminates windows for now
-//
-// While more OS can be supported in the future, we only support linux for now
-#if WASM_RT_ALLOW_SEGUE && !WABT_BIG_ENDIAN &&                               \
-    (defined(__x86_64__) || defined(_M_X64)) && IS_SINGLE_UNSHARED_MEMORY && \
-    __clang__ && __has_builtin(__builtin_ia32_wrgsbase64) &&                 \
-    !defined(_WIN32) && defined(__linux__)
-#define WASM_RT_USE_SEGUE 1
+// We can only use Segue for this module if it uses a single unshared imported
+// or exported memory
+#if WASM_RT_USE_SEGUE && IS_SINGLE_UNSHARED_MEMORY
+#define WASM_RT_USE_SEGUE_FOR_THIS_MODULE 1
 #else
-#define WASM_RT_USE_SEGUE 0
-#endif
+#define WASM_RT_USE_SEGUE_FOR_THIS_MODULE 0
 #endif
 
-#if WASM_RT_USE_SEGUE
+#if WASM_RT_USE_SEGUE_FOR_THIS_MODULE
 // POSIX uses FS for TLS, GS is free
 static inline void* wasm_rt_segue_read_base() {
   if (wasm_rt_fsgsbase_inst_supported) {
@@ -124,7 +104,7 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
     TRAP(OOB);
 #endif
 
-#if WASM_RT_USE_SEGUE && WASM_RT_SANITY_CHECKS
+#if WASM_RT_USE_SEGUE_FOR_THIS_MODULE && WASM_RT_SANITY_CHECKS
 #include <stdio.h>
 #define WASM_RT_CHECK_BASE(mem)                                               \
   if (((uintptr_t)((mem)->data)) != ((uintptr_t)wasm_rt_segue_read_base())) { \

--- a/test/wasm2c/add.txt
+++ b/test/wasm2c/add.txt
@@ -87,35 +87,15 @@ u32 w2c_test_add(w2c_test*, u32, u32);
 #define MEM_ADDR(mem, addr, n) &(mem)->data[addr]
 #endif
 
-#ifndef WASM_RT_USE_SEGUE
-// Memory functions can use the segue optimization if allowed. The segue
-// optimization uses x86 segments to point to a linear memory. We use this
-// optimization when:
-//
-// (1) Segue is allowed using WASM_RT_ALLOW_SEGUE
-// (2) on x86_64 without WABT_BIG_ENDIAN enabled
-// (3) the Wasm module uses a single unshared imported or exported memory
-// (4) the compiler supports: intrinsics for (rd|wr)gsbase, "address namespaces"
-//     for accessing pointers, and supports memcpy on pointers with custom
-//     "address namespaces". GCC does not support the memcpy requirement, so
-//     this leaves only clang for now.
-// (5) The OS provides a way to query if (rd|wr)gsbase is allowed by the kernel
-// or the implementation has to use a syscall for this.
-// (6) The OS doesn't replace the segment register on context switch which
-//     eliminates windows for now
-//
-// While more OS can be supported in the future, we only support linux for now
-#if WASM_RT_ALLOW_SEGUE && !WABT_BIG_ENDIAN &&                               \
-    (defined(__x86_64__) || defined(_M_X64)) && IS_SINGLE_UNSHARED_MEMORY && \
-    __clang__ && __has_builtin(__builtin_ia32_wrgsbase64) &&                 \
-    !defined(_WIN32) && defined(__linux__)
-#define WASM_RT_USE_SEGUE 1
+// We can only use Segue for this module if it uses a single unshared imported
+// or exported memory
+#if WASM_RT_USE_SEGUE && IS_SINGLE_UNSHARED_MEMORY
+#define WASM_RT_USE_SEGUE_FOR_THIS_MODULE 1
 #else
-#define WASM_RT_USE_SEGUE 0
-#endif
+#define WASM_RT_USE_SEGUE_FOR_THIS_MODULE 0
 #endif
 
-#if WASM_RT_USE_SEGUE
+#if WASM_RT_USE_SEGUE_FOR_THIS_MODULE
 // POSIX uses FS for TLS, GS is free
 static inline void* wasm_rt_segue_read_base() {
   if (wasm_rt_fsgsbase_inst_supported) {
@@ -191,7 +171,7 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
     TRAP(OOB);
 #endif
 
-#if WASM_RT_USE_SEGUE && WASM_RT_SANITY_CHECKS
+#if WASM_RT_USE_SEGUE_FOR_THIS_MODULE && WASM_RT_SANITY_CHECKS
 #include <stdio.h>
 #define WASM_RT_CHECK_BASE(mem)                                               \
   if (((uintptr_t)((mem)->data)) != ((uintptr_t)wasm_rt_segue_read_base())) { \

--- a/test/wasm2c/check-imports.txt
+++ b/test/wasm2c/check-imports.txt
@@ -111,35 +111,15 @@ extern const u8 wasm2c_test_is64_env_0x5F_linear_memory;
 #define MEM_ADDR(mem, addr, n) &(mem)->data[addr]
 #endif
 
-#ifndef WASM_RT_USE_SEGUE
-// Memory functions can use the segue optimization if allowed. The segue
-// optimization uses x86 segments to point to a linear memory. We use this
-// optimization when:
-//
-// (1) Segue is allowed using WASM_RT_ALLOW_SEGUE
-// (2) on x86_64 without WABT_BIG_ENDIAN enabled
-// (3) the Wasm module uses a single unshared imported or exported memory
-// (4) the compiler supports: intrinsics for (rd|wr)gsbase, "address namespaces"
-//     for accessing pointers, and supports memcpy on pointers with custom
-//     "address namespaces". GCC does not support the memcpy requirement, so
-//     this leaves only clang for now.
-// (5) The OS provides a way to query if (rd|wr)gsbase is allowed by the kernel
-// or the implementation has to use a syscall for this.
-// (6) The OS doesn't replace the segment register on context switch which
-//     eliminates windows for now
-//
-// While more OS can be supported in the future, we only support linux for now
-#if WASM_RT_ALLOW_SEGUE && !WABT_BIG_ENDIAN &&                               \
-    (defined(__x86_64__) || defined(_M_X64)) && IS_SINGLE_UNSHARED_MEMORY && \
-    __clang__ && __has_builtin(__builtin_ia32_wrgsbase64) &&                 \
-    !defined(_WIN32) && defined(__linux__)
-#define WASM_RT_USE_SEGUE 1
+// We can only use Segue for this module if it uses a single unshared imported
+// or exported memory
+#if WASM_RT_USE_SEGUE && IS_SINGLE_UNSHARED_MEMORY
+#define WASM_RT_USE_SEGUE_FOR_THIS_MODULE 1
 #else
-#define WASM_RT_USE_SEGUE 0
-#endif
+#define WASM_RT_USE_SEGUE_FOR_THIS_MODULE 0
 #endif
 
-#if WASM_RT_USE_SEGUE
+#if WASM_RT_USE_SEGUE_FOR_THIS_MODULE
 // POSIX uses FS for TLS, GS is free
 static inline void* wasm_rt_segue_read_base() {
   if (wasm_rt_fsgsbase_inst_supported) {
@@ -215,7 +195,7 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
     TRAP(OOB);
 #endif
 
-#if WASM_RT_USE_SEGUE && WASM_RT_SANITY_CHECKS
+#if WASM_RT_USE_SEGUE_FOR_THIS_MODULE && WASM_RT_SANITY_CHECKS
 #include <stdio.h>
 #define WASM_RT_CHECK_BASE(mem)                                               \
   if (((uintptr_t)((mem)->data)) != ((uintptr_t)wasm_rt_segue_read_base())) { \
@@ -836,14 +816,14 @@ void wasm2c_test_instantiate(w2c_test* instance, struct w2c_env* w2c_env_instanc
   init_instance_import(instance, w2c_env_instance);
   init_tables(instance);
   init_memories(instance);
-#if WASM_RT_USE_SEGUE
+#if WASM_RT_USE_SEGUE_FOR_THIS_MODULE
 #if !WASM_RT_SEGUE_FREE_SEGMENT
   void* segue_saved_base = wasm_rt_segue_read_base();
 #endif
   wasm_rt_segue_write_base((*instance->w2c_env_0x5F_linear_memory).data);
 #endif
   init_elem_instances(instance);
-#if WASM_RT_USE_SEGUE && !WASM_RT_SEGUE_FREE_SEGMENT
+#if WASM_RT_USE_SEGUE_FOR_THIS_MODULE && !WASM_RT_SEGUE_FREE_SEGMENT
   wasm_rt_segue_write_base(segue_saved_base);
 #endif
 }

--- a/test/wasm2c/export-names.txt
+++ b/test/wasm2c/export-names.txt
@@ -111,35 +111,15 @@ void w2c_test_0xE20x9D0xA40xEF0xB80x8F(w2c_test*);
 #define MEM_ADDR(mem, addr, n) &(mem)->data[addr]
 #endif
 
-#ifndef WASM_RT_USE_SEGUE
-// Memory functions can use the segue optimization if allowed. The segue
-// optimization uses x86 segments to point to a linear memory. We use this
-// optimization when:
-//
-// (1) Segue is allowed using WASM_RT_ALLOW_SEGUE
-// (2) on x86_64 without WABT_BIG_ENDIAN enabled
-// (3) the Wasm module uses a single unshared imported or exported memory
-// (4) the compiler supports: intrinsics for (rd|wr)gsbase, "address namespaces"
-//     for accessing pointers, and supports memcpy on pointers with custom
-//     "address namespaces". GCC does not support the memcpy requirement, so
-//     this leaves only clang for now.
-// (5) The OS provides a way to query if (rd|wr)gsbase is allowed by the kernel
-// or the implementation has to use a syscall for this.
-// (6) The OS doesn't replace the segment register on context switch which
-//     eliminates windows for now
-//
-// While more OS can be supported in the future, we only support linux for now
-#if WASM_RT_ALLOW_SEGUE && !WABT_BIG_ENDIAN &&                               \
-    (defined(__x86_64__) || defined(_M_X64)) && IS_SINGLE_UNSHARED_MEMORY && \
-    __clang__ && __has_builtin(__builtin_ia32_wrgsbase64) &&                 \
-    !defined(_WIN32) && defined(__linux__)
-#define WASM_RT_USE_SEGUE 1
+// We can only use Segue for this module if it uses a single unshared imported
+// or exported memory
+#if WASM_RT_USE_SEGUE && IS_SINGLE_UNSHARED_MEMORY
+#define WASM_RT_USE_SEGUE_FOR_THIS_MODULE 1
 #else
-#define WASM_RT_USE_SEGUE 0
-#endif
+#define WASM_RT_USE_SEGUE_FOR_THIS_MODULE 0
 #endif
 
-#if WASM_RT_USE_SEGUE
+#if WASM_RT_USE_SEGUE_FOR_THIS_MODULE
 // POSIX uses FS for TLS, GS is free
 static inline void* wasm_rt_segue_read_base() {
   if (wasm_rt_fsgsbase_inst_supported) {
@@ -215,7 +195,7 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
     TRAP(OOB);
 #endif
 
-#if WASM_RT_USE_SEGUE && WASM_RT_SANITY_CHECKS
+#if WASM_RT_USE_SEGUE_FOR_THIS_MODULE && WASM_RT_SANITY_CHECKS
 #include <stdio.h>
 #define WASM_RT_CHECK_BASE(mem)                                               \
   if (((uintptr_t)((mem)->data)) != ((uintptr_t)wasm_rt_segue_read_base())) { \
@@ -803,70 +783,70 @@ static void init_memories(w2c_test* instance) {
 
 /* export: '' */
 void w2c_test_(w2c_test* instance) {
-#if WASM_RT_USE_SEGUE
+#if WASM_RT_USE_SEGUE_FOR_THIS_MODULE
 #if !WASM_RT_SEGUE_FREE_SEGMENT
   void* segue_saved_base = wasm_rt_segue_read_base();
 #endif
   wasm_rt_segue_write_base((*instance->w2c_0x5Cmodule_import0x200x2A0x2F).data);
 #endif
   w2c_test__0(instance);
-#if WASM_RT_USE_SEGUE && !WASM_RT_SEGUE_FREE_SEGMENT
+#if WASM_RT_USE_SEGUE_FOR_THIS_MODULE && !WASM_RT_SEGUE_FREE_SEGMENT
   wasm_rt_segue_write_base(segue_saved_base);
 #endif
 }
 
 /* export: '*\2F' */
 void w2c_test_0x2A0x2F(w2c_test* instance) {
-#if WASM_RT_USE_SEGUE
+#if WASM_RT_USE_SEGUE_FOR_THIS_MODULE
 #if !WASM_RT_SEGUE_FREE_SEGMENT
   void* segue_saved_base = wasm_rt_segue_read_base();
 #endif
   wasm_rt_segue_write_base((*instance->w2c_0x5Cmodule_import0x200x2A0x2F).data);
 #endif
   w2c_test__0(instance);
-#if WASM_RT_USE_SEGUE && !WASM_RT_SEGUE_FREE_SEGMENT
+#if WASM_RT_USE_SEGUE_FOR_THIS_MODULE && !WASM_RT_SEGUE_FREE_SEGMENT
   wasm_rt_segue_write_base(segue_saved_base);
 #endif
 }
 
 /* export: '\3F\3F\2F' */
 void w2c_test_0x3F0x3F0x2F(w2c_test* instance) {
-#if WASM_RT_USE_SEGUE
+#if WASM_RT_USE_SEGUE_FOR_THIS_MODULE
 #if !WASM_RT_SEGUE_FREE_SEGMENT
   void* segue_saved_base = wasm_rt_segue_read_base();
 #endif
   wasm_rt_segue_write_base((*instance->w2c_0x5Cmodule_import0x200x2A0x2F).data);
 #endif
   w2c_test__0(instance);
-#if WASM_RT_USE_SEGUE && !WASM_RT_SEGUE_FREE_SEGMENT
+#if WASM_RT_USE_SEGUE_FOR_THIS_MODULE && !WASM_RT_SEGUE_FREE_SEGMENT
   wasm_rt_segue_write_base(segue_saved_base);
 #endif
 }
 
 /* export: '\0A' */
 void w2c_test_0x0A(w2c_test* instance) {
-#if WASM_RT_USE_SEGUE
+#if WASM_RT_USE_SEGUE_FOR_THIS_MODULE
 #if !WASM_RT_SEGUE_FREE_SEGMENT
   void* segue_saved_base = wasm_rt_segue_read_base();
 #endif
   wasm_rt_segue_write_base((*instance->w2c_0x5Cmodule_import0x200x2A0x2F).data);
 #endif
   w2c_test__0(instance);
-#if WASM_RT_USE_SEGUE && !WASM_RT_SEGUE_FREE_SEGMENT
+#if WASM_RT_USE_SEGUE_FOR_THIS_MODULE && !WASM_RT_SEGUE_FREE_SEGMENT
   wasm_rt_segue_write_base(segue_saved_base);
 #endif
 }
 
 /* export: '\E2\9D\A4\EF\B8\8F' */
 void w2c_test_0xE20x9D0xA40xEF0xB80x8F(w2c_test* instance) {
-#if WASM_RT_USE_SEGUE
+#if WASM_RT_USE_SEGUE_FOR_THIS_MODULE
 #if !WASM_RT_SEGUE_FREE_SEGMENT
   void* segue_saved_base = wasm_rt_segue_read_base();
 #endif
   wasm_rt_segue_write_base((*instance->w2c_0x5Cmodule_import0x200x2A0x2F).data);
 #endif
   w2c_test__0(instance);
-#if WASM_RT_USE_SEGUE && !WASM_RT_SEGUE_FREE_SEGMENT
+#if WASM_RT_USE_SEGUE_FOR_THIS_MODULE && !WASM_RT_SEGUE_FREE_SEGMENT
   wasm_rt_segue_write_base(segue_saved_base);
 #endif
 }
@@ -883,13 +863,13 @@ void wasm2c_test_instantiate(w2c_test* instance, struct w2c_0x5Cmodule* w2c_0x5C
   assert(wasm_rt_is_initialized());
   init_instance_import(instance, w2c_0x5Cmodule_instance);
   init_memories(instance);
-#if WASM_RT_USE_SEGUE
+#if WASM_RT_USE_SEGUE_FOR_THIS_MODULE
 #if !WASM_RT_SEGUE_FREE_SEGMENT
   void* segue_saved_base = wasm_rt_segue_read_base();
 #endif
   wasm_rt_segue_write_base((*instance->w2c_0x5Cmodule_import0x200x2A0x2F).data);
 #endif
-#if WASM_RT_USE_SEGUE && !WASM_RT_SEGUE_FREE_SEGMENT
+#if WASM_RT_USE_SEGUE_FOR_THIS_MODULE && !WASM_RT_SEGUE_FREE_SEGMENT
   wasm_rt_segue_write_base(segue_saved_base);
 #endif
 }

--- a/test/wasm2c/hello.txt
+++ b/test/wasm2c/hello.txt
@@ -119,35 +119,15 @@ void w2c_test_0x5Fstart(w2c_test*);
 #define MEM_ADDR(mem, addr, n) &(mem)->data[addr]
 #endif
 
-#ifndef WASM_RT_USE_SEGUE
-// Memory functions can use the segue optimization if allowed. The segue
-// optimization uses x86 segments to point to a linear memory. We use this
-// optimization when:
-//
-// (1) Segue is allowed using WASM_RT_ALLOW_SEGUE
-// (2) on x86_64 without WABT_BIG_ENDIAN enabled
-// (3) the Wasm module uses a single unshared imported or exported memory
-// (4) the compiler supports: intrinsics for (rd|wr)gsbase, "address namespaces"
-//     for accessing pointers, and supports memcpy on pointers with custom
-//     "address namespaces". GCC does not support the memcpy requirement, so
-//     this leaves only clang for now.
-// (5) The OS provides a way to query if (rd|wr)gsbase is allowed by the kernel
-// or the implementation has to use a syscall for this.
-// (6) The OS doesn't replace the segment register on context switch which
-//     eliminates windows for now
-//
-// While more OS can be supported in the future, we only support linux for now
-#if WASM_RT_ALLOW_SEGUE && !WABT_BIG_ENDIAN &&                               \
-    (defined(__x86_64__) || defined(_M_X64)) && IS_SINGLE_UNSHARED_MEMORY && \
-    __clang__ && __has_builtin(__builtin_ia32_wrgsbase64) &&                 \
-    !defined(_WIN32) && defined(__linux__)
-#define WASM_RT_USE_SEGUE 1
+// We can only use Segue for this module if it uses a single unshared imported
+// or exported memory
+#if WASM_RT_USE_SEGUE && IS_SINGLE_UNSHARED_MEMORY
+#define WASM_RT_USE_SEGUE_FOR_THIS_MODULE 1
 #else
-#define WASM_RT_USE_SEGUE 0
-#endif
+#define WASM_RT_USE_SEGUE_FOR_THIS_MODULE 0
 #endif
 
-#if WASM_RT_USE_SEGUE
+#if WASM_RT_USE_SEGUE_FOR_THIS_MODULE
 // POSIX uses FS for TLS, GS is free
 static inline void* wasm_rt_segue_read_base() {
   if (wasm_rt_fsgsbase_inst_supported) {
@@ -223,7 +203,7 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
     TRAP(OOB);
 #endif
 
-#if WASM_RT_USE_SEGUE && WASM_RT_SANITY_CHECKS
+#if WASM_RT_USE_SEGUE_FOR_THIS_MODULE && WASM_RT_SANITY_CHECKS
 #include <stdio.h>
 #define WASM_RT_CHECK_BASE(mem)                                               \
   if (((uintptr_t)((mem)->data)) != ((uintptr_t)wasm_rt_segue_read_base())) { \
@@ -844,14 +824,14 @@ wasm_rt_memory_t* w2c_test_memory(w2c_test* instance) {
 
 /* export: '_start' */
 void w2c_test_0x5Fstart(w2c_test* instance) {
-#if WASM_RT_USE_SEGUE
+#if WASM_RT_USE_SEGUE_FOR_THIS_MODULE
 #if !WASM_RT_SEGUE_FREE_SEGMENT
   void* segue_saved_base = wasm_rt_segue_read_base();
 #endif
   wasm_rt_segue_write_base(instance->w2c_memory.data);
 #endif
   w2c_test_0x5Fstart_0(instance);
-#if WASM_RT_USE_SEGUE && !WASM_RT_SEGUE_FREE_SEGMENT
+#if WASM_RT_USE_SEGUE_FOR_THIS_MODULE && !WASM_RT_SEGUE_FREE_SEGMENT
   wasm_rt_segue_write_base(segue_saved_base);
 #endif
 }
@@ -865,7 +845,7 @@ void wasm2c_test_instantiate(w2c_test* instance, struct w2c_wasi__snapshot__prev
   init_instance_import(instance, w2c_wasi__snapshot__preview1_instance);
   init_tables(instance);
   init_memories(instance);
-#if WASM_RT_USE_SEGUE
+#if WASM_RT_USE_SEGUE_FOR_THIS_MODULE
 #if !WASM_RT_SEGUE_FREE_SEGMENT
   void* segue_saved_base = wasm_rt_segue_read_base();
 #endif
@@ -873,7 +853,7 @@ void wasm2c_test_instantiate(w2c_test* instance, struct w2c_wasi__snapshot__prev
 #endif
   init_elem_instances(instance);
   init_data_instances(instance);
-#if WASM_RT_USE_SEGUE && !WASM_RT_SEGUE_FREE_SEGMENT
+#if WASM_RT_USE_SEGUE_FOR_THIS_MODULE && !WASM_RT_SEGUE_FREE_SEGMENT
   wasm_rt_segue_write_base(segue_saved_base);
 #endif
 }

--- a/test/wasm2c/minimal.txt
+++ b/test/wasm2c/minimal.txt
@@ -81,35 +81,15 @@ wasm_rt_func_type_t wasm2c_test_get_func_type(uint32_t param_count, uint32_t res
 #define MEM_ADDR(mem, addr, n) &(mem)->data[addr]
 #endif
 
-#ifndef WASM_RT_USE_SEGUE
-// Memory functions can use the segue optimization if allowed. The segue
-// optimization uses x86 segments to point to a linear memory. We use this
-// optimization when:
-//
-// (1) Segue is allowed using WASM_RT_ALLOW_SEGUE
-// (2) on x86_64 without WABT_BIG_ENDIAN enabled
-// (3) the Wasm module uses a single unshared imported or exported memory
-// (4) the compiler supports: intrinsics for (rd|wr)gsbase, "address namespaces"
-//     for accessing pointers, and supports memcpy on pointers with custom
-//     "address namespaces". GCC does not support the memcpy requirement, so
-//     this leaves only clang for now.
-// (5) The OS provides a way to query if (rd|wr)gsbase is allowed by the kernel
-// or the implementation has to use a syscall for this.
-// (6) The OS doesn't replace the segment register on context switch which
-//     eliminates windows for now
-//
-// While more OS can be supported in the future, we only support linux for now
-#if WASM_RT_ALLOW_SEGUE && !WABT_BIG_ENDIAN &&                               \
-    (defined(__x86_64__) || defined(_M_X64)) && IS_SINGLE_UNSHARED_MEMORY && \
-    __clang__ && __has_builtin(__builtin_ia32_wrgsbase64) &&                 \
-    !defined(_WIN32) && defined(__linux__)
-#define WASM_RT_USE_SEGUE 1
+// We can only use Segue for this module if it uses a single unshared imported
+// or exported memory
+#if WASM_RT_USE_SEGUE && IS_SINGLE_UNSHARED_MEMORY
+#define WASM_RT_USE_SEGUE_FOR_THIS_MODULE 1
 #else
-#define WASM_RT_USE_SEGUE 0
-#endif
+#define WASM_RT_USE_SEGUE_FOR_THIS_MODULE 0
 #endif
 
-#if WASM_RT_USE_SEGUE
+#if WASM_RT_USE_SEGUE_FOR_THIS_MODULE
 // POSIX uses FS for TLS, GS is free
 static inline void* wasm_rt_segue_read_base() {
   if (wasm_rt_fsgsbase_inst_supported) {
@@ -185,7 +165,7 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
     TRAP(OOB);
 #endif
 
-#if WASM_RT_USE_SEGUE && WASM_RT_SANITY_CHECKS
+#if WASM_RT_USE_SEGUE_FOR_THIS_MODULE && WASM_RT_SANITY_CHECKS
 #include <stdio.h>
 #define WASM_RT_CHECK_BASE(mem)                                               \
   if (((uintptr_t)((mem)->data)) != ((uintptr_t)wasm_rt_segue_read_base())) { \

--- a/test/wasm2c/tail-calls.txt
+++ b/test/wasm2c/tail-calls.txt
@@ -111,35 +111,15 @@ void wasm_tailcall_w2c_test_tailcaller(void **instance_ptr, void *tail_call_stac
 #define MEM_ADDR(mem, addr, n) &(mem)->data[addr]
 #endif
 
-#ifndef WASM_RT_USE_SEGUE
-// Memory functions can use the segue optimization if allowed. The segue
-// optimization uses x86 segments to point to a linear memory. We use this
-// optimization when:
-//
-// (1) Segue is allowed using WASM_RT_ALLOW_SEGUE
-// (2) on x86_64 without WABT_BIG_ENDIAN enabled
-// (3) the Wasm module uses a single unshared imported or exported memory
-// (4) the compiler supports: intrinsics for (rd|wr)gsbase, "address namespaces"
-//     for accessing pointers, and supports memcpy on pointers with custom
-//     "address namespaces". GCC does not support the memcpy requirement, so
-//     this leaves only clang for now.
-// (5) The OS provides a way to query if (rd|wr)gsbase is allowed by the kernel
-// or the implementation has to use a syscall for this.
-// (6) The OS doesn't replace the segment register on context switch which
-//     eliminates windows for now
-//
-// While more OS can be supported in the future, we only support linux for now
-#if WASM_RT_ALLOW_SEGUE && !WABT_BIG_ENDIAN &&                               \
-    (defined(__x86_64__) || defined(_M_X64)) && IS_SINGLE_UNSHARED_MEMORY && \
-    __clang__ && __has_builtin(__builtin_ia32_wrgsbase64) &&                 \
-    !defined(_WIN32) && defined(__linux__)
-#define WASM_RT_USE_SEGUE 1
+// We can only use Segue for this module if it uses a single unshared imported
+// or exported memory
+#if WASM_RT_USE_SEGUE && IS_SINGLE_UNSHARED_MEMORY
+#define WASM_RT_USE_SEGUE_FOR_THIS_MODULE 1
 #else
-#define WASM_RT_USE_SEGUE 0
-#endif
+#define WASM_RT_USE_SEGUE_FOR_THIS_MODULE 0
 #endif
 
-#if WASM_RT_USE_SEGUE
+#if WASM_RT_USE_SEGUE_FOR_THIS_MODULE
 // POSIX uses FS for TLS, GS is free
 static inline void* wasm_rt_segue_read_base() {
   if (wasm_rt_fsgsbase_inst_supported) {
@@ -215,7 +195,7 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
     TRAP(OOB);
 #endif
 
-#if WASM_RT_USE_SEGUE && WASM_RT_SANITY_CHECKS
+#if WASM_RT_USE_SEGUE_FOR_THIS_MODULE && WASM_RT_SANITY_CHECKS
 #include <stdio.h>
 #define WASM_RT_CHECK_BASE(mem)                                               \
   if (((uintptr_t)((mem)->data)) != ((uintptr_t)wasm_rt_segue_read_base())) { \

--- a/wasm2c/examples/fac/fac.c
+++ b/wasm2c/examples/fac/fac.c
@@ -39,35 +39,15 @@
 #define MEM_ADDR(mem, addr, n) &(mem)->data[addr]
 #endif
 
-#ifndef WASM_RT_USE_SEGUE
-// Memory functions can use the segue optimization if allowed. The segue
-// optimization uses x86 segments to point to a linear memory. We use this
-// optimization when:
-//
-// (1) Segue is allowed using WASM_RT_ALLOW_SEGUE
-// (2) on x86_64 without WABT_BIG_ENDIAN enabled
-// (3) the Wasm module uses a single unshared imported or exported memory
-// (4) the compiler supports: intrinsics for (rd|wr)gsbase, "address namespaces"
-//     for accessing pointers, and supports memcpy on pointers with custom
-//     "address namespaces". GCC does not support the memcpy requirement, so
-//     this leaves only clang for now.
-// (5) The OS provides a way to query if (rd|wr)gsbase is allowed by the kernel
-// or the implementation has to use a syscall for this.
-// (6) The OS doesn't replace the segment register on context switch which
-//     eliminates windows for now
-//
-// While more OS can be supported in the future, we only support linux for now
-#if WASM_RT_ALLOW_SEGUE && !WABT_BIG_ENDIAN &&                               \
-    (defined(__x86_64__) || defined(_M_X64)) && IS_SINGLE_UNSHARED_MEMORY && \
-    __clang__ && __has_builtin(__builtin_ia32_wrgsbase64) &&                 \
-    !defined(_WIN32) && defined(__linux__)
-#define WASM_RT_USE_SEGUE 1
+// We can only use Segue for this module if it uses a single unshared imported
+// or exported memory
+#if WASM_RT_USE_SEGUE && IS_SINGLE_UNSHARED_MEMORY
+#define WASM_RT_USE_SEGUE_FOR_THIS_MODULE 1
 #else
-#define WASM_RT_USE_SEGUE 0
-#endif
+#define WASM_RT_USE_SEGUE_FOR_THIS_MODULE 0
 #endif
 
-#if WASM_RT_USE_SEGUE
+#if WASM_RT_USE_SEGUE_FOR_THIS_MODULE
 // POSIX uses FS for TLS, GS is free
 static inline void* wasm_rt_segue_read_base() {
   if (wasm_rt_fsgsbase_inst_supported) {
@@ -143,7 +123,7 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
     TRAP(OOB);
 #endif
 
-#if WASM_RT_USE_SEGUE && WASM_RT_SANITY_CHECKS
+#if WASM_RT_USE_SEGUE_FOR_THIS_MODULE && WASM_RT_SANITY_CHECKS
 #include <stdio.h>
 #define WASM_RT_CHECK_BASE(mem)                                               \
   if (((uintptr_t)((mem)->data)) != ((uintptr_t)wasm_rt_segue_read_base())) { \

--- a/wasm2c/wasm-rt-impl.c
+++ b/wasm2c/wasm-rt-impl.c
@@ -49,7 +49,7 @@ static void* g_sig_handler_handle = 0;
 #endif
 #endif
 
-#if WASM_RT_USE_SEGUE || WASM_RT_ALLOW_SEGUE
+#if WASM_RT_USE_SEGUE
 // Currently Segue is used only for linux
 #include <sys/auxv.h>
 #ifdef __GLIBC__
@@ -239,7 +239,7 @@ void wasm_rt_init(void) {
   }
 #endif
 
-#if WASM_RT_USE_SEGUE || WASM_RT_ALLOW_SEGUE
+#if WASM_RT_USE_SEGUE
 #if defined(__GLIBC__) && __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 18
   // Check for support for userspace wrgsbase instructions
   unsigned long val = getauxval(AT_HWCAP2);
@@ -284,7 +284,7 @@ void wasm_rt_free_thread(void) {
 #endif
 }
 
-#if WASM_RT_USE_SEGUE || WASM_RT_ALLOW_SEGUE
+#if WASM_RT_USE_SEGUE
 void wasm_rt_syscall_set_segue_base(void* base) {
   if (syscall(SYS_arch_prctl, ARCH_SET_GS, base) != 0) {
     perror("wasm_rt_syscall_set_segue_base error");

--- a/wasm2c/wasm-rt.h
+++ b/wasm2c/wasm-rt.h
@@ -228,6 +228,33 @@ extern "C" {
 #define WASM_RT_SEGUE_FREE_SEGMENT 0
 #endif
 
+#ifndef WASM_RT_USE_SEGUE
+// Memory functions can use the segue optimization if allowed. The segue
+// optimization uses x86 segments to point to a linear memory. We use this
+// optimization when:
+//
+// (1) Segue is allowed using WASM_RT_ALLOW_SEGUE
+// (2) on x86_64 without WABT_BIG_ENDIAN enabled
+// (3) the compiler supports: intrinsics for (rd|wr)gsbase, "address namespaces"
+//     for accessing pointers, and supports memcpy on pointers with custom
+//     "address namespaces". GCC does not support the memcpy requirement, so
+//     this leaves only clang for now.
+// (4) The OS provides a way to query if (rd|wr)gsbase is allowed by the kernel
+// or the implementation has to use a syscall for this.
+// (5) The OS doesn't replace the segment register on context switch which
+//     eliminates windows for now
+//
+// While more OS can be supported in the future, we only support linux for now
+#if WASM_RT_ALLOW_SEGUE && !WABT_BIG_ENDIAN &&                      \
+    (defined(__x86_64__) || defined(_M_X64)) && __clang__ &&        \
+    __has_builtin(__builtin_ia32_wrgsbase64) && !defined(_WIN32) && \
+    defined(__linux__)
+#define WASM_RT_USE_SEGUE 1
+#else
+#define WASM_RT_USE_SEGUE 0
+#endif
+#endif
+
 /**
  * This macro, if defined, allows the embedder to disable all stack exhaustion
  * checks. This a non conformant configuration, i.e., this does not respect
@@ -306,7 +333,7 @@ extern WASM_RT_THREAD_LOCAL uint32_t wasm_rt_call_stack_depth;
 
 #endif
 
-#if WASM_RT_USE_SEGUE || WASM_RT_ALLOW_SEGUE
+#if WASM_RT_USE_SEGUE
 /**
  * The segue optimization uses x86 segments to point to a linear memory. If
  * used, the runtime must query whether it can use the fast userspace wrgsbase


### PR DESCRIPTION
The `WASM_RT_USE_SEGUE` macro was previously overloaded for two checks:

1. Check if Segue is supported by the current compiler/arch/OS combination
2. Check if the current module only uses one memory, as we do not use Segue for modules using multiple memories

Check 2 means that `WASM_RT_USE_SEGUE` is only available in the generated C file, and not in the runtime (`wasm-rt-impl.c`).

However, the runtime needs this information as it must include certain headers only if Segue is supported (Check 1 above), and thus this macro must be available in `wasm-rt.h`. We thus split this macro into two parts `WASM_RT_USE_SEGUE` and `WASM_RT_USE_SEGUE_FOR_THIS_MODULE` to address the two use cases: "check if Segue is supported" and "check if Segue should be used for the current module"