### PR TITLE
wasm-decompile: Fix unescaped characters in data output.

### DIFF
--- a/src/decompiler.cc
+++ b/src/decompiler.cc
@@ -702,7 +702,7 @@ struct Decompiler {
     size_t line_start = 0;
     static const char s_hexdigits[] = "0123456789abcdef";
     for (auto c : in) {
-      if (c >= ' ' && c <= '~') {
+      if (c >= ' ' && c <= '~' && c != '"' && c != '\\') {
         s += c;
       } else {
         s += '\\';


### PR DESCRIPTION
Characters `"` and `\` which have special meaning in data representations are not escaped by wasm-decompile and are passed to output as is.
This PR fixes such incorrect behavior.
All tests still pass (although no cases are added).