### PR TITLE
Fix bug in wasm2c's tail call optimization codegen

### DIFF
--- a/src/c-writer.cc
+++ b/src/c-writer.cc
@@ -1895,7 +1895,7 @@ void CWriter::WriteTailCallWeakImports() {
     Index num_results = func.GetNumResults();
     if (num_params >= 1) {
       Write(func.decl.sig.param_types, " params;", Newline());
-      Write("wasm_rt_memcpy(params, tail_call_stack, sizeof(params));",
+      Write("wasm_rt_memcpy(&params, tail_call_stack, sizeof(params));",
             Newline());
     }
 

--- a/test/wasm2c/tail-calls.txt
+++ b/test/wasm2c/tail-calls.txt
@@ -822,7 +822,7 @@ WEAK_FUNC_DECL(wasm_tailcall_w2c_spectest_print_i32_f32, wasm_fallback_test_w2c_
 {
   next->fn = NULL;
   struct wasm_multi_if params;
-  wasm_rt_memcpy(params, tail_call_stack, sizeof(params));
+  wasm_rt_memcpy(&params, tail_call_stack, sizeof(params));
   w2c_spectest_print_i32_f32(*instance_ptr, params.i0, params.f1);
 }
 


### PR DESCRIPTION
The default wasm-rt implementation defines `wasm_rt_memcpy` as `memcpy` which expects void*