### PR TITLE
wat-writer.cc: update text serialization of data memuse

### DIFF
--- a/src/wat-writer.cc
+++ b/src/wat-writer.cc
@@ -1504,7 +1504,11 @@ void WatWriter::WriteDataSegment(const DataSegment& segment) {
   WriteOpenSpace("data");
   WriteNameOrIndex(segment.name, data_segment_index_, NextChar::Space);
   if (segment.kind != SegmentKind::Passive) {
-    WriteMemoryVarUnlessZero(segment.memory_var, NextChar::Space);
+    if (module.GetMemoryIndex(segment.memory_var) != 0) {
+      WriteOpenSpace("memory");
+      WriteVar(segment.memory_var, NextChar::Space);
+      WriteCloseSpace();
+    }
     WriteInitExpr(segment.offset);
   }
   WriteQuotedData(segment.data.data(), segment.data.size());

--- a/test/regress/write-memuse.txt
+++ b/test/regress/write-memuse.txt
@@ -1,0 +1,12 @@
+;;; TOOL: run-roundtrip
+;;; ARGS*: --stdout --enable-multi-memory --enable-memory64 --debug-names
+(module
+  (memory 0)
+  (memory $k i64 (data))
+)
+(;; STDOUT ;;;
+(module
+  (memory (;0;) 0)
+  (memory $k i64 0 0)
+  (data (;0;) (memory $k) (i64.const 0) ""))
+;;; STDOUT ;;)

--- a/test/regress/write-memuse.txt
+++ b/test/regress/write-memuse.txt
@@ -1,12 +1,4 @@
 ;;; TOOL: run-roundtrip
-;;; ARGS*: --stdout --enable-multi-memory --enable-memory64 --debug-names
-(module
-  (memory 0)
-  (memory $k i64 (data))
-)
-(;; STDOUT ;;;
-(module
-  (memory (;0;) 0)
-  (memory $k i64 0 0)
-  (data (;0;) (memory $k) (i64.const 0) ""))
-;;; STDOUT ;;)
+;;; ARGS*: --enable-multi-memory --debug-names
+(memory 0)
+(memory $k (data))


### PR DESCRIPTION
wat-writer.cc currently prints active data segments (targeting a non-0 memory) using the Wasm 1.0 format:
```wasm
(data 𝑥:memidx_𝐼 ...)
```

... but the multi-memory feature really requires the current format:
```wasm
(data id? 𝑥:memuse_𝐼 ...)
memuse_𝐼 ::= (memory 𝑥:memidx_𝐼)
```

This PR adjusts wat-writer.cc to print data segments (that target a non-0 memory) with the post-1.0 syntax. This only affects modules that use multi-memory feature so I don't think it will break anything.

Before this PR, WABT wasn't able to roundtrip this module with debug-names enabled:
```wasm
(memory 0)
(memory $k i64 (data))
```

... because after round-tripping it would be printed like this (which is invalid because it's parsed so that the data segment itself has id $k but the memuse is memory 0 which is indexed by i32):
```wasm
(module
  (memory (;0;) 0)
  (memory $k i64 0 0)
  (data (;0;) $k (i64.const 0) ""))
```

After this PR, it gets round-tripped like this:
```wasm
(module
  (memory (;0;) 0)
  (memory $k i64 0 0)
  (data (;0;) (memory $k) (i64.const 0) ""))
```