### PR TITLE
[EH] Fix exnref's opcode

### DIFF
--- a/include/wabt/type.h
+++ b/include/wabt/type.h
@@ -42,7 +42,7 @@ class Type {
     V128 = -0x05,       // 0x7b
     I8 = -0x06,         // 0x7a  : packed-type only, used in gc and as v128 lane
     I16 = -0x07,        // 0x79  : packed-type only, used in gc and as v128 lane
-    ExnRef = -0x0c,     // 0x74
+    ExnRef = -0x17,     // 0x69
     FuncRef = -0x10,    // 0x70
     ExternRef = -0x11,  // 0x6f
     Reference = -0x15,  // 0x6b


### PR DESCRIPTION
`exnref`'s opcode is -0x17:
https://github.com/WebAssembly/exception-handling/blob/main/proposals/exception-handling/Exceptions.md#exnref