### PR TITLE
test/run-roundtrip.py: test roundtrip even with --stdout

### DIFF
--- a/test/regress/write-memuse.txt
+++ b/test/regress/write-memuse.txt
@@ -1,4 +1,10 @@
 ;;; TOOL: run-roundtrip
-;;; ARGS*: --enable-multi-memory --debug-names
+;;; ARGS*: --enable-multi-memory --debug-names --stdout
 (memory 0)
 (memory $k (data))
+(;; STDOUT ;;;
+(module
+  (memory (;0;) 0)
+  (memory $k 0 0)
+  (data (;0;) (memory $k) (i32.const 0) ""))
+;;; STDOUT ;;)

--- a/test/run-roundtrip.py
+++ b/test/run-roundtrip.py
@@ -79,6 +79,7 @@ def DoRoundtrip(wat2wasm, wasm2wat, out_dir, filename, verbose, stdout, skip_rou
         return (OK, '')
     return FilesAreEqual(wasm1_file, wasm3_file, verbose)
 
+
 def main(args):
     parser = argparse.ArgumentParser()
     parser.add_argument('-v', '--verbose', help='print more diagnotic messages.',

--- a/test/run-roundtrip.py
+++ b/test/run-roundtrip.py
@@ -55,7 +55,7 @@ def FilesAreEqual(filename1, filename2, verbose=False):
     return (OK, '')
 
 
-def DoRoundtrip(wat2wasm, wasm2wat, out_dir, filename, verbose, stdout):
+def DoRoundtrip(wat2wasm, wasm2wat, out_dir, filename, verbose, stdout, skip_roundtrip_check):
     basename = os.path.basename(filename)
     basename_noext = os.path.splitext(basename)[0]
     wasm1_file = os.path.join(out_dir, basename_noext + '-1.wasm')
@@ -75,10 +75,9 @@ def DoRoundtrip(wat2wasm, wasm2wat, out_dir, filename, verbose, stdout):
     if stdout:
         with open(wat2_file) as f:
             sys.stdout.write(f.read())
+    if skip_roundtrip_check:
         return (OK, '')
-    else:
-        return FilesAreEqual(wasm1_file, wasm3_file, verbose)
-
+    return FilesAreEqual(wasm1_file, wasm3_file, verbose)
 
 def main(args):
     parser = argparse.ArgumentParser()
@@ -90,7 +89,7 @@ def main(args):
                         default=find_exe.GetDefaultPath(),
                         help='directory to search for all executables.')
     parser.add_argument('--stdout', action='store_true',
-                        help='do one roundtrip and write wat output to stdout')
+                        help='write wat output to stdout')
     parser.add_argument('--no-error-cmdline',
                         help='don\'t display the subprocess\'s commandline when '
                         'an error occurs', dest='error_cmdline',
@@ -100,7 +99,9 @@ def main(args):
                         action='store_true')
     parser.add_argument('--no-check', action='store_true')
     parser.add_argument('--debug-names', action='store_true')
-    parser.add_argument('--generate-names', action='store_true')
+    # --generate-names modifies name section, so skip roundtrip check
+    parser.add_argument('--generate-names', action='store_true',
+                        help="write debug names and skip end-to-end roundtrip check")
     parser.add_argument('--fold-exprs', action='store_true')
     parser.add_argument('--enable-exceptions', action='store_true')
     parser.add_argument('--enable-saturating-float-to-int', action='store_true')
@@ -115,7 +116,9 @@ def main(args):
     parser.add_argument('--enable-annotations', action='store_true')
     parser.add_argument('--enable-code-metadata', action='store_true')
     parser.add_argument('--enable-custom-page-sizes', action='store_true')
-    parser.add_argument('--inline-exports', action='store_true')
+    # --inline-exports can reorder exports, so skip roundtrip check
+    parser.add_argument('--inline-exports', action='store_true',
+                        help="write exports inline and skip end-to-end roundtrip check")
     parser.add_argument('--inline-imports', action='store_true')
     parser.add_argument('--reloc', action='store_true')
     parser.add_argument('file', help='test file.')
@@ -178,9 +181,10 @@ def main(args):
         sys.stderr.write('File not found: %s\n' % filename)
         return ERROR
 
+    skip_roundtrip_check = options.generate_names or options.inline_exports
     with utils.TempDirectory(options.out_dir, 'roundtrip-') as out_dir:
         result, msg = DoRoundtrip(wat2wasm, wasm2wat, out_dir, filename,
-                                  options.verbose, options.stdout)
+                                  options.verbose, options.stdout, skip_roundtrip_check)
         if result == ERROR:
             sys.stderr.write(msg)
         return result


### PR DESCRIPTION
Since #1661, run-roundtrip.py always converts wat0 -> wasm1 -> wat2 -> wasm3 and fails if any of the conversions fails. With the `--stdout` argument, it then prints the wat2 file; otherwise, it compares the wasm1 and wasm3 binaries and fails if they're different.

This PR makes the roundtrip comparison always happen (even with `--stdout`), unless an argument is given that asks wat2wasm to change the binary on purpose (in particular: `--generate-names`, which changes the name section, or `--inline-exports` which can reorder exports).

This didn't catch any bugs, but it gives some more test coverage.

(@SoniEx2)