### PR TITLE
wasm2c: update memory/table operations to use u64 + harmonize checks

### DIFF
--- a/src/prebuilt/wasm2c_simd_source_declarations.cc
+++ b/src/prebuilt/wasm2c_simd_source_declarations.cc
@@ -15,26 +15,26 @@ R"w2c_template(#endif
 R"w2c_template(// TODO: equivalent constraint for ARM and other architectures
 )w2c_template"
 R"w2c_template(
-#define DEFINE_SIMD_LOAD_FUNC(name, func, t)                 \
+#define DEFINE_SIMD_LOAD_FUNC(name, func, t)                             \
 )w2c_template"
-R"w2c_template(  static inline v128 name(wasm_rt_memory_t* mem, u64 addr) { \
+R"w2c_template(  static inline v128 name##_unchecked(wasm_rt_memory_t* mem, u64 addr) { \
 )w2c_template"
-R"w2c_template(    MEMCHECK(mem, addr, t);                                  \
+R"w2c_template(    v128 result = func(MEM_ADDR(mem, addr, sizeof(t)));                  \
 )w2c_template"
-R"w2c_template(    v128 result = func(MEM_ADDR(mem, addr, sizeof(t)));      \
+R"w2c_template(    SIMD_FORCE_READ(result);                                             \
 )w2c_template"
-R"w2c_template(    SIMD_FORCE_READ(result);                                 \
+R"w2c_template(    return result;                                                       \
 )w2c_template"
-R"w2c_template(    return result;                                           \
+R"w2c_template(  }                                                                      \
 )w2c_template"
-R"w2c_template(  }
+R"w2c_template(  DEF_MEM_CHECKS0(name, _, t, return, v128);
 )w2c_template"
 R"w2c_template(
 #define DEFINE_SIMD_LOAD_LANE(name, func, t, lane)                     \
 )w2c_template"
-R"w2c_template(  static inline v128 name(wasm_rt_memory_t* mem, u64 addr, v128 vec) { \
+R"w2c_template(  static inline v128 name##_unchecked(wasm_rt_memory_t* mem, u64 addr, \
 )w2c_template"
-R"w2c_template(    MEMCHECK(mem, addr, t);                                            \
+R"w2c_template(                                      v128 vec) {                      \
 )w2c_template"
 R"w2c_template(    v128 result = func(MEM_ADDR(mem, addr, sizeof(t)), vec, lane);     \
 )w2c_template"
@@ -42,29 +42,35 @@ R"w2c_template(    SIMD_FORCE_READ(result);                                     
 )w2c_template"
 R"w2c_template(    return result;                                                     \
 )w2c_template"
-R"w2c_template(  }
+R"w2c_template(  }                                                                    \
+)w2c_template"
+R"w2c_template(  DEF_MEM_CHECKS1(name, _, t, return, v128, v128);
 )w2c_template"
 R"w2c_template(
-#define DEFINE_SIMD_STORE(name, t)                                       \
+#define DEFINE_SIMD_STORE(name, t)                                     \
 )w2c_template"
-R"w2c_template(  static inline void name(wasm_rt_memory_t* mem, u64 addr, v128 value) { \
+R"w2c_template(  static inline void name##_unchecked(wasm_rt_memory_t* mem, u64 addr, \
 )w2c_template"
-R"w2c_template(    MEMCHECK(mem, addr, t);                                              \
+R"w2c_template(                                      v128 value) {                    \
 )w2c_template"
-R"w2c_template(    simde_wasm_v128_store(MEM_ADDR(mem, addr, sizeof(t)), value);        \
+R"w2c_template(    simde_wasm_v128_store(MEM_ADDR(mem, addr, sizeof(t)), value);      \
 )w2c_template"
-R"w2c_template(  }
+R"w2c_template(  }                                                                    \
+)w2c_template"
+R"w2c_template(  DEF_MEM_CHECKS1(name, _, t, , void, v128);
 )w2c_template"
 R"w2c_template(
-#define DEFINE_SIMD_STORE_LANE(name, func, t, lane)                      \
+#define DEFINE_SIMD_STORE_LANE(name, func, t, lane)                    \
 )w2c_template"
-R"w2c_template(  static inline void name(wasm_rt_memory_t* mem, u64 addr, v128 value) { \
+R"w2c_template(  static inline void name##_unchecked(wasm_rt_memory_t* mem, u64 addr, \
 )w2c_template"
-R"w2c_template(    MEMCHECK(mem, addr, t);                                              \
+R"w2c_template(                                      v128 value) {                    \
 )w2c_template"
-R"w2c_template(    func(MEM_ADDR(mem, addr, sizeof(t)), value, lane);                   \
+R"w2c_template(    func(MEM_ADDR(mem, addr, sizeof(t)), value, lane);                 \
 )w2c_template"
-R"w2c_template(  }
+R"w2c_template(  }                                                                    \
+)w2c_template"
+R"w2c_template(  DEF_MEM_CHECKS1(name, _, t, , void, v128);
 )w2c_template"
 R"w2c_template(
 // clang-format off

--- a/src/prebuilt/wasm2c_source_declarations.cc
+++ b/src/prebuilt/wasm2c_source_declarations.cc
@@ -165,23 +165,23 @@ R"w2c_template(  (CHECK_CALL_INDIRECT(table, ft, x),       \
 R"w2c_template(   DO_CALL_INDIRECT(table, t, x, __VA_ARGS__))
 )w2c_template"
 R"w2c_template(
-#if __has_builtin(__builtin_add_overflow)
+static inline bool add_overflow(uint64_t a, uint64_t b, uint64_t* resptr) {
 )w2c_template"
-R"w2c_template(#define add_overflow(a, b, resptr) __builtin_add_overflow(a, b, resptr)
+R"w2c_template(#if __has_builtin(__builtin_add_overflow)
+)w2c_template"
+R"w2c_template(  return __builtin_add_overflow(a, b, resptr);
 )w2c_template"
 R"w2c_template(#elif defined(_MSC_VER)
 )w2c_template"
-R"w2c_template(static inline bool add_overflow(uint64_t a, uint64_t b, uint64_t* resptr) {
-)w2c_template"
 R"w2c_template(  return _addcarry_u64(0, a, b, resptr);
-)w2c_template"
-R"w2c_template(}
 )w2c_template"
 R"w2c_template(#else
 )w2c_template"
 R"w2c_template(#error "Missing implementation of __builtin_add_overflow or _addcarry_u64"
 )w2c_template"
 R"w2c_template(#endif
+)w2c_template"
+R"w2c_template(}
 )w2c_template"
 R"w2c_template(
 #define RANGE_CHECK(mem, offset, len)              \

--- a/src/prebuilt/wasm2c_source_declarations.cc
+++ b/src/prebuilt/wasm2c_source_declarations.cc
@@ -222,19 +222,38 @@ R"w2c_template(#define WASM_RT_CHECK_BASE(mem)
 R"w2c_template(#endif
 )w2c_template"
 R"w2c_template(
-#if WASM_RT_MEMCHECK_GUARD_PAGES
+// MEMCHECK_DEFAULT32 is an "accelerated" MEMCHECK used only for
 )w2c_template"
-R"w2c_template(#define MEMCHECK(mem, a, t) WASM_RT_CHECK_BASE(mem);
+R"w2c_template(// default-page-size, 32-bit memories. It may do nothing at all
+)w2c_template"
+R"w2c_template(// (if hardware bounds-checking is enabled via guard pages)
+)w2c_template"
+R"w2c_template(// or it may do a slightly faster RANGE_CHECK.
+)w2c_template"
+R"w2c_template(#if WASM_RT_MEMCHECK_GUARD_PAGES
+)w2c_template"
+R"w2c_template(#define MEMCHECK_DEFAULT32(mem, a, t) WASM_RT_CHECK_BASE(mem);
 )w2c_template"
 R"w2c_template(#else
 )w2c_template"
-R"w2c_template(#define MEMCHECK(mem, a, t) \
+R"w2c_template(#define MEMCHECK_DEFAULT32(mem, a, t)                \
 )w2c_template"
-R"w2c_template(  WASM_RT_CHECK_BASE(mem);  \
+R"w2c_template(  WASM_RT_CHECK_BASE(mem);                           \
 )w2c_template"
-R"w2c_template(  RANGE_CHECK(mem, a, sizeof(t))
+R"w2c_template(  if (UNLIKELY(a + (uint64_t)sizeof(t) > mem->size)) \
+)w2c_template"
+R"w2c_template(    TRAP(OOB);
 )w2c_template"
 R"w2c_template(#endif
+)w2c_template"
+R"w2c_template(
+// MEMCHECK_GENERAL can be used for any memory
+)w2c_template"
+R"w2c_template(#define MEMCHECK_GENERAL(mem, a, t) \
+)w2c_template"
+R"w2c_template(  WASM_RT_CHECK_BASE(mem);          \
+)w2c_template"
+R"w2c_template(  RANGE_CHECK(mem, a, sizeof(t));
 )w2c_template"
 R"w2c_template(
 #ifdef __GNUC__
@@ -306,30 +325,103 @@ R"w2c_template(    load_data(MEM_ADDR(&m, o, s), i, s); \
 R"w2c_template(  } while (0)
 )w2c_template"
 R"w2c_template(
-#define DEFINE_LOAD(name, t1, t2, t3, force_read)                  \
+#define DEF_MEM_CHECKS0(name, shared, mem_type, ret_kw, return_type)         \
 )w2c_template"
-R"w2c_template(  static inline t3 name(wasm_rt_memory_t* mem, u64 addr) {         \
+R"w2c_template(  static inline return_type name##_default32(wasm_rt##shared##memory_t* mem, \
 )w2c_template"
-R"w2c_template(    MEMCHECK(mem, addr, t1);                                       \
+R"w2c_template(                                             u64 addr) {                     \
 )w2c_template"
-R"w2c_template(    t1 result;                                                     \
+R"w2c_template(    MEMCHECK_DEFAULT32(mem, addr, mem_type);                                 \
 )w2c_template"
-R"w2c_template(    wasm_rt_memcpy(&result, MEM_ADDR_MEMOP(mem, addr, sizeof(t1)), \
+R"w2c_template(    ret_kw name##_unchecked(mem, addr);                                      \
 )w2c_template"
-R"w2c_template(                   sizeof(t1));                                    \
+R"w2c_template(  }                                                                          \
 )w2c_template"
-R"w2c_template(    force_read(result);                                            \
+R"w2c_template(  static inline return_type name(wasm_rt##shared##memory_t* mem, u64 addr) { \
 )w2c_template"
-R"w2c_template(    return (t3)(t2)result;                                         \
+R"w2c_template(    MEMCHECK_GENERAL(mem, addr, mem_type);                                   \
+)w2c_template"
+R"w2c_template(    ret_kw name##_unchecked(mem, addr);                                      \
 )w2c_template"
 R"w2c_template(  }
 )w2c_template"
 R"w2c_template(
+#define DEF_MEM_CHECKS1(name, shared, mem_type, ret_kw, return_type,         \
+)w2c_template"
+R"w2c_template(                        val_type1)                                           \
+)w2c_template"
+R"w2c_template(  static inline return_type name##_default32(wasm_rt##shared##memory_t* mem, \
+)w2c_template"
+R"w2c_template(                                             u64 addr, val_type1 val1) {     \
+)w2c_template"
+R"w2c_template(    MEMCHECK_DEFAULT32(mem, addr, mem_type);                                 \
+)w2c_template"
+R"w2c_template(    ret_kw name##_unchecked(mem, addr, val1);                                \
+)w2c_template"
+R"w2c_template(  }                                                                          \
+)w2c_template"
+R"w2c_template(  static inline return_type name(wasm_rt##shared##memory_t* mem, u64 addr,   \
+)w2c_template"
+R"w2c_template(                                 val_type1 val1) {                           \
+)w2c_template"
+R"w2c_template(    MEMCHECK_GENERAL(mem, addr, mem_type);                                   \
+)w2c_template"
+R"w2c_template(    ret_kw name##_unchecked(mem, addr, val1);                                \
+)w2c_template"
+R"w2c_template(  }
+)w2c_template"
+R"w2c_template(
+#define DEF_MEM_CHECKS2(name, shared, mem_type, ret_kw, return_type,         \
+)w2c_template"
+R"w2c_template(                        val_type1, val_type2)                                \
+)w2c_template"
+R"w2c_template(  static inline return_type name##_default32(wasm_rt##shared##memory_t* mem, \
+)w2c_template"
+R"w2c_template(                                             u64 addr, val_type1 val1,       \
+)w2c_template"
+R"w2c_template(                                             val_type2 val2) {               \
+)w2c_template"
+R"w2c_template(    MEMCHECK_DEFAULT32(mem, addr, mem_type);                                 \
+)w2c_template"
+R"w2c_template(    ret_kw name##_unchecked(mem, addr, val1, val2);                          \
+)w2c_template"
+R"w2c_template(  }                                                                          \
+)w2c_template"
+R"w2c_template(  static inline return_type name(wasm_rt##shared##memory_t* mem, u64 addr,   \
+)w2c_template"
+R"w2c_template(                                 val_type1 val1, val_type2 val2) {           \
+)w2c_template"
+R"w2c_template(    MEMCHECK_GENERAL(mem, addr, mem_type);                                   \
+)w2c_template"
+R"w2c_template(    ret_kw name##_unchecked(mem, addr, val1, val2);                          \
+)w2c_template"
+R"w2c_template(  }
+)w2c_template"
+R"w2c_template(
+#define DEFINE_LOAD(name, t1, t2, t3, force_read)                      \
+)w2c_template"
+R"w2c_template(  static inline t3 name##_unchecked(wasm_rt_memory_t* mem, u64 addr) { \
+)w2c_template"
+R"w2c_template(    t1 result;                                                         \
+)w2c_template"
+R"w2c_template(    wasm_rt_memcpy(&result, MEM_ADDR_MEMOP(mem, addr, sizeof(t1)),     \
+)w2c_template"
+R"w2c_template(                   sizeof(t1));                                        \
+)w2c_template"
+R"w2c_template(    force_read(result);                                                \
+)w2c_template"
+R"w2c_template(    return (t3)(t2)result;                                             \
+)w2c_template"
+R"w2c_template(  }                                                                    \
+)w2c_template"
+R"w2c_template(  DEF_MEM_CHECKS0(name, _, t1, return, t3)
+)w2c_template"
+R"w2c_template(
 #define DEFINE_STORE(name, t1, t2)                                     \
 )w2c_template"
-R"w2c_template(  static inline void name(wasm_rt_memory_t* mem, u64 addr, t2 value) { \
+R"w2c_template(  static inline void name##_unchecked(wasm_rt_memory_t* mem, u64 addr, \
 )w2c_template"
-R"w2c_template(    MEMCHECK(mem, addr, t1);                                           \
+R"w2c_template(                                      t2 value) {                      \
 )w2c_template"
 R"w2c_template(    t1 wrapped = (t1)value;                                            \
 )w2c_template"
@@ -337,7 +429,9 @@ R"w2c_template(    wasm_rt_memcpy(MEM_ADDR_MEMOP(mem, addr, sizeof(t1)), &wrappe
 )w2c_template"
 R"w2c_template(                   sizeof(t1));                                        \
 )w2c_template"
-R"w2c_template(  }
+R"w2c_template(  }                                                                    \
+)w2c_template"
+R"w2c_template(  DEF_MEM_CHECKS1(name, _, t1, , void, t2)
 )w2c_template"
 R"w2c_template(
 DEFINE_LOAD(i32_load, u32, u32, u32, FORCE_READ_INT)

--- a/src/prebuilt/wasm2c_source_declarations.cc
+++ b/src/prebuilt/wasm2c_source_declarations.cc
@@ -169,13 +169,17 @@ R"w2c_template(
 )w2c_template"
 R"w2c_template(#define add_overflow(a, b, resptr) __builtin_add_overflow(a, b, resptr)
 )w2c_template"
-R"w2c_template(#else /* MSVC */
+R"w2c_template(#elif defined(_MSC_VER)
 )w2c_template"
 R"w2c_template(static inline bool add_overflow(uint64_t a, uint64_t b, uint64_t* resptr) {
 )w2c_template"
 R"w2c_template(  return _addcarry_u64(0, a, b, resptr);
 )w2c_template"
 R"w2c_template(}
+)w2c_template"
+R"w2c_template(#else
+)w2c_template"
+R"w2c_template(#error "Missing implementation of __builtin_add_overflow or _addcarry_u64"
 )w2c_template"
 R"w2c_template(#endif
 )w2c_template"

--- a/src/template/wasm2c.declarations.c
+++ b/src/template/wasm2c.declarations.c
@@ -89,20 +89,22 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
   (CHECK_CALL_INDIRECT(table, ft, x),       \
    DO_CALL_INDIRECT(table, t, x, __VA_ARGS__))
 
-#ifdef SUPPORT_MEMORY64
+#if __has_builtin(__builtin_add_overflow)
+#define add_overflow(a, b, resptr) __builtin_add_overflow(a, b, resptr)
+#else /* MSVC */
+static inline bool add_overflow(uint64_t a, uint64_t b, uint64_t* resptr) {
+  return _addcarry_u64(0, a, b, resptr);
+}
+#endif
+
 #define RANGE_CHECK(mem, offset, len)              \
   do {                                             \
     uint64_t res;                                  \
-    if (__builtin_add_overflow(offset, len, &res)) \
+    if (UNLIKELY(add_overflow(offset, len, &res))) \
       TRAP(OOB);                                   \
     if (UNLIKELY(res > mem->size))                 \
       TRAP(OOB);                                   \
   } while (0);
-#else
-#define RANGE_CHECK(mem, offset, len)               \
-  if (UNLIKELY(offset + (uint64_t)len > mem->size)) \
-    TRAP(OOB);
-#endif
 
 #if WASM_RT_USE_SEGUE_FOR_THIS_MODULE && WASM_RT_SANITY_CHECKS
 #include <stdio.h>
@@ -523,16 +525,16 @@ static float wasm_sqrtf(float x) {
   return sqrtf(x);
 }
 
-static inline void memory_fill(wasm_rt_memory_t* mem, u32 d, u32 val, u32 n) {
+static inline void memory_fill(wasm_rt_memory_t* mem, u64 d, u32 val, u64 n) {
   RANGE_CHECK(mem, d, n);
   memset(MEM_ADDR(mem, d, n), val, n);
 }
 
 static inline void memory_copy(wasm_rt_memory_t* dest,
                                const wasm_rt_memory_t* src,
-                               u32 dest_addr,
-                               u32 src_addr,
-                               u32 n) {
+                               u64 dest_addr,
+                               u64 src_addr,
+                               u64 n) {
   RANGE_CHECK(dest, dest_addr, n);
   RANGE_CHECK(src, src_addr, n);
   memmove(MEM_ADDR(dest, dest_addr, n), MEM_ADDR(src, src_addr, n), n);
@@ -541,7 +543,7 @@ static inline void memory_copy(wasm_rt_memory_t* dest,
 static inline void memory_init(wasm_rt_memory_t* dest,
                                const u8* src,
                                u32 src_size,
-                               u32 dest_addr,
+                               u64 dest_addr,
                                u32 src_addr,
                                u32 n) {
   if (UNLIKELY(src_addr + (uint64_t)n > src_size))
@@ -560,14 +562,13 @@ typedef struct {
 static inline void funcref_table_init(wasm_rt_funcref_table_t* dest,
                                       const wasm_elem_segment_expr_t* src,
                                       u32 src_size,
-                                      u32 dest_addr,
+                                      u64 dest_addr,
                                       u32 src_addr,
                                       u32 n,
                                       void* module_instance) {
   if (UNLIKELY(src_addr + (uint64_t)n > src_size))
     TRAP(OOB);
-  if (UNLIKELY(dest_addr + (uint64_t)n > dest->size))
-    TRAP(OOB);
+  RANGE_CHECK(dest, dest_addr, n);
   for (u32 i = 0; i < n; i++) {
     const wasm_elem_segment_expr_t* const src_expr = &src[src_addr + i];
     wasm_rt_funcref_t* const dest_val = &(dest->data[dest_addr + i]);
@@ -591,13 +592,12 @@ static inline void funcref_table_init(wasm_rt_funcref_table_t* dest,
 // Currently wasm2c only supports initializing externref tables with ref.null.
 static inline void externref_table_init(wasm_rt_externref_table_t* dest,
                                         u32 src_size,
-                                        u32 dest_addr,
+                                        u64 dest_addr,
                                         u32 src_addr,
                                         u32 n) {
   if (UNLIKELY(src_addr + (uint64_t)n > src_size))
     TRAP(OOB);
-  if (UNLIKELY(dest_addr + (uint64_t)n > dest->size))
-    TRAP(OOB);
+  RANGE_CHECK(dest, dest_addr, n);
   for (u32 i = 0; i < n; i++) {
     dest->data[dest_addr + i] = wasm_rt_externref_null_value;
   }
@@ -606,12 +606,9 @@ static inline void externref_table_init(wasm_rt_externref_table_t* dest,
 #define DEFINE_TABLE_COPY(type)                                              \
   static inline void type##_table_copy(wasm_rt_##type##_table_t* dest,       \
                                        const wasm_rt_##type##_table_t* src,  \
-                                       u32 dest_addr, u32 src_addr, u32 n) { \
-    if (UNLIKELY(dest_addr + (uint64_t)n > dest->size))                      \
-      TRAP(OOB);                                                             \
-    if (UNLIKELY(src_addr + (uint64_t)n > src->size))                        \
-      TRAP(OOB);                                                             \
-                                                                             \
+                                       u64 dest_addr, u64 src_addr, u64 n) { \
+    RANGE_CHECK(dest, dest_addr, n);                                         \
+    RANGE_CHECK(src, src_addr, n);                                           \
     memmove(dest->data + dest_addr, src->data + src_addr,                    \
             n * sizeof(wasm_rt_##type##_t));                                 \
   }
@@ -621,7 +618,7 @@ DEFINE_TABLE_COPY(externref)
 
 #define DEFINE_TABLE_GET(type)                        \
   static inline wasm_rt_##type##_t type##_table_get(  \
-      const wasm_rt_##type##_table_t* table, u32 i) { \
+      const wasm_rt_##type##_table_t* table, u64 i) { \
     if (UNLIKELY(i >= table->size))                   \
       TRAP(OOB);                                      \
     return table->data[i];                            \
@@ -632,7 +629,7 @@ DEFINE_TABLE_GET(externref)
 
 #define DEFINE_TABLE_SET(type)                                               \
   static inline void type##_table_set(const wasm_rt_##type##_table_t* table, \
-                                      u32 i, const wasm_rt_##type##_t val) { \
+                                      u64 i, const wasm_rt_##type##_t val) { \
     if (UNLIKELY(i >= table->size))                                          \
       TRAP(OOB);                                                             \
     table->data[i] = val;                                                    \
@@ -643,10 +640,9 @@ DEFINE_TABLE_SET(externref)
 
 #define DEFINE_TABLE_FILL(type)                                               \
   static inline void type##_table_fill(const wasm_rt_##type##_table_t* table, \
-                                       u32 d, const wasm_rt_##type##_t val,   \
-                                       u32 n) {                               \
-    if (UNLIKELY((uint64_t)d + n > table->size))                              \
-      TRAP(OOB);                                                              \
+                                       u64 d, const wasm_rt_##type##_t val,   \
+                                       u64 n) {                               \
+    RANGE_CHECK(table, d, n);                                                 \
     for (uint32_t i = d; i < d + n; i++) {                                    \
       table->data[i] = val;                                                   \
     }                                                                         \

--- a/src/template/wasm2c.declarations.c
+++ b/src/template/wasm2c.declarations.c
@@ -89,15 +89,15 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
   (CHECK_CALL_INDIRECT(table, ft, x),       \
    DO_CALL_INDIRECT(table, t, x, __VA_ARGS__))
 
-#if __has_builtin(__builtin_add_overflow)
-#define add_overflow(a, b, resptr) __builtin_add_overflow(a, b, resptr)
-#elif defined(_MSC_VER)
 static inline bool add_overflow(uint64_t a, uint64_t b, uint64_t* resptr) {
+#if __has_builtin(__builtin_add_overflow)
+  return __builtin_add_overflow(a, b, resptr);
+#elif defined(_MSC_VER)
   return _addcarry_u64(0, a, b, resptr);
-}
 #else
 #error "Missing implementation of __builtin_add_overflow or _addcarry_u64"
 #endif
+}
 
 #define RANGE_CHECK(mem, offset, len)              \
   do {                                             \

--- a/src/template/wasm2c.declarations.c
+++ b/src/template/wasm2c.declarations.c
@@ -119,13 +119,23 @@ static inline bool add_overflow(uint64_t a, uint64_t b, uint64_t* resptr) {
 #define WASM_RT_CHECK_BASE(mem)
 #endif
 
+// MEMCHECK_DEFAULT32 is an "accelerated" MEMCHECK used only for
+// default-page-size, 32-bit memories. It may do nothing at all
+// (if hardware bounds-checking is enabled via guard pages)
+// or it may do a slightly faster RANGE_CHECK.
 #if WASM_RT_MEMCHECK_GUARD_PAGES
-#define MEMCHECK(mem, a, t) WASM_RT_CHECK_BASE(mem);
+#define MEMCHECK_DEFAULT32(mem, a, t) WASM_RT_CHECK_BASE(mem);
 #else
-#define MEMCHECK(mem, a, t) \
-  WASM_RT_CHECK_BASE(mem);  \
-  RANGE_CHECK(mem, a, sizeof(t))
+#define MEMCHECK_DEFAULT32(mem, a, t)                \
+  WASM_RT_CHECK_BASE(mem);                           \
+  if (UNLIKELY(a + (uint64_t)sizeof(t) > mem->size)) \
+    TRAP(OOB);
 #endif
+
+// MEMCHECK_GENERAL can be used for any memory
+#define MEMCHECK_GENERAL(mem, a, t) \
+  WASM_RT_CHECK_BASE(mem);          \
+  RANGE_CHECK(mem, a, sizeof(t));
 
 #ifdef __GNUC__
 #define FORCE_READ_INT(var) __asm__("" ::"r"(var));
@@ -163,23 +173,62 @@ static inline void load_data(void* dest, const void* src, size_t n) {
     load_data(MEM_ADDR(&m, o, s), i, s); \
   } while (0)
 
-#define DEFINE_LOAD(name, t1, t2, t3, force_read)                  \
-  static inline t3 name(wasm_rt_memory_t* mem, u64 addr) {         \
-    MEMCHECK(mem, addr, t1);                                       \
-    t1 result;                                                     \
-    wasm_rt_memcpy(&result, MEM_ADDR_MEMOP(mem, addr, sizeof(t1)), \
-                   sizeof(t1));                                    \
-    force_read(result);                                            \
-    return (t3)(t2)result;                                         \
+#define DEF_MEM_CHECKS0(name, shared, mem_type, ret_kw, return_type)         \
+  static inline return_type name##_default32(wasm_rt##shared##memory_t* mem, \
+                                             u64 addr) {                     \
+    MEMCHECK_DEFAULT32(mem, addr, mem_type);                                 \
+    ret_kw name##_unchecked(mem, addr);                                      \
+  }                                                                          \
+  static inline return_type name(wasm_rt##shared##memory_t* mem, u64 addr) { \
+    MEMCHECK_GENERAL(mem, addr, mem_type);                                   \
+    ret_kw name##_unchecked(mem, addr);                                      \
   }
 
+#define DEF_MEM_CHECKS1(name, shared, mem_type, ret_kw, return_type,         \
+                        val_type1)                                           \
+  static inline return_type name##_default32(wasm_rt##shared##memory_t* mem, \
+                                             u64 addr, val_type1 val1) {     \
+    MEMCHECK_DEFAULT32(mem, addr, mem_type);                                 \
+    ret_kw name##_unchecked(mem, addr, val1);                                \
+  }                                                                          \
+  static inline return_type name(wasm_rt##shared##memory_t* mem, u64 addr,   \
+                                 val_type1 val1) {                           \
+    MEMCHECK_GENERAL(mem, addr, mem_type);                                   \
+    ret_kw name##_unchecked(mem, addr, val1);                                \
+  }
+
+#define DEF_MEM_CHECKS2(name, shared, mem_type, ret_kw, return_type,         \
+                        val_type1, val_type2)                                \
+  static inline return_type name##_default32(wasm_rt##shared##memory_t* mem, \
+                                             u64 addr, val_type1 val1,       \
+                                             val_type2 val2) {               \
+    MEMCHECK_DEFAULT32(mem, addr, mem_type);                                 \
+    ret_kw name##_unchecked(mem, addr, val1, val2);                          \
+  }                                                                          \
+  static inline return_type name(wasm_rt##shared##memory_t* mem, u64 addr,   \
+                                 val_type1 val1, val_type2 val2) {           \
+    MEMCHECK_GENERAL(mem, addr, mem_type);                                   \
+    ret_kw name##_unchecked(mem, addr, val1, val2);                          \
+  }
+
+#define DEFINE_LOAD(name, t1, t2, t3, force_read)                      \
+  static inline t3 name##_unchecked(wasm_rt_memory_t* mem, u64 addr) { \
+    t1 result;                                                         \
+    wasm_rt_memcpy(&result, MEM_ADDR_MEMOP(mem, addr, sizeof(t1)),     \
+                   sizeof(t1));                                        \
+    force_read(result);                                                \
+    return (t3)(t2)result;                                             \
+  }                                                                    \
+  DEF_MEM_CHECKS0(name, _, t1, return, t3)
+
 #define DEFINE_STORE(name, t1, t2)                                     \
-  static inline void name(wasm_rt_memory_t* mem, u64 addr, t2 value) { \
-    MEMCHECK(mem, addr, t1);                                           \
+  static inline void name##_unchecked(wasm_rt_memory_t* mem, u64 addr, \
+                                      t2 value) {                      \
     t1 wrapped = (t1)value;                                            \
     wasm_rt_memcpy(MEM_ADDR_MEMOP(mem, addr, sizeof(t1)), &wrapped,    \
                    sizeof(t1));                                        \
-  }
+  }                                                                    \
+  DEF_MEM_CHECKS1(name, _, t1, , void, t2)
 
 DEFINE_LOAD(i32_load, u32, u32, u32, FORCE_READ_INT)
 DEFINE_LOAD(i64_load, u64, u64, u64, FORCE_READ_INT)

--- a/src/template/wasm2c.declarations.c
+++ b/src/template/wasm2c.declarations.c
@@ -91,10 +91,12 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
 
 #if __has_builtin(__builtin_add_overflow)
 #define add_overflow(a, b, resptr) __builtin_add_overflow(a, b, resptr)
-#else /* MSVC */
+#elif defined(_MSC_VER)
 static inline bool add_overflow(uint64_t a, uint64_t b, uint64_t* resptr) {
   return _addcarry_u64(0, a, b, resptr);
 }
+#else
+#error "Missing implementation of __builtin_add_overflow or _addcarry_u64"
 #endif
 
 #define RANGE_CHECK(mem, offset, len)              \

--- a/src/template/wasm2c_atomicops.declarations.c
+++ b/src/template/wasm2c_atomicops.declarations.c
@@ -9,16 +9,16 @@
     TRAP(UNALIGNED);                     \
   }
 
-#define DEFINE_SHARED_LOAD(name, t1, t2, t3, force_read)          \
-  static inline t3 name(wasm_rt_shared_memory_t* mem, u64 addr) { \
-    MEMCHECK(mem, addr, t1);                                      \
-    t1 result;                                                    \
-    result = atomic_load_explicit(                                \
-        (_Atomic volatile t1*)MEM_ADDR(mem, addr, sizeof(t1)),    \
-        memory_order_relaxed);                                    \
-    force_read(result);                                           \
-    return (t3)(t2)result;                                        \
-  }
+#define DEFINE_SHARED_LOAD(name, t1, t2, t3, force_read)                      \
+  static inline t3 name##_unchecked(wasm_rt_shared_memory_t* mem, u64 addr) { \
+    t1 result;                                                                \
+    result = atomic_load_explicit(                                            \
+        (_Atomic volatile t1*)MEM_ADDR(mem, addr, sizeof(t1)),                \
+        memory_order_relaxed);                                                \
+    force_read(result);                                                       \
+    return (t3)(t2)result;                                                    \
+  }                                                                           \
+  DEF_MEM_CHECKS0(name, _shared_, t1, return, t3)
 
 DEFINE_SHARED_LOAD(i32_load_shared, u32, u32, u32, FORCE_READ_INT)
 DEFINE_SHARED_LOAD(i64_load_shared, u64, u64, u64, FORCE_READ_INT)
@@ -36,13 +36,14 @@ DEFINE_SHARED_LOAD(i64_load32_s_shared, s32, s64, u64, FORCE_READ_INT)
 DEFINE_SHARED_LOAD(i64_load32_u_shared, u32, u64, u64, FORCE_READ_INT)
 
 #define DEFINE_SHARED_STORE(name, t1, t2)                                     \
-  static inline void name(wasm_rt_shared_memory_t* mem, u64 addr, t2 value) { \
-    MEMCHECK(mem, addr, t1);                                                  \
+  static inline void name##_unchecked(wasm_rt_shared_memory_t* mem, u64 addr, \
+                                      t2 value) {                             \
     t1 wrapped = (t1)value;                                                   \
     atomic_store_explicit(                                                    \
         (_Atomic volatile t1*)MEM_ADDR(mem, addr, sizeof(t1)), wrapped,       \
         memory_order_relaxed);                                                \
-  }
+  }                                                                           \
+  DEF_MEM_CHECKS1(name, _shared_, t1, , void, t2)
 
 DEFINE_SHARED_STORE(i32_store_shared, u32, u32)
 DEFINE_SHARED_STORE(i64_store_shared, u64, u64)
@@ -55,23 +56,24 @@ DEFINE_SHARED_STORE(i64_store16_shared, u16, u64)
 DEFINE_SHARED_STORE(i64_store32_shared, u32, u64)
 
 #define DEFINE_ATOMIC_LOAD(name, t1, t2, t3, force_read)                    \
-  static inline t3 name(wasm_rt_memory_t* mem, u64 addr) {                  \
-    MEMCHECK(mem, addr, t1);                                                \
+  static inline t3 name##_unchecked(wasm_rt_memory_t* mem, u64 addr) {      \
     ATOMIC_ALIGNMENT_CHECK(addr, t1);                                       \
     t1 result;                                                              \
     wasm_rt_memcpy(&result, MEM_ADDR(mem, addr, sizeof(t1)), sizeof(t1));   \
     force_read(result);                                                     \
     return (t3)(t2)result;                                                  \
   }                                                                         \
-  static inline t3 name##_shared(wasm_rt_shared_memory_t* mem, u64 addr) {  \
-    MEMCHECK(mem, addr, t1);                                                \
+  DEF_MEM_CHECKS0(name, _, t1, return, t3)                                  \
+  static inline t3 name##_shared_unchecked(wasm_rt_shared_memory_t* mem,    \
+                                           u64 addr) {                      \
     ATOMIC_ALIGNMENT_CHECK(addr, t1);                                       \
     t1 result;                                                              \
     result =                                                                \
         atomic_load((_Atomic volatile t1*)MEM_ADDR(mem, addr, sizeof(t1))); \
     force_read(result);                                                     \
     return (t3)(t2)result;                                                  \
-  }
+  }                                                                         \
+  DEF_MEM_CHECKS0(name##_shared, _shared_, t1, return, t3)
 
 DEFINE_ATOMIC_LOAD(i32_atomic_load, u32, u32, u32, FORCE_READ_INT)
 DEFINE_ATOMIC_LOAD(i64_atomic_load, u64, u64, u64, FORCE_READ_INT)
@@ -82,20 +84,21 @@ DEFINE_ATOMIC_LOAD(i64_atomic_load16_u, u16, u64, u64, FORCE_READ_INT)
 DEFINE_ATOMIC_LOAD(i64_atomic_load32_u, u32, u64, u64, FORCE_READ_INT)
 
 #define DEFINE_ATOMIC_STORE(name, t1, t2)                                  \
-  static inline void name(wasm_rt_memory_t* mem, u64 addr, t2 value) {     \
-    MEMCHECK(mem, addr, t1);                                               \
+  static inline void name##_unchecked(wasm_rt_memory_t* mem, u64 addr,     \
+                                      t2 value) {                          \
     ATOMIC_ALIGNMENT_CHECK(addr, t1);                                      \
     t1 wrapped = (t1)value;                                                \
     wasm_rt_memcpy(MEM_ADDR(mem, addr, sizeof(t1)), &wrapped, sizeof(t1)); \
   }                                                                        \
-  static inline void name##_shared(wasm_rt_shared_memory_t* mem, u64 addr, \
-                                   t2 value) {                             \
-    MEMCHECK(mem, addr, t1);                                               \
+  DEF_MEM_CHECKS1(name, _, t1, , void, t2)                                 \
+  static inline void name##_shared_unchecked(wasm_rt_shared_memory_t* mem, \
+                                             u64 addr, t2 value) {         \
     ATOMIC_ALIGNMENT_CHECK(addr, t1);                                      \
     t1 wrapped = (t1)value;                                                \
     atomic_store((_Atomic volatile t1*)MEM_ADDR(mem, addr, sizeof(t1)),    \
                  wrapped);                                                 \
-  }
+  }                                                                        \
+  DEF_MEM_CHECKS1(name##_shared, _shared_, t1, , void, t2)
 
 DEFINE_ATOMIC_STORE(i32_atomic_store, u32, u32)
 DEFINE_ATOMIC_STORE(i64_atomic_store, u64, u64)
@@ -106,8 +109,8 @@ DEFINE_ATOMIC_STORE(i64_atomic_store16, u16, u64)
 DEFINE_ATOMIC_STORE(i64_atomic_store32, u32, u64)
 
 #define DEFINE_ATOMIC_RMW(name, opname, op, t1, t2)                      \
-  static inline t2 name(wasm_rt_memory_t* mem, u64 addr, t2 value) {     \
-    MEMCHECK(mem, addr, t1);                                             \
+  static inline t2 name##_unchecked(wasm_rt_memory_t* mem, u64 addr,     \
+                                    t2 value) {                          \
     ATOMIC_ALIGNMENT_CHECK(addr, t1);                                    \
     t1 wrapped = (t1)value;                                              \
     t1 ret;                                                              \
@@ -116,15 +119,16 @@ DEFINE_ATOMIC_STORE(i64_atomic_store32, u32, u64)
     wasm_rt_memcpy(MEM_ADDR(mem, addr, sizeof(t1)), &ret, sizeof(t1));   \
     return (t2)ret;                                                      \
   }                                                                      \
-  static inline t2 name##_shared(wasm_rt_shared_memory_t* mem, u64 addr, \
-                                 t2 value) {                             \
-    MEMCHECK(mem, addr, t1);                                             \
+  DEF_MEM_CHECKS1(name, _, t1, return, t2, t2)                           \
+  static inline t2 name##_shared_unchecked(wasm_rt_shared_memory_t* mem, \
+                                           u64 addr, t2 value) {         \
     ATOMIC_ALIGNMENT_CHECK(addr, t1);                                    \
     t1 wrapped = (t1)value;                                              \
     t1 ret = atomic_##opname(                                            \
         (_Atomic volatile t1*)MEM_ADDR(mem, addr, sizeof(t1)), wrapped); \
     return (t2)ret;                                                      \
-  }
+  }                                                                      \
+  DEF_MEM_CHECKS1(name##_shared, _shared_, t1, return, t2, t2)
 
 DEFINE_ATOMIC_RMW(i32_atomic_rmw8_add_u, fetch_add, +, u8, u32)
 DEFINE_ATOMIC_RMW(i32_atomic_rmw16_add_u, fetch_add, +, u16, u32)
@@ -167,8 +171,8 @@ DEFINE_ATOMIC_RMW(i64_atomic_rmw32_xor_u, fetch_xor, ^, u32, u64)
 DEFINE_ATOMIC_RMW(i64_atomic_rmw_xor, fetch_xor, ^, u64, u64)
 
 #define DEFINE_ATOMIC_XCHG(name, opname, t1, t2)                           \
-  static inline t2 name(wasm_rt_memory_t* mem, u64 addr, t2 value) {       \
-    MEMCHECK(mem, addr, t1);                                               \
+  static inline t2 name##_unchecked(wasm_rt_memory_t* mem, u64 addr,       \
+                                    t2 value) {                            \
     ATOMIC_ALIGNMENT_CHECK(addr, t1);                                      \
     t1 wrapped = (t1)value;                                                \
     t1 ret;                                                                \
@@ -176,15 +180,16 @@ DEFINE_ATOMIC_RMW(i64_atomic_rmw_xor, fetch_xor, ^, u64, u64)
     wasm_rt_memcpy(MEM_ADDR(mem, addr, sizeof(t1)), &wrapped, sizeof(t1)); \
     return (t2)ret;                                                        \
   }                                                                        \
-  static inline t2 name##_shared(wasm_rt_shared_memory_t* mem, u64 addr,   \
-                                 t2 value) {                               \
-    MEMCHECK(mem, addr, t1);                                               \
+  DEF_MEM_CHECKS1(name, _, t1, return, t2, t2)                             \
+  static inline t2 name##_shared_unchecked(wasm_rt_shared_memory_t* mem,   \
+                                           u64 addr, t2 value) {           \
     ATOMIC_ALIGNMENT_CHECK(addr, t1);                                      \
     t1 wrapped = (t1)value;                                                \
     t1 ret = atomic_##opname(                                              \
         (_Atomic volatile t1*)MEM_ADDR(mem, addr, sizeof(t1)), wrapped);   \
     return (t2)ret;                                                        \
-  }
+  }                                                                        \
+  DEF_MEM_CHECKS1(name##_shared, _shared_, t1, return, t2, t2)
 
 DEFINE_ATOMIC_XCHG(i32_atomic_rmw8_xchg_u, exchange, u8, u32)
 DEFINE_ATOMIC_XCHG(i32_atomic_rmw16_xchg_u, exchange, u16, u32)
@@ -194,32 +199,32 @@ DEFINE_ATOMIC_XCHG(i64_atomic_rmw16_xchg_u, exchange, u16, u64)
 DEFINE_ATOMIC_XCHG(i64_atomic_rmw32_xchg_u, exchange, u32, u64)
 DEFINE_ATOMIC_XCHG(i64_atomic_rmw_xchg, exchange, u64, u64)
 
-#define DEFINE_ATOMIC_CMP_XCHG(name, t1, t2)                                \
-  static inline t1 name(wasm_rt_memory_t* mem, u64 addr, t1 expected,       \
-                        t1 replacement) {                                   \
-    MEMCHECK(mem, addr, t2);                                                \
-    ATOMIC_ALIGNMENT_CHECK(addr, t2);                                       \
-    t2 expected_wrapped = (t2)expected;                                     \
-    t2 replacement_wrapped = (t2)replacement;                               \
-    t2 ret;                                                                 \
-    wasm_rt_memcpy(&ret, MEM_ADDR(mem, addr, sizeof(t2)), sizeof(t2));      \
-    if (ret == expected_wrapped) {                                          \
-      wasm_rt_memcpy(MEM_ADDR(mem, addr, sizeof(t2)), &replacement_wrapped, \
-                     sizeof(t2));                                           \
-    }                                                                       \
-    return (t1)expected_wrapped;                                            \
-  }                                                                         \
-  static inline t1 name##_shared(wasm_rt_shared_memory_t* mem, u64 addr,    \
-                                 t1 expected, t1 replacement) {             \
-    MEMCHECK(mem, addr, t2);                                                \
-    ATOMIC_ALIGNMENT_CHECK(addr, t2);                                       \
-    t2 expected_wrapped = (t2)expected;                                     \
-    t2 replacement_wrapped = (t2)replacement;                               \
-    atomic_compare_exchange_strong(                                         \
-        (_Atomic volatile t2*)MEM_ADDR(mem, addr, sizeof(t2)),              \
-        &expected_wrapped, replacement_wrapped);                            \
-    return (t1)expected_wrapped;                                            \
-  }
+#define DEFINE_ATOMIC_CMP_XCHG(name, t1, t2)                                 \
+  static inline t1 name##_unchecked(wasm_rt_memory_t* mem, u64 addr,         \
+                                    t1 expected, t1 replacement) {           \
+    ATOMIC_ALIGNMENT_CHECK(addr, t2);                                        \
+    t2 expected_wrapped = (t2)expected;                                      \
+    t2 replacement_wrapped = (t2)replacement;                                \
+    t2 ret;                                                                  \
+    wasm_rt_memcpy(&ret, MEM_ADDR(mem, addr, sizeof(t2)), sizeof(t2));       \
+    if (ret == expected_wrapped) {                                           \
+      wasm_rt_memcpy(MEM_ADDR(mem, addr, sizeof(t2)), &replacement_wrapped,  \
+                     sizeof(t2));                                            \
+    }                                                                        \
+    return (t1)expected_wrapped;                                             \
+  }                                                                          \
+  DEF_MEM_CHECKS2(name, _, t2, return, t1, t1, t1)                           \
+  static inline t1 name##_shared_unchecked(                                  \
+      wasm_rt_shared_memory_t* mem, u64 addr, t1 expected, t1 replacement) { \
+    ATOMIC_ALIGNMENT_CHECK(addr, t2);                                        \
+    t2 expected_wrapped = (t2)expected;                                      \
+    t2 replacement_wrapped = (t2)replacement;                                \
+    atomic_compare_exchange_strong(                                          \
+        (_Atomic volatile t2*)MEM_ADDR(mem, addr, sizeof(t2)),               \
+        &expected_wrapped, replacement_wrapped);                             \
+    return (t1)expected_wrapped;                                             \
+  }                                                                          \
+  DEF_MEM_CHECKS2(name##_shared, _shared_, t2, return, t1, t1, t1)
 
 DEFINE_ATOMIC_CMP_XCHG(i32_atomic_rmw8_cmpxchg_u, u32, u8);
 DEFINE_ATOMIC_CMP_XCHG(i32_atomic_rmw16_cmpxchg_u, u32, u16);

--- a/src/template/wasm2c_simd.declarations.c
+++ b/src/template/wasm2c_simd.declarations.c
@@ -7,33 +7,36 @@
 #endif
 // TODO: equivalent constraint for ARM and other architectures
 
-#define DEFINE_SIMD_LOAD_FUNC(name, func, t)                 \
-  static inline v128 name(wasm_rt_memory_t* mem, u64 addr) { \
-    MEMCHECK(mem, addr, t);                                  \
-    v128 result = func(MEM_ADDR(mem, addr, sizeof(t)));      \
-    SIMD_FORCE_READ(result);                                 \
-    return result;                                           \
-  }
+#define DEFINE_SIMD_LOAD_FUNC(name, func, t)                             \
+  static inline v128 name##_unchecked(wasm_rt_memory_t* mem, u64 addr) { \
+    v128 result = func(MEM_ADDR(mem, addr, sizeof(t)));                  \
+    SIMD_FORCE_READ(result);                                             \
+    return result;                                                       \
+  }                                                                      \
+  DEF_MEM_CHECKS0(name, _, t, return, v128);
 
 #define DEFINE_SIMD_LOAD_LANE(name, func, t, lane)                     \
-  static inline v128 name(wasm_rt_memory_t* mem, u64 addr, v128 vec) { \
-    MEMCHECK(mem, addr, t);                                            \
+  static inline v128 name##_unchecked(wasm_rt_memory_t* mem, u64 addr, \
+                                      v128 vec) {                      \
     v128 result = func(MEM_ADDR(mem, addr, sizeof(t)), vec, lane);     \
     SIMD_FORCE_READ(result);                                           \
     return result;                                                     \
-  }
+  }                                                                    \
+  DEF_MEM_CHECKS1(name, _, t, return, v128, v128);
 
-#define DEFINE_SIMD_STORE(name, t)                                       \
-  static inline void name(wasm_rt_memory_t* mem, u64 addr, v128 value) { \
-    MEMCHECK(mem, addr, t);                                              \
-    simde_wasm_v128_store(MEM_ADDR(mem, addr, sizeof(t)), value);        \
-  }
+#define DEFINE_SIMD_STORE(name, t)                                     \
+  static inline void name##_unchecked(wasm_rt_memory_t* mem, u64 addr, \
+                                      v128 value) {                    \
+    simde_wasm_v128_store(MEM_ADDR(mem, addr, sizeof(t)), value);      \
+  }                                                                    \
+  DEF_MEM_CHECKS1(name, _, t, , void, v128);
 
-#define DEFINE_SIMD_STORE_LANE(name, func, t, lane)                      \
-  static inline void name(wasm_rt_memory_t* mem, u64 addr, v128 value) { \
-    MEMCHECK(mem, addr, t);                                              \
-    func(MEM_ADDR(mem, addr, sizeof(t)), value, lane);                   \
-  }
+#define DEFINE_SIMD_STORE_LANE(name, func, t, lane)                    \
+  static inline void name##_unchecked(wasm_rt_memory_t* mem, u64 addr, \
+                                      v128 value) {                    \
+    func(MEM_ADDR(mem, addr, sizeof(t)), value, lane);                 \
+  }                                                                    \
+  DEF_MEM_CHECKS1(name, _, t, , void, v128);
 
 // clang-format off
 #if WABT_BIG_ENDIAN

--- a/test/run-spec-wasm2c.py
+++ b/test/run-spec-wasm2c.py
@@ -609,7 +609,6 @@ def main(args):
             if IS_WINDOWS:
                 sys.stderr.write('skipping: wasm2c+memory64 is not yet supported under msvc\n')
                 return SKIPPED
-            cflags.append('-DSUPPORT_MEMORY64=1')
 
         use_c11 = options.enable_threads
 

--- a/test/wasm2c/add.txt
+++ b/test/wasm2c/add.txt
@@ -156,20 +156,22 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
   (CHECK_CALL_INDIRECT(table, ft, x),       \
    DO_CALL_INDIRECT(table, t, x, __VA_ARGS__))
 
-#ifdef SUPPORT_MEMORY64
+#if __has_builtin(__builtin_add_overflow)
+#define add_overflow(a, b, resptr) __builtin_add_overflow(a, b, resptr)
+#else /* MSVC */
+static inline bool add_overflow(uint64_t a, uint64_t b, uint64_t* resptr) {
+  return _addcarry_u64(0, a, b, resptr);
+}
+#endif
+
 #define RANGE_CHECK(mem, offset, len)              \
   do {                                             \
     uint64_t res;                                  \
-    if (__builtin_add_overflow(offset, len, &res)) \
+    if (UNLIKELY(add_overflow(offset, len, &res))) \
       TRAP(OOB);                                   \
     if (UNLIKELY(res > mem->size))                 \
       TRAP(OOB);                                   \
   } while (0);
-#else
-#define RANGE_CHECK(mem, offset, len)               \
-  if (UNLIKELY(offset + (uint64_t)len > mem->size)) \
-    TRAP(OOB);
-#endif
 
 #if WASM_RT_USE_SEGUE_FOR_THIS_MODULE && WASM_RT_SANITY_CHECKS
 #include <stdio.h>
@@ -590,16 +592,16 @@ static float wasm_sqrtf(float x) {
   return sqrtf(x);
 }
 
-static inline void memory_fill(wasm_rt_memory_t* mem, u32 d, u32 val, u32 n) {
+static inline void memory_fill(wasm_rt_memory_t* mem, u64 d, u32 val, u64 n) {
   RANGE_CHECK(mem, d, n);
   memset(MEM_ADDR(mem, d, n), val, n);
 }
 
 static inline void memory_copy(wasm_rt_memory_t* dest,
                                const wasm_rt_memory_t* src,
-                               u32 dest_addr,
-                               u32 src_addr,
-                               u32 n) {
+                               u64 dest_addr,
+                               u64 src_addr,
+                               u64 n) {
   RANGE_CHECK(dest, dest_addr, n);
   RANGE_CHECK(src, src_addr, n);
   memmove(MEM_ADDR(dest, dest_addr, n), MEM_ADDR(src, src_addr, n), n);
@@ -608,7 +610,7 @@ static inline void memory_copy(wasm_rt_memory_t* dest,
 static inline void memory_init(wasm_rt_memory_t* dest,
                                const u8* src,
                                u32 src_size,
-                               u32 dest_addr,
+                               u64 dest_addr,
                                u32 src_addr,
                                u32 n) {
   if (UNLIKELY(src_addr + (uint64_t)n > src_size))
@@ -627,14 +629,13 @@ typedef struct {
 static inline void funcref_table_init(wasm_rt_funcref_table_t* dest,
                                       const wasm_elem_segment_expr_t* src,
                                       u32 src_size,
-                                      u32 dest_addr,
+                                      u64 dest_addr,
                                       u32 src_addr,
                                       u32 n,
                                       void* module_instance) {
   if (UNLIKELY(src_addr + (uint64_t)n > src_size))
     TRAP(OOB);
-  if (UNLIKELY(dest_addr + (uint64_t)n > dest->size))
-    TRAP(OOB);
+  RANGE_CHECK(dest, dest_addr, n);
   for (u32 i = 0; i < n; i++) {
     const wasm_elem_segment_expr_t* const src_expr = &src[src_addr + i];
     wasm_rt_funcref_t* const dest_val = &(dest->data[dest_addr + i]);
@@ -658,13 +659,12 @@ static inline void funcref_table_init(wasm_rt_funcref_table_t* dest,
 // Currently wasm2c only supports initializing externref tables with ref.null.
 static inline void externref_table_init(wasm_rt_externref_table_t* dest,
                                         u32 src_size,
-                                        u32 dest_addr,
+                                        u64 dest_addr,
                                         u32 src_addr,
                                         u32 n) {
   if (UNLIKELY(src_addr + (uint64_t)n > src_size))
     TRAP(OOB);
-  if (UNLIKELY(dest_addr + (uint64_t)n > dest->size))
-    TRAP(OOB);
+  RANGE_CHECK(dest, dest_addr, n);
   for (u32 i = 0; i < n; i++) {
     dest->data[dest_addr + i] = wasm_rt_externref_null_value;
   }
@@ -673,12 +673,9 @@ static inline void externref_table_init(wasm_rt_externref_table_t* dest,
 #define DEFINE_TABLE_COPY(type)                                              \
   static inline void type##_table_copy(wasm_rt_##type##_table_t* dest,       \
                                        const wasm_rt_##type##_table_t* src,  \
-                                       u32 dest_addr, u32 src_addr, u32 n) { \
-    if (UNLIKELY(dest_addr + (uint64_t)n > dest->size))                      \
-      TRAP(OOB);                                                             \
-    if (UNLIKELY(src_addr + (uint64_t)n > src->size))                        \
-      TRAP(OOB);                                                             \
-                                                                             \
+                                       u64 dest_addr, u64 src_addr, u64 n) { \
+    RANGE_CHECK(dest, dest_addr, n);                                         \
+    RANGE_CHECK(src, src_addr, n);                                           \
     memmove(dest->data + dest_addr, src->data + src_addr,                    \
             n * sizeof(wasm_rt_##type##_t));                                 \
   }
@@ -688,7 +685,7 @@ DEFINE_TABLE_COPY(externref)
 
 #define DEFINE_TABLE_GET(type)                        \
   static inline wasm_rt_##type##_t type##_table_get(  \
-      const wasm_rt_##type##_table_t* table, u32 i) { \
+      const wasm_rt_##type##_table_t* table, u64 i) { \
     if (UNLIKELY(i >= table->size))                   \
       TRAP(OOB);                                      \
     return table->data[i];                            \
@@ -699,7 +696,7 @@ DEFINE_TABLE_GET(externref)
 
 #define DEFINE_TABLE_SET(type)                                               \
   static inline void type##_table_set(const wasm_rt_##type##_table_t* table, \
-                                      u32 i, const wasm_rt_##type##_t val) { \
+                                      u64 i, const wasm_rt_##type##_t val) { \
     if (UNLIKELY(i >= table->size))                                          \
       TRAP(OOB);                                                             \
     table->data[i] = val;                                                    \
@@ -710,10 +707,9 @@ DEFINE_TABLE_SET(externref)
 
 #define DEFINE_TABLE_FILL(type)                                               \
   static inline void type##_table_fill(const wasm_rt_##type##_table_t* table, \
-                                       u32 d, const wasm_rt_##type##_t val,   \
-                                       u32 n) {                               \
-    if (UNLIKELY((uint64_t)d + n > table->size))                              \
-      TRAP(OOB);                                                              \
+                                       u64 d, const wasm_rt_##type##_t val,   \
+                                       u64 n) {                               \
+    RANGE_CHECK(table, d, n);                                                 \
     for (uint32_t i = d; i < d + n; i++) {                                    \
       table->data[i] = val;                                                   \
     }                                                                         \

--- a/test/wasm2c/add.txt
+++ b/test/wasm2c/add.txt
@@ -186,13 +186,23 @@ static inline bool add_overflow(uint64_t a, uint64_t b, uint64_t* resptr) {
 #define WASM_RT_CHECK_BASE(mem)
 #endif
 
+// MEMCHECK_DEFAULT32 is an "accelerated" MEMCHECK used only for
+// default-page-size, 32-bit memories. It may do nothing at all
+// (if hardware bounds-checking is enabled via guard pages)
+// or it may do a slightly faster RANGE_CHECK.
 #if WASM_RT_MEMCHECK_GUARD_PAGES
-#define MEMCHECK(mem, a, t) WASM_RT_CHECK_BASE(mem);
+#define MEMCHECK_DEFAULT32(mem, a, t) WASM_RT_CHECK_BASE(mem);
 #else
-#define MEMCHECK(mem, a, t) \
-  WASM_RT_CHECK_BASE(mem);  \
-  RANGE_CHECK(mem, a, sizeof(t))
+#define MEMCHECK_DEFAULT32(mem, a, t)                \
+  WASM_RT_CHECK_BASE(mem);                           \
+  if (UNLIKELY(a + (uint64_t)sizeof(t) > mem->size)) \
+    TRAP(OOB);
 #endif
+
+// MEMCHECK_GENERAL can be used for any memory
+#define MEMCHECK_GENERAL(mem, a, t) \
+  WASM_RT_CHECK_BASE(mem);          \
+  RANGE_CHECK(mem, a, sizeof(t));
 
 #ifdef __GNUC__
 #define FORCE_READ_INT(var) __asm__("" ::"r"(var));
@@ -230,23 +240,62 @@ static inline void load_data(void* dest, const void* src, size_t n) {
     load_data(MEM_ADDR(&m, o, s), i, s); \
   } while (0)
 
-#define DEFINE_LOAD(name, t1, t2, t3, force_read)                  \
-  static inline t3 name(wasm_rt_memory_t* mem, u64 addr) {         \
-    MEMCHECK(mem, addr, t1);                                       \
-    t1 result;                                                     \
-    wasm_rt_memcpy(&result, MEM_ADDR_MEMOP(mem, addr, sizeof(t1)), \
-                   sizeof(t1));                                    \
-    force_read(result);                                            \
-    return (t3)(t2)result;                                         \
+#define DEF_MEM_CHECKS0(name, shared, mem_type, ret_kw, return_type)         \
+  static inline return_type name##_default32(wasm_rt##shared##memory_t* mem, \
+                                             u64 addr) {                     \
+    MEMCHECK_DEFAULT32(mem, addr, mem_type);                                 \
+    ret_kw name##_unchecked(mem, addr);                                      \
+  }                                                                          \
+  static inline return_type name(wasm_rt##shared##memory_t* mem, u64 addr) { \
+    MEMCHECK_GENERAL(mem, addr, mem_type);                                   \
+    ret_kw name##_unchecked(mem, addr);                                      \
   }
 
+#define DEF_MEM_CHECKS1(name, shared, mem_type, ret_kw, return_type,         \
+                        val_type1)                                           \
+  static inline return_type name##_default32(wasm_rt##shared##memory_t* mem, \
+                                             u64 addr, val_type1 val1) {     \
+    MEMCHECK_DEFAULT32(mem, addr, mem_type);                                 \
+    ret_kw name##_unchecked(mem, addr, val1);                                \
+  }                                                                          \
+  static inline return_type name(wasm_rt##shared##memory_t* mem, u64 addr,   \
+                                 val_type1 val1) {                           \
+    MEMCHECK_GENERAL(mem, addr, mem_type);                                   \
+    ret_kw name##_unchecked(mem, addr, val1);                                \
+  }
+
+#define DEF_MEM_CHECKS2(name, shared, mem_type, ret_kw, return_type,         \
+                        val_type1, val_type2)                                \
+  static inline return_type name##_default32(wasm_rt##shared##memory_t* mem, \
+                                             u64 addr, val_type1 val1,       \
+                                             val_type2 val2) {               \
+    MEMCHECK_DEFAULT32(mem, addr, mem_type);                                 \
+    ret_kw name##_unchecked(mem, addr, val1, val2);                          \
+  }                                                                          \
+  static inline return_type name(wasm_rt##shared##memory_t* mem, u64 addr,   \
+                                 val_type1 val1, val_type2 val2) {           \
+    MEMCHECK_GENERAL(mem, addr, mem_type);                                   \
+    ret_kw name##_unchecked(mem, addr, val1, val2);                          \
+  }
+
+#define DEFINE_LOAD(name, t1, t2, t3, force_read)                      \
+  static inline t3 name##_unchecked(wasm_rt_memory_t* mem, u64 addr) { \
+    t1 result;                                                         \
+    wasm_rt_memcpy(&result, MEM_ADDR_MEMOP(mem, addr, sizeof(t1)),     \
+                   sizeof(t1));                                        \
+    force_read(result);                                                \
+    return (t3)(t2)result;                                             \
+  }                                                                    \
+  DEF_MEM_CHECKS0(name, _, t1, return, t3)
+
 #define DEFINE_STORE(name, t1, t2)                                     \
-  static inline void name(wasm_rt_memory_t* mem, u64 addr, t2 value) { \
-    MEMCHECK(mem, addr, t1);                                           \
+  static inline void name##_unchecked(wasm_rt_memory_t* mem, u64 addr, \
+                                      t2 value) {                      \
     t1 wrapped = (t1)value;                                            \
     wasm_rt_memcpy(MEM_ADDR_MEMOP(mem, addr, sizeof(t1)), &wrapped,    \
                    sizeof(t1));                                        \
-  }
+  }                                                                    \
+  DEF_MEM_CHECKS1(name, _, t1, , void, t2)
 
 DEFINE_LOAD(i32_load, u32, u32, u32, FORCE_READ_INT)
 DEFINE_LOAD(i64_load, u64, u64, u64, FORCE_READ_INT)

--- a/test/wasm2c/add.txt
+++ b/test/wasm2c/add.txt
@@ -158,10 +158,12 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
 
 #if __has_builtin(__builtin_add_overflow)
 #define add_overflow(a, b, resptr) __builtin_add_overflow(a, b, resptr)
-#else /* MSVC */
+#elif defined(_MSC_VER)
 static inline bool add_overflow(uint64_t a, uint64_t b, uint64_t* resptr) {
   return _addcarry_u64(0, a, b, resptr);
 }
+#else
+#error "Missing implementation of __builtin_add_overflow or _addcarry_u64"
 #endif
 
 #define RANGE_CHECK(mem, offset, len)              \

--- a/test/wasm2c/add.txt
+++ b/test/wasm2c/add.txt
@@ -156,15 +156,15 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
   (CHECK_CALL_INDIRECT(table, ft, x),       \
    DO_CALL_INDIRECT(table, t, x, __VA_ARGS__))
 
-#if __has_builtin(__builtin_add_overflow)
-#define add_overflow(a, b, resptr) __builtin_add_overflow(a, b, resptr)
-#elif defined(_MSC_VER)
 static inline bool add_overflow(uint64_t a, uint64_t b, uint64_t* resptr) {
+#if __has_builtin(__builtin_add_overflow)
+  return __builtin_add_overflow(a, b, resptr);
+#elif defined(_MSC_VER)
   return _addcarry_u64(0, a, b, resptr);
-}
 #else
 #error "Missing implementation of __builtin_add_overflow or _addcarry_u64"
 #endif
+}
 
 #define RANGE_CHECK(mem, offset, len)              \
   do {                                             \

--- a/test/wasm2c/check-imports.txt
+++ b/test/wasm2c/check-imports.txt
@@ -180,20 +180,22 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
   (CHECK_CALL_INDIRECT(table, ft, x),       \
    DO_CALL_INDIRECT(table, t, x, __VA_ARGS__))
 
-#ifdef SUPPORT_MEMORY64
+#if __has_builtin(__builtin_add_overflow)
+#define add_overflow(a, b, resptr) __builtin_add_overflow(a, b, resptr)
+#else /* MSVC */
+static inline bool add_overflow(uint64_t a, uint64_t b, uint64_t* resptr) {
+  return _addcarry_u64(0, a, b, resptr);
+}
+#endif
+
 #define RANGE_CHECK(mem, offset, len)              \
   do {                                             \
     uint64_t res;                                  \
-    if (__builtin_add_overflow(offset, len, &res)) \
+    if (UNLIKELY(add_overflow(offset, len, &res))) \
       TRAP(OOB);                                   \
     if (UNLIKELY(res > mem->size))                 \
       TRAP(OOB);                                   \
   } while (0);
-#else
-#define RANGE_CHECK(mem, offset, len)               \
-  if (UNLIKELY(offset + (uint64_t)len > mem->size)) \
-    TRAP(OOB);
-#endif
 
 #if WASM_RT_USE_SEGUE_FOR_THIS_MODULE && WASM_RT_SANITY_CHECKS
 #include <stdio.h>
@@ -614,16 +616,16 @@ static float wasm_sqrtf(float x) {
   return sqrtf(x);
 }
 
-static inline void memory_fill(wasm_rt_memory_t* mem, u32 d, u32 val, u32 n) {
+static inline void memory_fill(wasm_rt_memory_t* mem, u64 d, u32 val, u64 n) {
   RANGE_CHECK(mem, d, n);
   memset(MEM_ADDR(mem, d, n), val, n);
 }
 
 static inline void memory_copy(wasm_rt_memory_t* dest,
                                const wasm_rt_memory_t* src,
-                               u32 dest_addr,
-                               u32 src_addr,
-                               u32 n) {
+                               u64 dest_addr,
+                               u64 src_addr,
+                               u64 n) {
   RANGE_CHECK(dest, dest_addr, n);
   RANGE_CHECK(src, src_addr, n);
   memmove(MEM_ADDR(dest, dest_addr, n), MEM_ADDR(src, src_addr, n), n);
@@ -632,7 +634,7 @@ static inline void memory_copy(wasm_rt_memory_t* dest,
 static inline void memory_init(wasm_rt_memory_t* dest,
                                const u8* src,
                                u32 src_size,
-                               u32 dest_addr,
+                               u64 dest_addr,
                                u32 src_addr,
                                u32 n) {
   if (UNLIKELY(src_addr + (uint64_t)n > src_size))
@@ -651,14 +653,13 @@ typedef struct {
 static inline void funcref_table_init(wasm_rt_funcref_table_t* dest,
                                       const wasm_elem_segment_expr_t* src,
                                       u32 src_size,
-                                      u32 dest_addr,
+                                      u64 dest_addr,
                                       u32 src_addr,
                                       u32 n,
                                       void* module_instance) {
   if (UNLIKELY(src_addr + (uint64_t)n > src_size))
     TRAP(OOB);
-  if (UNLIKELY(dest_addr + (uint64_t)n > dest->size))
-    TRAP(OOB);
+  RANGE_CHECK(dest, dest_addr, n);
   for (u32 i = 0; i < n; i++) {
     const wasm_elem_segment_expr_t* const src_expr = &src[src_addr + i];
     wasm_rt_funcref_t* const dest_val = &(dest->data[dest_addr + i]);
@@ -682,13 +683,12 @@ static inline void funcref_table_init(wasm_rt_funcref_table_t* dest,
 // Currently wasm2c only supports initializing externref tables with ref.null.
 static inline void externref_table_init(wasm_rt_externref_table_t* dest,
                                         u32 src_size,
-                                        u32 dest_addr,
+                                        u64 dest_addr,
                                         u32 src_addr,
                                         u32 n) {
   if (UNLIKELY(src_addr + (uint64_t)n > src_size))
     TRAP(OOB);
-  if (UNLIKELY(dest_addr + (uint64_t)n > dest->size))
-    TRAP(OOB);
+  RANGE_CHECK(dest, dest_addr, n);
   for (u32 i = 0; i < n; i++) {
     dest->data[dest_addr + i] = wasm_rt_externref_null_value;
   }
@@ -697,12 +697,9 @@ static inline void externref_table_init(wasm_rt_externref_table_t* dest,
 #define DEFINE_TABLE_COPY(type)                                              \
   static inline void type##_table_copy(wasm_rt_##type##_table_t* dest,       \
                                        const wasm_rt_##type##_table_t* src,  \
-                                       u32 dest_addr, u32 src_addr, u32 n) { \
-    if (UNLIKELY(dest_addr + (uint64_t)n > dest->size))                      \
-      TRAP(OOB);                                                             \
-    if (UNLIKELY(src_addr + (uint64_t)n > src->size))                        \
-      TRAP(OOB);                                                             \
-                                                                             \
+                                       u64 dest_addr, u64 src_addr, u64 n) { \
+    RANGE_CHECK(dest, dest_addr, n);                                         \
+    RANGE_CHECK(src, src_addr, n);                                           \
     memmove(dest->data + dest_addr, src->data + src_addr,                    \
             n * sizeof(wasm_rt_##type##_t));                                 \
   }
@@ -712,7 +709,7 @@ DEFINE_TABLE_COPY(externref)
 
 #define DEFINE_TABLE_GET(type)                        \
   static inline wasm_rt_##type##_t type##_table_get(  \
-      const wasm_rt_##type##_table_t* table, u32 i) { \
+      const wasm_rt_##type##_table_t* table, u64 i) { \
     if (UNLIKELY(i >= table->size))                   \
       TRAP(OOB);                                      \
     return table->data[i];                            \
@@ -723,7 +720,7 @@ DEFINE_TABLE_GET(externref)
 
 #define DEFINE_TABLE_SET(type)                                               \
   static inline void type##_table_set(const wasm_rt_##type##_table_t* table, \
-                                      u32 i, const wasm_rt_##type##_t val) { \
+                                      u64 i, const wasm_rt_##type##_t val) { \
     if (UNLIKELY(i >= table->size))                                          \
       TRAP(OOB);                                                             \
     table->data[i] = val;                                                    \
@@ -734,10 +731,9 @@ DEFINE_TABLE_SET(externref)
 
 #define DEFINE_TABLE_FILL(type)                                               \
   static inline void type##_table_fill(const wasm_rt_##type##_table_t* table, \
-                                       u32 d, const wasm_rt_##type##_t val,   \
-                                       u32 n) {                               \
-    if (UNLIKELY((uint64_t)d + n > table->size))                              \
-      TRAP(OOB);                                                              \
+                                       u64 d, const wasm_rt_##type##_t val,   \
+                                       u64 n) {                               \
+    RANGE_CHECK(table, d, n);                                                 \
     for (uint32_t i = d; i < d + n; i++) {                                    \
       table->data[i] = val;                                                   \
     }                                                                         \

--- a/test/wasm2c/check-imports.txt
+++ b/test/wasm2c/check-imports.txt
@@ -210,13 +210,23 @@ static inline bool add_overflow(uint64_t a, uint64_t b, uint64_t* resptr) {
 #define WASM_RT_CHECK_BASE(mem)
 #endif
 
+// MEMCHECK_DEFAULT32 is an "accelerated" MEMCHECK used only for
+// default-page-size, 32-bit memories. It may do nothing at all
+// (if hardware bounds-checking is enabled via guard pages)
+// or it may do a slightly faster RANGE_CHECK.
 #if WASM_RT_MEMCHECK_GUARD_PAGES
-#define MEMCHECK(mem, a, t) WASM_RT_CHECK_BASE(mem);
+#define MEMCHECK_DEFAULT32(mem, a, t) WASM_RT_CHECK_BASE(mem);
 #else
-#define MEMCHECK(mem, a, t) \
-  WASM_RT_CHECK_BASE(mem);  \
-  RANGE_CHECK(mem, a, sizeof(t))
+#define MEMCHECK_DEFAULT32(mem, a, t)                \
+  WASM_RT_CHECK_BASE(mem);                           \
+  if (UNLIKELY(a + (uint64_t)sizeof(t) > mem->size)) \
+    TRAP(OOB);
 #endif
+
+// MEMCHECK_GENERAL can be used for any memory
+#define MEMCHECK_GENERAL(mem, a, t) \
+  WASM_RT_CHECK_BASE(mem);          \
+  RANGE_CHECK(mem, a, sizeof(t));
 
 #ifdef __GNUC__
 #define FORCE_READ_INT(var) __asm__("" ::"r"(var));
@@ -254,23 +264,62 @@ static inline void load_data(void* dest, const void* src, size_t n) {
     load_data(MEM_ADDR(&m, o, s), i, s); \
   } while (0)
 
-#define DEFINE_LOAD(name, t1, t2, t3, force_read)                  \
-  static inline t3 name(wasm_rt_memory_t* mem, u64 addr) {         \
-    MEMCHECK(mem, addr, t1);                                       \
-    t1 result;                                                     \
-    wasm_rt_memcpy(&result, MEM_ADDR_MEMOP(mem, addr, sizeof(t1)), \
-                   sizeof(t1));                                    \
-    force_read(result);                                            \
-    return (t3)(t2)result;                                         \
+#define DEF_MEM_CHECKS0(name, shared, mem_type, ret_kw, return_type)         \
+  static inline return_type name##_default32(wasm_rt##shared##memory_t* mem, \
+                                             u64 addr) {                     \
+    MEMCHECK_DEFAULT32(mem, addr, mem_type);                                 \
+    ret_kw name##_unchecked(mem, addr);                                      \
+  }                                                                          \
+  static inline return_type name(wasm_rt##shared##memory_t* mem, u64 addr) { \
+    MEMCHECK_GENERAL(mem, addr, mem_type);                                   \
+    ret_kw name##_unchecked(mem, addr);                                      \
   }
 
+#define DEF_MEM_CHECKS1(name, shared, mem_type, ret_kw, return_type,         \
+                        val_type1)                                           \
+  static inline return_type name##_default32(wasm_rt##shared##memory_t* mem, \
+                                             u64 addr, val_type1 val1) {     \
+    MEMCHECK_DEFAULT32(mem, addr, mem_type);                                 \
+    ret_kw name##_unchecked(mem, addr, val1);                                \
+  }                                                                          \
+  static inline return_type name(wasm_rt##shared##memory_t* mem, u64 addr,   \
+                                 val_type1 val1) {                           \
+    MEMCHECK_GENERAL(mem, addr, mem_type);                                   \
+    ret_kw name##_unchecked(mem, addr, val1);                                \
+  }
+
+#define DEF_MEM_CHECKS2(name, shared, mem_type, ret_kw, return_type,         \
+                        val_type1, val_type2)                                \
+  static inline return_type name##_default32(wasm_rt##shared##memory_t* mem, \
+                                             u64 addr, val_type1 val1,       \
+                                             val_type2 val2) {               \
+    MEMCHECK_DEFAULT32(mem, addr, mem_type);                                 \
+    ret_kw name##_unchecked(mem, addr, val1, val2);                          \
+  }                                                                          \
+  static inline return_type name(wasm_rt##shared##memory_t* mem, u64 addr,   \
+                                 val_type1 val1, val_type2 val2) {           \
+    MEMCHECK_GENERAL(mem, addr, mem_type);                                   \
+    ret_kw name##_unchecked(mem, addr, val1, val2);                          \
+  }
+
+#define DEFINE_LOAD(name, t1, t2, t3, force_read)                      \
+  static inline t3 name##_unchecked(wasm_rt_memory_t* mem, u64 addr) { \
+    t1 result;                                                         \
+    wasm_rt_memcpy(&result, MEM_ADDR_MEMOP(mem, addr, sizeof(t1)),     \
+                   sizeof(t1));                                        \
+    force_read(result);                                                \
+    return (t3)(t2)result;                                             \
+  }                                                                    \
+  DEF_MEM_CHECKS0(name, _, t1, return, t3)
+
 #define DEFINE_STORE(name, t1, t2)                                     \
-  static inline void name(wasm_rt_memory_t* mem, u64 addr, t2 value) { \
-    MEMCHECK(mem, addr, t1);                                           \
+  static inline void name##_unchecked(wasm_rt_memory_t* mem, u64 addr, \
+                                      t2 value) {                      \
     t1 wrapped = (t1)value;                                            \
     wasm_rt_memcpy(MEM_ADDR_MEMOP(mem, addr, sizeof(t1)), &wrapped,    \
                    sizeof(t1));                                        \
-  }
+  }                                                                    \
+  DEF_MEM_CHECKS1(name, _, t1, , void, t2)
 
 DEFINE_LOAD(i32_load, u32, u32, u32, FORCE_READ_INT)
 DEFINE_LOAD(i64_load, u64, u64, u64, FORCE_READ_INT)
@@ -878,7 +927,7 @@ u32 w2c_test_f1(w2c_test* instance) {
   FUNC_PROLOGUE;
   u32 var_i0;
   var_i0 = 16u;
-  var_i0 = i32_load(instance->w2c_env_0x5F_linear_memory, (u64)(var_i0));
+  var_i0 = i32_load_default32(instance->w2c_env_0x5F_linear_memory, (u64)(var_i0));
   FUNC_EPILOGUE;
   return var_i0;
 }

--- a/test/wasm2c/check-imports.txt
+++ b/test/wasm2c/check-imports.txt
@@ -182,10 +182,12 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
 
 #if __has_builtin(__builtin_add_overflow)
 #define add_overflow(a, b, resptr) __builtin_add_overflow(a, b, resptr)
-#else /* MSVC */
+#elif defined(_MSC_VER)
 static inline bool add_overflow(uint64_t a, uint64_t b, uint64_t* resptr) {
   return _addcarry_u64(0, a, b, resptr);
 }
+#else
+#error "Missing implementation of __builtin_add_overflow or _addcarry_u64"
 #endif
 
 #define RANGE_CHECK(mem, offset, len)              \

--- a/test/wasm2c/check-imports.txt
+++ b/test/wasm2c/check-imports.txt
@@ -180,15 +180,15 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
   (CHECK_CALL_INDIRECT(table, ft, x),       \
    DO_CALL_INDIRECT(table, t, x, __VA_ARGS__))
 
-#if __has_builtin(__builtin_add_overflow)
-#define add_overflow(a, b, resptr) __builtin_add_overflow(a, b, resptr)
-#elif defined(_MSC_VER)
 static inline bool add_overflow(uint64_t a, uint64_t b, uint64_t* resptr) {
+#if __has_builtin(__builtin_add_overflow)
+  return __builtin_add_overflow(a, b, resptr);
+#elif defined(_MSC_VER)
   return _addcarry_u64(0, a, b, resptr);
-}
 #else
 #error "Missing implementation of __builtin_add_overflow or _addcarry_u64"
 #endif
+}
 
 #define RANGE_CHECK(mem, offset, len)              \
   do {                                             \

--- a/test/wasm2c/export-names.txt
+++ b/test/wasm2c/export-names.txt
@@ -180,20 +180,22 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
   (CHECK_CALL_INDIRECT(table, ft, x),       \
    DO_CALL_INDIRECT(table, t, x, __VA_ARGS__))
 
-#ifdef SUPPORT_MEMORY64
+#if __has_builtin(__builtin_add_overflow)
+#define add_overflow(a, b, resptr) __builtin_add_overflow(a, b, resptr)
+#else /* MSVC */
+static inline bool add_overflow(uint64_t a, uint64_t b, uint64_t* resptr) {
+  return _addcarry_u64(0, a, b, resptr);
+}
+#endif
+
 #define RANGE_CHECK(mem, offset, len)              \
   do {                                             \
     uint64_t res;                                  \
-    if (__builtin_add_overflow(offset, len, &res)) \
+    if (UNLIKELY(add_overflow(offset, len, &res))) \
       TRAP(OOB);                                   \
     if (UNLIKELY(res > mem->size))                 \
       TRAP(OOB);                                   \
   } while (0);
-#else
-#define RANGE_CHECK(mem, offset, len)               \
-  if (UNLIKELY(offset + (uint64_t)len > mem->size)) \
-    TRAP(OOB);
-#endif
 
 #if WASM_RT_USE_SEGUE_FOR_THIS_MODULE && WASM_RT_SANITY_CHECKS
 #include <stdio.h>
@@ -614,16 +616,16 @@ static float wasm_sqrtf(float x) {
   return sqrtf(x);
 }
 
-static inline void memory_fill(wasm_rt_memory_t* mem, u32 d, u32 val, u32 n) {
+static inline void memory_fill(wasm_rt_memory_t* mem, u64 d, u32 val, u64 n) {
   RANGE_CHECK(mem, d, n);
   memset(MEM_ADDR(mem, d, n), val, n);
 }
 
 static inline void memory_copy(wasm_rt_memory_t* dest,
                                const wasm_rt_memory_t* src,
-                               u32 dest_addr,
-                               u32 src_addr,
-                               u32 n) {
+                               u64 dest_addr,
+                               u64 src_addr,
+                               u64 n) {
   RANGE_CHECK(dest, dest_addr, n);
   RANGE_CHECK(src, src_addr, n);
   memmove(MEM_ADDR(dest, dest_addr, n), MEM_ADDR(src, src_addr, n), n);
@@ -632,7 +634,7 @@ static inline void memory_copy(wasm_rt_memory_t* dest,
 static inline void memory_init(wasm_rt_memory_t* dest,
                                const u8* src,
                                u32 src_size,
-                               u32 dest_addr,
+                               u64 dest_addr,
                                u32 src_addr,
                                u32 n) {
   if (UNLIKELY(src_addr + (uint64_t)n > src_size))
@@ -651,14 +653,13 @@ typedef struct {
 static inline void funcref_table_init(wasm_rt_funcref_table_t* dest,
                                       const wasm_elem_segment_expr_t* src,
                                       u32 src_size,
-                                      u32 dest_addr,
+                                      u64 dest_addr,
                                       u32 src_addr,
                                       u32 n,
                                       void* module_instance) {
   if (UNLIKELY(src_addr + (uint64_t)n > src_size))
     TRAP(OOB);
-  if (UNLIKELY(dest_addr + (uint64_t)n > dest->size))
-    TRAP(OOB);
+  RANGE_CHECK(dest, dest_addr, n);
   for (u32 i = 0; i < n; i++) {
     const wasm_elem_segment_expr_t* const src_expr = &src[src_addr + i];
     wasm_rt_funcref_t* const dest_val = &(dest->data[dest_addr + i]);
@@ -682,13 +683,12 @@ static inline void funcref_table_init(wasm_rt_funcref_table_t* dest,
 // Currently wasm2c only supports initializing externref tables with ref.null.
 static inline void externref_table_init(wasm_rt_externref_table_t* dest,
                                         u32 src_size,
-                                        u32 dest_addr,
+                                        u64 dest_addr,
                                         u32 src_addr,
                                         u32 n) {
   if (UNLIKELY(src_addr + (uint64_t)n > src_size))
     TRAP(OOB);
-  if (UNLIKELY(dest_addr + (uint64_t)n > dest->size))
-    TRAP(OOB);
+  RANGE_CHECK(dest, dest_addr, n);
   for (u32 i = 0; i < n; i++) {
     dest->data[dest_addr + i] = wasm_rt_externref_null_value;
   }
@@ -697,12 +697,9 @@ static inline void externref_table_init(wasm_rt_externref_table_t* dest,
 #define DEFINE_TABLE_COPY(type)                                              \
   static inline void type##_table_copy(wasm_rt_##type##_table_t* dest,       \
                                        const wasm_rt_##type##_table_t* src,  \
-                                       u32 dest_addr, u32 src_addr, u32 n) { \
-    if (UNLIKELY(dest_addr + (uint64_t)n > dest->size))                      \
-      TRAP(OOB);                                                             \
-    if (UNLIKELY(src_addr + (uint64_t)n > src->size))                        \
-      TRAP(OOB);                                                             \
-                                                                             \
+                                       u64 dest_addr, u64 src_addr, u64 n) { \
+    RANGE_CHECK(dest, dest_addr, n);                                         \
+    RANGE_CHECK(src, src_addr, n);                                           \
     memmove(dest->data + dest_addr, src->data + src_addr,                    \
             n * sizeof(wasm_rt_##type##_t));                                 \
   }
@@ -712,7 +709,7 @@ DEFINE_TABLE_COPY(externref)
 
 #define DEFINE_TABLE_GET(type)                        \
   static inline wasm_rt_##type##_t type##_table_get(  \
-      const wasm_rt_##type##_table_t* table, u32 i) { \
+      const wasm_rt_##type##_table_t* table, u64 i) { \
     if (UNLIKELY(i >= table->size))                   \
       TRAP(OOB);                                      \
     return table->data[i];                            \
@@ -723,7 +720,7 @@ DEFINE_TABLE_GET(externref)
 
 #define DEFINE_TABLE_SET(type)                                               \
   static inline void type##_table_set(const wasm_rt_##type##_table_t* table, \
-                                      u32 i, const wasm_rt_##type##_t val) { \
+                                      u64 i, const wasm_rt_##type##_t val) { \
     if (UNLIKELY(i >= table->size))                                          \
       TRAP(OOB);                                                             \
     table->data[i] = val;                                                    \
@@ -734,10 +731,9 @@ DEFINE_TABLE_SET(externref)
 
 #define DEFINE_TABLE_FILL(type)                                               \
   static inline void type##_table_fill(const wasm_rt_##type##_table_t* table, \
-                                       u32 d, const wasm_rt_##type##_t val,   \
-                                       u32 n) {                               \
-    if (UNLIKELY((uint64_t)d + n > table->size))                              \
-      TRAP(OOB);                                                              \
+                                       u64 d, const wasm_rt_##type##_t val,   \
+                                       u64 n) {                               \
+    RANGE_CHECK(table, d, n);                                                 \
     for (uint32_t i = d; i < d + n; i++) {                                    \
       table->data[i] = val;                                                   \
     }                                                                         \

--- a/test/wasm2c/export-names.txt
+++ b/test/wasm2c/export-names.txt
@@ -182,10 +182,12 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
 
 #if __has_builtin(__builtin_add_overflow)
 #define add_overflow(a, b, resptr) __builtin_add_overflow(a, b, resptr)
-#else /* MSVC */
+#elif defined(_MSC_VER)
 static inline bool add_overflow(uint64_t a, uint64_t b, uint64_t* resptr) {
   return _addcarry_u64(0, a, b, resptr);
 }
+#else
+#error "Missing implementation of __builtin_add_overflow or _addcarry_u64"
 #endif
 
 #define RANGE_CHECK(mem, offset, len)              \

--- a/test/wasm2c/export-names.txt
+++ b/test/wasm2c/export-names.txt
@@ -180,15 +180,15 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
   (CHECK_CALL_INDIRECT(table, ft, x),       \
    DO_CALL_INDIRECT(table, t, x, __VA_ARGS__))
 
-#if __has_builtin(__builtin_add_overflow)
-#define add_overflow(a, b, resptr) __builtin_add_overflow(a, b, resptr)
-#elif defined(_MSC_VER)
 static inline bool add_overflow(uint64_t a, uint64_t b, uint64_t* resptr) {
+#if __has_builtin(__builtin_add_overflow)
+  return __builtin_add_overflow(a, b, resptr);
+#elif defined(_MSC_VER)
   return _addcarry_u64(0, a, b, resptr);
-}
 #else
 #error "Missing implementation of __builtin_add_overflow or _addcarry_u64"
 #endif
+}
 
 #define RANGE_CHECK(mem, offset, len)              \
   do {                                             \

--- a/test/wasm2c/export-names.txt
+++ b/test/wasm2c/export-names.txt
@@ -210,13 +210,23 @@ static inline bool add_overflow(uint64_t a, uint64_t b, uint64_t* resptr) {
 #define WASM_RT_CHECK_BASE(mem)
 #endif
 
+// MEMCHECK_DEFAULT32 is an "accelerated" MEMCHECK used only for
+// default-page-size, 32-bit memories. It may do nothing at all
+// (if hardware bounds-checking is enabled via guard pages)
+// or it may do a slightly faster RANGE_CHECK.
 #if WASM_RT_MEMCHECK_GUARD_PAGES
-#define MEMCHECK(mem, a, t) WASM_RT_CHECK_BASE(mem);
+#define MEMCHECK_DEFAULT32(mem, a, t) WASM_RT_CHECK_BASE(mem);
 #else
-#define MEMCHECK(mem, a, t) \
-  WASM_RT_CHECK_BASE(mem);  \
-  RANGE_CHECK(mem, a, sizeof(t))
+#define MEMCHECK_DEFAULT32(mem, a, t)                \
+  WASM_RT_CHECK_BASE(mem);                           \
+  if (UNLIKELY(a + (uint64_t)sizeof(t) > mem->size)) \
+    TRAP(OOB);
 #endif
+
+// MEMCHECK_GENERAL can be used for any memory
+#define MEMCHECK_GENERAL(mem, a, t) \
+  WASM_RT_CHECK_BASE(mem);          \
+  RANGE_CHECK(mem, a, sizeof(t));
 
 #ifdef __GNUC__
 #define FORCE_READ_INT(var) __asm__("" ::"r"(var));
@@ -254,23 +264,62 @@ static inline void load_data(void* dest, const void* src, size_t n) {
     load_data(MEM_ADDR(&m, o, s), i, s); \
   } while (0)
 
-#define DEFINE_LOAD(name, t1, t2, t3, force_read)                  \
-  static inline t3 name(wasm_rt_memory_t* mem, u64 addr) {         \
-    MEMCHECK(mem, addr, t1);                                       \
-    t1 result;                                                     \
-    wasm_rt_memcpy(&result, MEM_ADDR_MEMOP(mem, addr, sizeof(t1)), \
-                   sizeof(t1));                                    \
-    force_read(result);                                            \
-    return (t3)(t2)result;                                         \
+#define DEF_MEM_CHECKS0(name, shared, mem_type, ret_kw, return_type)         \
+  static inline return_type name##_default32(wasm_rt##shared##memory_t* mem, \
+                                             u64 addr) {                     \
+    MEMCHECK_DEFAULT32(mem, addr, mem_type);                                 \
+    ret_kw name##_unchecked(mem, addr);                                      \
+  }                                                                          \
+  static inline return_type name(wasm_rt##shared##memory_t* mem, u64 addr) { \
+    MEMCHECK_GENERAL(mem, addr, mem_type);                                   \
+    ret_kw name##_unchecked(mem, addr);                                      \
   }
 
+#define DEF_MEM_CHECKS1(name, shared, mem_type, ret_kw, return_type,         \
+                        val_type1)                                           \
+  static inline return_type name##_default32(wasm_rt##shared##memory_t* mem, \
+                                             u64 addr, val_type1 val1) {     \
+    MEMCHECK_DEFAULT32(mem, addr, mem_type);                                 \
+    ret_kw name##_unchecked(mem, addr, val1);                                \
+  }                                                                          \
+  static inline return_type name(wasm_rt##shared##memory_t* mem, u64 addr,   \
+                                 val_type1 val1) {                           \
+    MEMCHECK_GENERAL(mem, addr, mem_type);                                   \
+    ret_kw name##_unchecked(mem, addr, val1);                                \
+  }
+
+#define DEF_MEM_CHECKS2(name, shared, mem_type, ret_kw, return_type,         \
+                        val_type1, val_type2)                                \
+  static inline return_type name##_default32(wasm_rt##shared##memory_t* mem, \
+                                             u64 addr, val_type1 val1,       \
+                                             val_type2 val2) {               \
+    MEMCHECK_DEFAULT32(mem, addr, mem_type);                                 \
+    ret_kw name##_unchecked(mem, addr, val1, val2);                          \
+  }                                                                          \
+  static inline return_type name(wasm_rt##shared##memory_t* mem, u64 addr,   \
+                                 val_type1 val1, val_type2 val2) {           \
+    MEMCHECK_GENERAL(mem, addr, mem_type);                                   \
+    ret_kw name##_unchecked(mem, addr, val1, val2);                          \
+  }
+
+#define DEFINE_LOAD(name, t1, t2, t3, force_read)                      \
+  static inline t3 name##_unchecked(wasm_rt_memory_t* mem, u64 addr) { \
+    t1 result;                                                         \
+    wasm_rt_memcpy(&result, MEM_ADDR_MEMOP(mem, addr, sizeof(t1)),     \
+                   sizeof(t1));                                        \
+    force_read(result);                                                \
+    return (t3)(t2)result;                                             \
+  }                                                                    \
+  DEF_MEM_CHECKS0(name, _, t1, return, t3)
+
 #define DEFINE_STORE(name, t1, t2)                                     \
-  static inline void name(wasm_rt_memory_t* mem, u64 addr, t2 value) { \
-    MEMCHECK(mem, addr, t1);                                           \
+  static inline void name##_unchecked(wasm_rt_memory_t* mem, u64 addr, \
+                                      t2 value) {                      \
     t1 wrapped = (t1)value;                                            \
     wasm_rt_memcpy(MEM_ADDR_MEMOP(mem, addr, sizeof(t1)), &wrapped,    \
                    sizeof(t1));                                        \
-  }
+  }                                                                    \
+  DEF_MEM_CHECKS1(name, _, t1, , void, t2)
 
 DEFINE_LOAD(i32_load, u32, u32, u32, FORCE_READ_INT)
 DEFINE_LOAD(i64_load, u64, u64, u64, FORCE_READ_INT)

--- a/test/wasm2c/hello.txt
+++ b/test/wasm2c/hello.txt
@@ -188,20 +188,22 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
   (CHECK_CALL_INDIRECT(table, ft, x),       \
    DO_CALL_INDIRECT(table, t, x, __VA_ARGS__))
 
-#ifdef SUPPORT_MEMORY64
+#if __has_builtin(__builtin_add_overflow)
+#define add_overflow(a, b, resptr) __builtin_add_overflow(a, b, resptr)
+#else /* MSVC */
+static inline bool add_overflow(uint64_t a, uint64_t b, uint64_t* resptr) {
+  return _addcarry_u64(0, a, b, resptr);
+}
+#endif
+
 #define RANGE_CHECK(mem, offset, len)              \
   do {                                             \
     uint64_t res;                                  \
-    if (__builtin_add_overflow(offset, len, &res)) \
+    if (UNLIKELY(add_overflow(offset, len, &res))) \
       TRAP(OOB);                                   \
     if (UNLIKELY(res > mem->size))                 \
       TRAP(OOB);                                   \
   } while (0);
-#else
-#define RANGE_CHECK(mem, offset, len)               \
-  if (UNLIKELY(offset + (uint64_t)len > mem->size)) \
-    TRAP(OOB);
-#endif
 
 #if WASM_RT_USE_SEGUE_FOR_THIS_MODULE && WASM_RT_SANITY_CHECKS
 #include <stdio.h>
@@ -622,16 +624,16 @@ static float wasm_sqrtf(float x) {
   return sqrtf(x);
 }
 
-static inline void memory_fill(wasm_rt_memory_t* mem, u32 d, u32 val, u32 n) {
+static inline void memory_fill(wasm_rt_memory_t* mem, u64 d, u32 val, u64 n) {
   RANGE_CHECK(mem, d, n);
   memset(MEM_ADDR(mem, d, n), val, n);
 }
 
 static inline void memory_copy(wasm_rt_memory_t* dest,
                                const wasm_rt_memory_t* src,
-                               u32 dest_addr,
-                               u32 src_addr,
-                               u32 n) {
+                               u64 dest_addr,
+                               u64 src_addr,
+                               u64 n) {
   RANGE_CHECK(dest, dest_addr, n);
   RANGE_CHECK(src, src_addr, n);
   memmove(MEM_ADDR(dest, dest_addr, n), MEM_ADDR(src, src_addr, n), n);
@@ -640,7 +642,7 @@ static inline void memory_copy(wasm_rt_memory_t* dest,
 static inline void memory_init(wasm_rt_memory_t* dest,
                                const u8* src,
                                u32 src_size,
-                               u32 dest_addr,
+                               u64 dest_addr,
                                u32 src_addr,
                                u32 n) {
   if (UNLIKELY(src_addr + (uint64_t)n > src_size))
@@ -659,14 +661,13 @@ typedef struct {
 static inline void funcref_table_init(wasm_rt_funcref_table_t* dest,
                                       const wasm_elem_segment_expr_t* src,
                                       u32 src_size,
-                                      u32 dest_addr,
+                                      u64 dest_addr,
                                       u32 src_addr,
                                       u32 n,
                                       void* module_instance) {
   if (UNLIKELY(src_addr + (uint64_t)n > src_size))
     TRAP(OOB);
-  if (UNLIKELY(dest_addr + (uint64_t)n > dest->size))
-    TRAP(OOB);
+  RANGE_CHECK(dest, dest_addr, n);
   for (u32 i = 0; i < n; i++) {
     const wasm_elem_segment_expr_t* const src_expr = &src[src_addr + i];
     wasm_rt_funcref_t* const dest_val = &(dest->data[dest_addr + i]);
@@ -690,13 +691,12 @@ static inline void funcref_table_init(wasm_rt_funcref_table_t* dest,
 // Currently wasm2c only supports initializing externref tables with ref.null.
 static inline void externref_table_init(wasm_rt_externref_table_t* dest,
                                         u32 src_size,
-                                        u32 dest_addr,
+                                        u64 dest_addr,
                                         u32 src_addr,
                                         u32 n) {
   if (UNLIKELY(src_addr + (uint64_t)n > src_size))
     TRAP(OOB);
-  if (UNLIKELY(dest_addr + (uint64_t)n > dest->size))
-    TRAP(OOB);
+  RANGE_CHECK(dest, dest_addr, n);
   for (u32 i = 0; i < n; i++) {
     dest->data[dest_addr + i] = wasm_rt_externref_null_value;
   }
@@ -705,12 +705,9 @@ static inline void externref_table_init(wasm_rt_externref_table_t* dest,
 #define DEFINE_TABLE_COPY(type)                                              \
   static inline void type##_table_copy(wasm_rt_##type##_table_t* dest,       \
                                        const wasm_rt_##type##_table_t* src,  \
-                                       u32 dest_addr, u32 src_addr, u32 n) { \
-    if (UNLIKELY(dest_addr + (uint64_t)n > dest->size))                      \
-      TRAP(OOB);                                                             \
-    if (UNLIKELY(src_addr + (uint64_t)n > src->size))                        \
-      TRAP(OOB);                                                             \
-                                                                             \
+                                       u64 dest_addr, u64 src_addr, u64 n) { \
+    RANGE_CHECK(dest, dest_addr, n);                                         \
+    RANGE_CHECK(src, src_addr, n);                                           \
     memmove(dest->data + dest_addr, src->data + src_addr,                    \
             n * sizeof(wasm_rt_##type##_t));                                 \
   }
@@ -720,7 +717,7 @@ DEFINE_TABLE_COPY(externref)
 
 #define DEFINE_TABLE_GET(type)                        \
   static inline wasm_rt_##type##_t type##_table_get(  \
-      const wasm_rt_##type##_table_t* table, u32 i) { \
+      const wasm_rt_##type##_table_t* table, u64 i) { \
     if (UNLIKELY(i >= table->size))                   \
       TRAP(OOB);                                      \
     return table->data[i];                            \
@@ -731,7 +728,7 @@ DEFINE_TABLE_GET(externref)
 
 #define DEFINE_TABLE_SET(type)                                               \
   static inline void type##_table_set(const wasm_rt_##type##_table_t* table, \
-                                      u32 i, const wasm_rt_##type##_t val) { \
+                                      u64 i, const wasm_rt_##type##_t val) { \
     if (UNLIKELY(i >= table->size))                                          \
       TRAP(OOB);                                                             \
     table->data[i] = val;                                                    \
@@ -742,10 +739,9 @@ DEFINE_TABLE_SET(externref)
 
 #define DEFINE_TABLE_FILL(type)                                               \
   static inline void type##_table_fill(const wasm_rt_##type##_table_t* table, \
-                                       u32 d, const wasm_rt_##type##_t val,   \
-                                       u32 n) {                               \
-    if (UNLIKELY((uint64_t)d + n > table->size))                              \
-      TRAP(OOB);                                                              \
+                                       u64 d, const wasm_rt_##type##_t val,   \
+                                       u64 n) {                               \
+    RANGE_CHECK(table, d, n);                                                 \
     for (uint32_t i = d; i < d + n; i++) {                                    \
       table->data[i] = val;                                                   \
     }                                                                         \

--- a/test/wasm2c/hello.txt
+++ b/test/wasm2c/hello.txt
@@ -188,15 +188,15 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
   (CHECK_CALL_INDIRECT(table, ft, x),       \
    DO_CALL_INDIRECT(table, t, x, __VA_ARGS__))
 
-#if __has_builtin(__builtin_add_overflow)
-#define add_overflow(a, b, resptr) __builtin_add_overflow(a, b, resptr)
-#elif defined(_MSC_VER)
 static inline bool add_overflow(uint64_t a, uint64_t b, uint64_t* resptr) {
+#if __has_builtin(__builtin_add_overflow)
+  return __builtin_add_overflow(a, b, resptr);
+#elif defined(_MSC_VER)
   return _addcarry_u64(0, a, b, resptr);
-}
 #else
 #error "Missing implementation of __builtin_add_overflow or _addcarry_u64"
 #endif
+}
 
 #define RANGE_CHECK(mem, offset, len)              \
   do {                                             \

--- a/test/wasm2c/hello.txt
+++ b/test/wasm2c/hello.txt
@@ -218,13 +218,23 @@ static inline bool add_overflow(uint64_t a, uint64_t b, uint64_t* resptr) {
 #define WASM_RT_CHECK_BASE(mem)
 #endif
 
+// MEMCHECK_DEFAULT32 is an "accelerated" MEMCHECK used only for
+// default-page-size, 32-bit memories. It may do nothing at all
+// (if hardware bounds-checking is enabled via guard pages)
+// or it may do a slightly faster RANGE_CHECK.
 #if WASM_RT_MEMCHECK_GUARD_PAGES
-#define MEMCHECK(mem, a, t) WASM_RT_CHECK_BASE(mem);
+#define MEMCHECK_DEFAULT32(mem, a, t) WASM_RT_CHECK_BASE(mem);
 #else
-#define MEMCHECK(mem, a, t) \
-  WASM_RT_CHECK_BASE(mem);  \
-  RANGE_CHECK(mem, a, sizeof(t))
+#define MEMCHECK_DEFAULT32(mem, a, t)                \
+  WASM_RT_CHECK_BASE(mem);                           \
+  if (UNLIKELY(a + (uint64_t)sizeof(t) > mem->size)) \
+    TRAP(OOB);
 #endif
+
+// MEMCHECK_GENERAL can be used for any memory
+#define MEMCHECK_GENERAL(mem, a, t) \
+  WASM_RT_CHECK_BASE(mem);          \
+  RANGE_CHECK(mem, a, sizeof(t));
 
 #ifdef __GNUC__
 #define FORCE_READ_INT(var) __asm__("" ::"r"(var));
@@ -262,23 +272,62 @@ static inline void load_data(void* dest, const void* src, size_t n) {
     load_data(MEM_ADDR(&m, o, s), i, s); \
   } while (0)
 
-#define DEFINE_LOAD(name, t1, t2, t3, force_read)                  \
-  static inline t3 name(wasm_rt_memory_t* mem, u64 addr) {         \
-    MEMCHECK(mem, addr, t1);                                       \
-    t1 result;                                                     \
-    wasm_rt_memcpy(&result, MEM_ADDR_MEMOP(mem, addr, sizeof(t1)), \
-                   sizeof(t1));                                    \
-    force_read(result);                                            \
-    return (t3)(t2)result;                                         \
+#define DEF_MEM_CHECKS0(name, shared, mem_type, ret_kw, return_type)         \
+  static inline return_type name##_default32(wasm_rt##shared##memory_t* mem, \
+                                             u64 addr) {                     \
+    MEMCHECK_DEFAULT32(mem, addr, mem_type);                                 \
+    ret_kw name##_unchecked(mem, addr);                                      \
+  }                                                                          \
+  static inline return_type name(wasm_rt##shared##memory_t* mem, u64 addr) { \
+    MEMCHECK_GENERAL(mem, addr, mem_type);                                   \
+    ret_kw name##_unchecked(mem, addr);                                      \
   }
 
+#define DEF_MEM_CHECKS1(name, shared, mem_type, ret_kw, return_type,         \
+                        val_type1)                                           \
+  static inline return_type name##_default32(wasm_rt##shared##memory_t* mem, \
+                                             u64 addr, val_type1 val1) {     \
+    MEMCHECK_DEFAULT32(mem, addr, mem_type);                                 \
+    ret_kw name##_unchecked(mem, addr, val1);                                \
+  }                                                                          \
+  static inline return_type name(wasm_rt##shared##memory_t* mem, u64 addr,   \
+                                 val_type1 val1) {                           \
+    MEMCHECK_GENERAL(mem, addr, mem_type);                                   \
+    ret_kw name##_unchecked(mem, addr, val1);                                \
+  }
+
+#define DEF_MEM_CHECKS2(name, shared, mem_type, ret_kw, return_type,         \
+                        val_type1, val_type2)                                \
+  static inline return_type name##_default32(wasm_rt##shared##memory_t* mem, \
+                                             u64 addr, val_type1 val1,       \
+                                             val_type2 val2) {               \
+    MEMCHECK_DEFAULT32(mem, addr, mem_type);                                 \
+    ret_kw name##_unchecked(mem, addr, val1, val2);                          \
+  }                                                                          \
+  static inline return_type name(wasm_rt##shared##memory_t* mem, u64 addr,   \
+                                 val_type1 val1, val_type2 val2) {           \
+    MEMCHECK_GENERAL(mem, addr, mem_type);                                   \
+    ret_kw name##_unchecked(mem, addr, val1, val2);                          \
+  }
+
+#define DEFINE_LOAD(name, t1, t2, t3, force_read)                      \
+  static inline t3 name##_unchecked(wasm_rt_memory_t* mem, u64 addr) { \
+    t1 result;                                                         \
+    wasm_rt_memcpy(&result, MEM_ADDR_MEMOP(mem, addr, sizeof(t1)),     \
+                   sizeof(t1));                                        \
+    force_read(result);                                                \
+    return (t3)(t2)result;                                             \
+  }                                                                    \
+  DEF_MEM_CHECKS0(name, _, t1, return, t3)
+
 #define DEFINE_STORE(name, t1, t2)                                     \
-  static inline void name(wasm_rt_memory_t* mem, u64 addr, t2 value) { \
-    MEMCHECK(mem, addr, t1);                                           \
+  static inline void name##_unchecked(wasm_rt_memory_t* mem, u64 addr, \
+                                      t2 value) {                      \
     t1 wrapped = (t1)value;                                            \
     wasm_rt_memcpy(MEM_ADDR_MEMOP(mem, addr, sizeof(t1)), &wrapped,    \
                    sizeof(t1));                                        \
-  }
+  }                                                                    \
+  DEF_MEM_CHECKS1(name, _, t1, , void, t2)
 
 DEFINE_LOAD(i32_load, u32, u32, u32, FORCE_READ_INT)
 DEFINE_LOAD(i64_load, u64, u64, u64, FORCE_READ_INT)
@@ -899,10 +948,10 @@ void w2c_test_0x5Fstart_0(w2c_test* instance) {
   u32 var_i0, var_i1, var_i2, var_i3, var_i4;
   var_i0 = 0u;
   var_i1 = 8u;
-  i32_store(&instance->w2c_memory, (u64)(var_i0), var_i1);
+  i32_store_default32(&instance->w2c_memory, (u64)(var_i0), var_i1);
   var_i0 = 4u;
   var_i1 = 14u;
-  i32_store(&instance->w2c_memory, (u64)(var_i0), var_i1);
+  i32_store_default32(&instance->w2c_memory, (u64)(var_i0), var_i1);
   var_i0 = 1u;
   var_i1 = 0u;
   var_i2 = 1u;

--- a/test/wasm2c/hello.txt
+++ b/test/wasm2c/hello.txt
@@ -190,10 +190,12 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
 
 #if __has_builtin(__builtin_add_overflow)
 #define add_overflow(a, b, resptr) __builtin_add_overflow(a, b, resptr)
-#else /* MSVC */
+#elif defined(_MSC_VER)
 static inline bool add_overflow(uint64_t a, uint64_t b, uint64_t* resptr) {
   return _addcarry_u64(0, a, b, resptr);
 }
+#else
+#error "Missing implementation of __builtin_add_overflow or _addcarry_u64"
 #endif
 
 #define RANGE_CHECK(mem, offset, len)              \

--- a/test/wasm2c/minimal.txt
+++ b/test/wasm2c/minimal.txt
@@ -150,20 +150,22 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
   (CHECK_CALL_INDIRECT(table, ft, x),       \
    DO_CALL_INDIRECT(table, t, x, __VA_ARGS__))
 
-#ifdef SUPPORT_MEMORY64
+#if __has_builtin(__builtin_add_overflow)
+#define add_overflow(a, b, resptr) __builtin_add_overflow(a, b, resptr)
+#else /* MSVC */
+static inline bool add_overflow(uint64_t a, uint64_t b, uint64_t* resptr) {
+  return _addcarry_u64(0, a, b, resptr);
+}
+#endif
+
 #define RANGE_CHECK(mem, offset, len)              \
   do {                                             \
     uint64_t res;                                  \
-    if (__builtin_add_overflow(offset, len, &res)) \
+    if (UNLIKELY(add_overflow(offset, len, &res))) \
       TRAP(OOB);                                   \
     if (UNLIKELY(res > mem->size))                 \
       TRAP(OOB);                                   \
   } while (0);
-#else
-#define RANGE_CHECK(mem, offset, len)               \
-  if (UNLIKELY(offset + (uint64_t)len > mem->size)) \
-    TRAP(OOB);
-#endif
 
 #if WASM_RT_USE_SEGUE_FOR_THIS_MODULE && WASM_RT_SANITY_CHECKS
 #include <stdio.h>
@@ -584,16 +586,16 @@ static float wasm_sqrtf(float x) {
   return sqrtf(x);
 }
 
-static inline void memory_fill(wasm_rt_memory_t* mem, u32 d, u32 val, u32 n) {
+static inline void memory_fill(wasm_rt_memory_t* mem, u64 d, u32 val, u64 n) {
   RANGE_CHECK(mem, d, n);
   memset(MEM_ADDR(mem, d, n), val, n);
 }
 
 static inline void memory_copy(wasm_rt_memory_t* dest,
                                const wasm_rt_memory_t* src,
-                               u32 dest_addr,
-                               u32 src_addr,
-                               u32 n) {
+                               u64 dest_addr,
+                               u64 src_addr,
+                               u64 n) {
   RANGE_CHECK(dest, dest_addr, n);
   RANGE_CHECK(src, src_addr, n);
   memmove(MEM_ADDR(dest, dest_addr, n), MEM_ADDR(src, src_addr, n), n);
@@ -602,7 +604,7 @@ static inline void memory_copy(wasm_rt_memory_t* dest,
 static inline void memory_init(wasm_rt_memory_t* dest,
                                const u8* src,
                                u32 src_size,
-                               u32 dest_addr,
+                               u64 dest_addr,
                                u32 src_addr,
                                u32 n) {
   if (UNLIKELY(src_addr + (uint64_t)n > src_size))
@@ -621,14 +623,13 @@ typedef struct {
 static inline void funcref_table_init(wasm_rt_funcref_table_t* dest,
                                       const wasm_elem_segment_expr_t* src,
                                       u32 src_size,
-                                      u32 dest_addr,
+                                      u64 dest_addr,
                                       u32 src_addr,
                                       u32 n,
                                       void* module_instance) {
   if (UNLIKELY(src_addr + (uint64_t)n > src_size))
     TRAP(OOB);
-  if (UNLIKELY(dest_addr + (uint64_t)n > dest->size))
-    TRAP(OOB);
+  RANGE_CHECK(dest, dest_addr, n);
   for (u32 i = 0; i < n; i++) {
     const wasm_elem_segment_expr_t* const src_expr = &src[src_addr + i];
     wasm_rt_funcref_t* const dest_val = &(dest->data[dest_addr + i]);
@@ -652,13 +653,12 @@ static inline void funcref_table_init(wasm_rt_funcref_table_t* dest,
 // Currently wasm2c only supports initializing externref tables with ref.null.
 static inline void externref_table_init(wasm_rt_externref_table_t* dest,
                                         u32 src_size,
-                                        u32 dest_addr,
+                                        u64 dest_addr,
                                         u32 src_addr,
                                         u32 n) {
   if (UNLIKELY(src_addr + (uint64_t)n > src_size))
     TRAP(OOB);
-  if (UNLIKELY(dest_addr + (uint64_t)n > dest->size))
-    TRAP(OOB);
+  RANGE_CHECK(dest, dest_addr, n);
   for (u32 i = 0; i < n; i++) {
     dest->data[dest_addr + i] = wasm_rt_externref_null_value;
   }
@@ -667,12 +667,9 @@ static inline void externref_table_init(wasm_rt_externref_table_t* dest,
 #define DEFINE_TABLE_COPY(type)                                              \
   static inline void type##_table_copy(wasm_rt_##type##_table_t* dest,       \
                                        const wasm_rt_##type##_table_t* src,  \
-                                       u32 dest_addr, u32 src_addr, u32 n) { \
-    if (UNLIKELY(dest_addr + (uint64_t)n > dest->size))                      \
-      TRAP(OOB);                                                             \
-    if (UNLIKELY(src_addr + (uint64_t)n > src->size))                        \
-      TRAP(OOB);                                                             \
-                                                                             \
+                                       u64 dest_addr, u64 src_addr, u64 n) { \
+    RANGE_CHECK(dest, dest_addr, n);                                         \
+    RANGE_CHECK(src, src_addr, n);                                           \
     memmove(dest->data + dest_addr, src->data + src_addr,                    \
             n * sizeof(wasm_rt_##type##_t));                                 \
   }
@@ -682,7 +679,7 @@ DEFINE_TABLE_COPY(externref)
 
 #define DEFINE_TABLE_GET(type)                        \
   static inline wasm_rt_##type##_t type##_table_get(  \
-      const wasm_rt_##type##_table_t* table, u32 i) { \
+      const wasm_rt_##type##_table_t* table, u64 i) { \
     if (UNLIKELY(i >= table->size))                   \
       TRAP(OOB);                                      \
     return table->data[i];                            \
@@ -693,7 +690,7 @@ DEFINE_TABLE_GET(externref)
 
 #define DEFINE_TABLE_SET(type)                                               \
   static inline void type##_table_set(const wasm_rt_##type##_table_t* table, \
-                                      u32 i, const wasm_rt_##type##_t val) { \
+                                      u64 i, const wasm_rt_##type##_t val) { \
     if (UNLIKELY(i >= table->size))                                          \
       TRAP(OOB);                                                             \
     table->data[i] = val;                                                    \
@@ -704,10 +701,9 @@ DEFINE_TABLE_SET(externref)
 
 #define DEFINE_TABLE_FILL(type)                                               \
   static inline void type##_table_fill(const wasm_rt_##type##_table_t* table, \
-                                       u32 d, const wasm_rt_##type##_t val,   \
-                                       u32 n) {                               \
-    if (UNLIKELY((uint64_t)d + n > table->size))                              \
-      TRAP(OOB);                                                              \
+                                       u64 d, const wasm_rt_##type##_t val,   \
+                                       u64 n) {                               \
+    RANGE_CHECK(table, d, n);                                                 \
     for (uint32_t i = d; i < d + n; i++) {                                    \
       table->data[i] = val;                                                   \
     }                                                                         \

--- a/test/wasm2c/minimal.txt
+++ b/test/wasm2c/minimal.txt
@@ -152,10 +152,12 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
 
 #if __has_builtin(__builtin_add_overflow)
 #define add_overflow(a, b, resptr) __builtin_add_overflow(a, b, resptr)
-#else /* MSVC */
+#elif defined(_MSC_VER)
 static inline bool add_overflow(uint64_t a, uint64_t b, uint64_t* resptr) {
   return _addcarry_u64(0, a, b, resptr);
 }
+#else
+#error "Missing implementation of __builtin_add_overflow or _addcarry_u64"
 #endif
 
 #define RANGE_CHECK(mem, offset, len)              \

--- a/test/wasm2c/minimal.txt
+++ b/test/wasm2c/minimal.txt
@@ -180,13 +180,23 @@ static inline bool add_overflow(uint64_t a, uint64_t b, uint64_t* resptr) {
 #define WASM_RT_CHECK_BASE(mem)
 #endif
 
+// MEMCHECK_DEFAULT32 is an "accelerated" MEMCHECK used only for
+// default-page-size, 32-bit memories. It may do nothing at all
+// (if hardware bounds-checking is enabled via guard pages)
+// or it may do a slightly faster RANGE_CHECK.
 #if WASM_RT_MEMCHECK_GUARD_PAGES
-#define MEMCHECK(mem, a, t) WASM_RT_CHECK_BASE(mem);
+#define MEMCHECK_DEFAULT32(mem, a, t) WASM_RT_CHECK_BASE(mem);
 #else
-#define MEMCHECK(mem, a, t) \
-  WASM_RT_CHECK_BASE(mem);  \
-  RANGE_CHECK(mem, a, sizeof(t))
+#define MEMCHECK_DEFAULT32(mem, a, t)                \
+  WASM_RT_CHECK_BASE(mem);                           \
+  if (UNLIKELY(a + (uint64_t)sizeof(t) > mem->size)) \
+    TRAP(OOB);
 #endif
+
+// MEMCHECK_GENERAL can be used for any memory
+#define MEMCHECK_GENERAL(mem, a, t) \
+  WASM_RT_CHECK_BASE(mem);          \
+  RANGE_CHECK(mem, a, sizeof(t));
 
 #ifdef __GNUC__
 #define FORCE_READ_INT(var) __asm__("" ::"r"(var));
@@ -224,23 +234,62 @@ static inline void load_data(void* dest, const void* src, size_t n) {
     load_data(MEM_ADDR(&m, o, s), i, s); \
   } while (0)
 
-#define DEFINE_LOAD(name, t1, t2, t3, force_read)                  \
-  static inline t3 name(wasm_rt_memory_t* mem, u64 addr) {         \
-    MEMCHECK(mem, addr, t1);                                       \
-    t1 result;                                                     \
-    wasm_rt_memcpy(&result, MEM_ADDR_MEMOP(mem, addr, sizeof(t1)), \
-                   sizeof(t1));                                    \
-    force_read(result);                                            \
-    return (t3)(t2)result;                                         \
+#define DEF_MEM_CHECKS0(name, shared, mem_type, ret_kw, return_type)         \
+  static inline return_type name##_default32(wasm_rt##shared##memory_t* mem, \
+                                             u64 addr) {                     \
+    MEMCHECK_DEFAULT32(mem, addr, mem_type);                                 \
+    ret_kw name##_unchecked(mem, addr);                                      \
+  }                                                                          \
+  static inline return_type name(wasm_rt##shared##memory_t* mem, u64 addr) { \
+    MEMCHECK_GENERAL(mem, addr, mem_type);                                   \
+    ret_kw name##_unchecked(mem, addr);                                      \
   }
 
+#define DEF_MEM_CHECKS1(name, shared, mem_type, ret_kw, return_type,         \
+                        val_type1)                                           \
+  static inline return_type name##_default32(wasm_rt##shared##memory_t* mem, \
+                                             u64 addr, val_type1 val1) {     \
+    MEMCHECK_DEFAULT32(mem, addr, mem_type);                                 \
+    ret_kw name##_unchecked(mem, addr, val1);                                \
+  }                                                                          \
+  static inline return_type name(wasm_rt##shared##memory_t* mem, u64 addr,   \
+                                 val_type1 val1) {                           \
+    MEMCHECK_GENERAL(mem, addr, mem_type);                                   \
+    ret_kw name##_unchecked(mem, addr, val1);                                \
+  }
+
+#define DEF_MEM_CHECKS2(name, shared, mem_type, ret_kw, return_type,         \
+                        val_type1, val_type2)                                \
+  static inline return_type name##_default32(wasm_rt##shared##memory_t* mem, \
+                                             u64 addr, val_type1 val1,       \
+                                             val_type2 val2) {               \
+    MEMCHECK_DEFAULT32(mem, addr, mem_type);                                 \
+    ret_kw name##_unchecked(mem, addr, val1, val2);                          \
+  }                                                                          \
+  static inline return_type name(wasm_rt##shared##memory_t* mem, u64 addr,   \
+                                 val_type1 val1, val_type2 val2) {           \
+    MEMCHECK_GENERAL(mem, addr, mem_type);                                   \
+    ret_kw name##_unchecked(mem, addr, val1, val2);                          \
+  }
+
+#define DEFINE_LOAD(name, t1, t2, t3, force_read)                      \
+  static inline t3 name##_unchecked(wasm_rt_memory_t* mem, u64 addr) { \
+    t1 result;                                                         \
+    wasm_rt_memcpy(&result, MEM_ADDR_MEMOP(mem, addr, sizeof(t1)),     \
+                   sizeof(t1));                                        \
+    force_read(result);                                                \
+    return (t3)(t2)result;                                             \
+  }                                                                    \
+  DEF_MEM_CHECKS0(name, _, t1, return, t3)
+
 #define DEFINE_STORE(name, t1, t2)                                     \
-  static inline void name(wasm_rt_memory_t* mem, u64 addr, t2 value) { \
-    MEMCHECK(mem, addr, t1);                                           \
+  static inline void name##_unchecked(wasm_rt_memory_t* mem, u64 addr, \
+                                      t2 value) {                      \
     t1 wrapped = (t1)value;                                            \
     wasm_rt_memcpy(MEM_ADDR_MEMOP(mem, addr, sizeof(t1)), &wrapped,    \
                    sizeof(t1));                                        \
-  }
+  }                                                                    \
+  DEF_MEM_CHECKS1(name, _, t1, , void, t2)
 
 DEFINE_LOAD(i32_load, u32, u32, u32, FORCE_READ_INT)
 DEFINE_LOAD(i64_load, u64, u64, u64, FORCE_READ_INT)

--- a/test/wasm2c/minimal.txt
+++ b/test/wasm2c/minimal.txt
@@ -150,15 +150,15 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
   (CHECK_CALL_INDIRECT(table, ft, x),       \
    DO_CALL_INDIRECT(table, t, x, __VA_ARGS__))
 
-#if __has_builtin(__builtin_add_overflow)
-#define add_overflow(a, b, resptr) __builtin_add_overflow(a, b, resptr)
-#elif defined(_MSC_VER)
 static inline bool add_overflow(uint64_t a, uint64_t b, uint64_t* resptr) {
+#if __has_builtin(__builtin_add_overflow)
+  return __builtin_add_overflow(a, b, resptr);
+#elif defined(_MSC_VER)
   return _addcarry_u64(0, a, b, resptr);
-}
 #else
 #error "Missing implementation of __builtin_add_overflow or _addcarry_u64"
 #endif
+}
 
 #define RANGE_CHECK(mem, offset, len)              \
   do {                                             \

--- a/test/wasm2c/tail-calls.txt
+++ b/test/wasm2c/tail-calls.txt
@@ -180,20 +180,22 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
   (CHECK_CALL_INDIRECT(table, ft, x),       \
    DO_CALL_INDIRECT(table, t, x, __VA_ARGS__))
 
-#ifdef SUPPORT_MEMORY64
+#if __has_builtin(__builtin_add_overflow)
+#define add_overflow(a, b, resptr) __builtin_add_overflow(a, b, resptr)
+#else /* MSVC */
+static inline bool add_overflow(uint64_t a, uint64_t b, uint64_t* resptr) {
+  return _addcarry_u64(0, a, b, resptr);
+}
+#endif
+
 #define RANGE_CHECK(mem, offset, len)              \
   do {                                             \
     uint64_t res;                                  \
-    if (__builtin_add_overflow(offset, len, &res)) \
+    if (UNLIKELY(add_overflow(offset, len, &res))) \
       TRAP(OOB);                                   \
     if (UNLIKELY(res > mem->size))                 \
       TRAP(OOB);                                   \
   } while (0);
-#else
-#define RANGE_CHECK(mem, offset, len)               \
-  if (UNLIKELY(offset + (uint64_t)len > mem->size)) \
-    TRAP(OOB);
-#endif
 
 #if WASM_RT_USE_SEGUE_FOR_THIS_MODULE && WASM_RT_SANITY_CHECKS
 #include <stdio.h>
@@ -614,16 +616,16 @@ static float wasm_sqrtf(float x) {
   return sqrtf(x);
 }
 
-static inline void memory_fill(wasm_rt_memory_t* mem, u32 d, u32 val, u32 n) {
+static inline void memory_fill(wasm_rt_memory_t* mem, u64 d, u32 val, u64 n) {
   RANGE_CHECK(mem, d, n);
   memset(MEM_ADDR(mem, d, n), val, n);
 }
 
 static inline void memory_copy(wasm_rt_memory_t* dest,
                                const wasm_rt_memory_t* src,
-                               u32 dest_addr,
-                               u32 src_addr,
-                               u32 n) {
+                               u64 dest_addr,
+                               u64 src_addr,
+                               u64 n) {
   RANGE_CHECK(dest, dest_addr, n);
   RANGE_CHECK(src, src_addr, n);
   memmove(MEM_ADDR(dest, dest_addr, n), MEM_ADDR(src, src_addr, n), n);
@@ -632,7 +634,7 @@ static inline void memory_copy(wasm_rt_memory_t* dest,
 static inline void memory_init(wasm_rt_memory_t* dest,
                                const u8* src,
                                u32 src_size,
-                               u32 dest_addr,
+                               u64 dest_addr,
                                u32 src_addr,
                                u32 n) {
   if (UNLIKELY(src_addr + (uint64_t)n > src_size))
@@ -651,14 +653,13 @@ typedef struct {
 static inline void funcref_table_init(wasm_rt_funcref_table_t* dest,
                                       const wasm_elem_segment_expr_t* src,
                                       u32 src_size,
-                                      u32 dest_addr,
+                                      u64 dest_addr,
                                       u32 src_addr,
                                       u32 n,
                                       void* module_instance) {
   if (UNLIKELY(src_addr + (uint64_t)n > src_size))
     TRAP(OOB);
-  if (UNLIKELY(dest_addr + (uint64_t)n > dest->size))
-    TRAP(OOB);
+  RANGE_CHECK(dest, dest_addr, n);
   for (u32 i = 0; i < n; i++) {
     const wasm_elem_segment_expr_t* const src_expr = &src[src_addr + i];
     wasm_rt_funcref_t* const dest_val = &(dest->data[dest_addr + i]);
@@ -682,13 +683,12 @@ static inline void funcref_table_init(wasm_rt_funcref_table_t* dest,
 // Currently wasm2c only supports initializing externref tables with ref.null.
 static inline void externref_table_init(wasm_rt_externref_table_t* dest,
                                         u32 src_size,
-                                        u32 dest_addr,
+                                        u64 dest_addr,
                                         u32 src_addr,
                                         u32 n) {
   if (UNLIKELY(src_addr + (uint64_t)n > src_size))
     TRAP(OOB);
-  if (UNLIKELY(dest_addr + (uint64_t)n > dest->size))
-    TRAP(OOB);
+  RANGE_CHECK(dest, dest_addr, n);
   for (u32 i = 0; i < n; i++) {
     dest->data[dest_addr + i] = wasm_rt_externref_null_value;
   }
@@ -697,12 +697,9 @@ static inline void externref_table_init(wasm_rt_externref_table_t* dest,
 #define DEFINE_TABLE_COPY(type)                                              \
   static inline void type##_table_copy(wasm_rt_##type##_table_t* dest,       \
                                        const wasm_rt_##type##_table_t* src,  \
-                                       u32 dest_addr, u32 src_addr, u32 n) { \
-    if (UNLIKELY(dest_addr + (uint64_t)n > dest->size))                      \
-      TRAP(OOB);                                                             \
-    if (UNLIKELY(src_addr + (uint64_t)n > src->size))                        \
-      TRAP(OOB);                                                             \
-                                                                             \
+                                       u64 dest_addr, u64 src_addr, u64 n) { \
+    RANGE_CHECK(dest, dest_addr, n);                                         \
+    RANGE_CHECK(src, src_addr, n);                                           \
     memmove(dest->data + dest_addr, src->data + src_addr,                    \
             n * sizeof(wasm_rt_##type##_t));                                 \
   }
@@ -712,7 +709,7 @@ DEFINE_TABLE_COPY(externref)
 
 #define DEFINE_TABLE_GET(type)                        \
   static inline wasm_rt_##type##_t type##_table_get(  \
-      const wasm_rt_##type##_table_t* table, u32 i) { \
+      const wasm_rt_##type##_table_t* table, u64 i) { \
     if (UNLIKELY(i >= table->size))                   \
       TRAP(OOB);                                      \
     return table->data[i];                            \
@@ -723,7 +720,7 @@ DEFINE_TABLE_GET(externref)
 
 #define DEFINE_TABLE_SET(type)                                               \
   static inline void type##_table_set(const wasm_rt_##type##_table_t* table, \
-                                      u32 i, const wasm_rt_##type##_t val) { \
+                                      u64 i, const wasm_rt_##type##_t val) { \
     if (UNLIKELY(i >= table->size))                                          \
       TRAP(OOB);                                                             \
     table->data[i] = val;                                                    \
@@ -734,10 +731,9 @@ DEFINE_TABLE_SET(externref)
 
 #define DEFINE_TABLE_FILL(type)                                               \
   static inline void type##_table_fill(const wasm_rt_##type##_table_t* table, \
-                                       u32 d, const wasm_rt_##type##_t val,   \
-                                       u32 n) {                               \
-    if (UNLIKELY((uint64_t)d + n > table->size))                              \
-      TRAP(OOB);                                                              \
+                                       u64 d, const wasm_rt_##type##_t val,   \
+                                       u64 n) {                               \
+    RANGE_CHECK(table, d, n);                                                 \
     for (uint32_t i = d; i < d + n; i++) {                                    \
       table->data[i] = val;                                                   \
     }                                                                         \

--- a/test/wasm2c/tail-calls.txt
+++ b/test/wasm2c/tail-calls.txt
@@ -182,10 +182,12 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
 
 #if __has_builtin(__builtin_add_overflow)
 #define add_overflow(a, b, resptr) __builtin_add_overflow(a, b, resptr)
-#else /* MSVC */
+#elif defined(_MSC_VER)
 static inline bool add_overflow(uint64_t a, uint64_t b, uint64_t* resptr) {
   return _addcarry_u64(0, a, b, resptr);
 }
+#else
+#error "Missing implementation of __builtin_add_overflow or _addcarry_u64"
 #endif
 
 #define RANGE_CHECK(mem, offset, len)              \

--- a/test/wasm2c/tail-calls.txt
+++ b/test/wasm2c/tail-calls.txt
@@ -180,15 +180,15 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
   (CHECK_CALL_INDIRECT(table, ft, x),       \
    DO_CALL_INDIRECT(table, t, x, __VA_ARGS__))
 
-#if __has_builtin(__builtin_add_overflow)
-#define add_overflow(a, b, resptr) __builtin_add_overflow(a, b, resptr)
-#elif defined(_MSC_VER)
 static inline bool add_overflow(uint64_t a, uint64_t b, uint64_t* resptr) {
+#if __has_builtin(__builtin_add_overflow)
+  return __builtin_add_overflow(a, b, resptr);
+#elif defined(_MSC_VER)
   return _addcarry_u64(0, a, b, resptr);
-}
 #else
 #error "Missing implementation of __builtin_add_overflow or _addcarry_u64"
 #endif
+}
 
 #define RANGE_CHECK(mem, offset, len)              \
   do {                                             \

--- a/test/wasm2c/tail-calls.txt
+++ b/test/wasm2c/tail-calls.txt
@@ -210,13 +210,23 @@ static inline bool add_overflow(uint64_t a, uint64_t b, uint64_t* resptr) {
 #define WASM_RT_CHECK_BASE(mem)
 #endif
 
+// MEMCHECK_DEFAULT32 is an "accelerated" MEMCHECK used only for
+// default-page-size, 32-bit memories. It may do nothing at all
+// (if hardware bounds-checking is enabled via guard pages)
+// or it may do a slightly faster RANGE_CHECK.
 #if WASM_RT_MEMCHECK_GUARD_PAGES
-#define MEMCHECK(mem, a, t) WASM_RT_CHECK_BASE(mem);
+#define MEMCHECK_DEFAULT32(mem, a, t) WASM_RT_CHECK_BASE(mem);
 #else
-#define MEMCHECK(mem, a, t) \
-  WASM_RT_CHECK_BASE(mem);  \
-  RANGE_CHECK(mem, a, sizeof(t))
+#define MEMCHECK_DEFAULT32(mem, a, t)                \
+  WASM_RT_CHECK_BASE(mem);                           \
+  if (UNLIKELY(a + (uint64_t)sizeof(t) > mem->size)) \
+    TRAP(OOB);
 #endif
+
+// MEMCHECK_GENERAL can be used for any memory
+#define MEMCHECK_GENERAL(mem, a, t) \
+  WASM_RT_CHECK_BASE(mem);          \
+  RANGE_CHECK(mem, a, sizeof(t));
 
 #ifdef __GNUC__
 #define FORCE_READ_INT(var) __asm__("" ::"r"(var));
@@ -254,23 +264,62 @@ static inline void load_data(void* dest, const void* src, size_t n) {
     load_data(MEM_ADDR(&m, o, s), i, s); \
   } while (0)
 
-#define DEFINE_LOAD(name, t1, t2, t3, force_read)                  \
-  static inline t3 name(wasm_rt_memory_t* mem, u64 addr) {         \
-    MEMCHECK(mem, addr, t1);                                       \
-    t1 result;                                                     \
-    wasm_rt_memcpy(&result, MEM_ADDR_MEMOP(mem, addr, sizeof(t1)), \
-                   sizeof(t1));                                    \
-    force_read(result);                                            \
-    return (t3)(t2)result;                                         \
+#define DEF_MEM_CHECKS0(name, shared, mem_type, ret_kw, return_type)         \
+  static inline return_type name##_default32(wasm_rt##shared##memory_t* mem, \
+                                             u64 addr) {                     \
+    MEMCHECK_DEFAULT32(mem, addr, mem_type);                                 \
+    ret_kw name##_unchecked(mem, addr);                                      \
+  }                                                                          \
+  static inline return_type name(wasm_rt##shared##memory_t* mem, u64 addr) { \
+    MEMCHECK_GENERAL(mem, addr, mem_type);                                   \
+    ret_kw name##_unchecked(mem, addr);                                      \
   }
 
+#define DEF_MEM_CHECKS1(name, shared, mem_type, ret_kw, return_type,         \
+                        val_type1)                                           \
+  static inline return_type name##_default32(wasm_rt##shared##memory_t* mem, \
+                                             u64 addr, val_type1 val1) {     \
+    MEMCHECK_DEFAULT32(mem, addr, mem_type);                                 \
+    ret_kw name##_unchecked(mem, addr, val1);                                \
+  }                                                                          \
+  static inline return_type name(wasm_rt##shared##memory_t* mem, u64 addr,   \
+                                 val_type1 val1) {                           \
+    MEMCHECK_GENERAL(mem, addr, mem_type);                                   \
+    ret_kw name##_unchecked(mem, addr, val1);                                \
+  }
+
+#define DEF_MEM_CHECKS2(name, shared, mem_type, ret_kw, return_type,         \
+                        val_type1, val_type2)                                \
+  static inline return_type name##_default32(wasm_rt##shared##memory_t* mem, \
+                                             u64 addr, val_type1 val1,       \
+                                             val_type2 val2) {               \
+    MEMCHECK_DEFAULT32(mem, addr, mem_type);                                 \
+    ret_kw name##_unchecked(mem, addr, val1, val2);                          \
+  }                                                                          \
+  static inline return_type name(wasm_rt##shared##memory_t* mem, u64 addr,   \
+                                 val_type1 val1, val_type2 val2) {           \
+    MEMCHECK_GENERAL(mem, addr, mem_type);                                   \
+    ret_kw name##_unchecked(mem, addr, val1, val2);                          \
+  }
+
+#define DEFINE_LOAD(name, t1, t2, t3, force_read)                      \
+  static inline t3 name##_unchecked(wasm_rt_memory_t* mem, u64 addr) { \
+    t1 result;                                                         \
+    wasm_rt_memcpy(&result, MEM_ADDR_MEMOP(mem, addr, sizeof(t1)),     \
+                   sizeof(t1));                                        \
+    force_read(result);                                                \
+    return (t3)(t2)result;                                             \
+  }                                                                    \
+  DEF_MEM_CHECKS0(name, _, t1, return, t3)
+
 #define DEFINE_STORE(name, t1, t2)                                     \
-  static inline void name(wasm_rt_memory_t* mem, u64 addr, t2 value) { \
-    MEMCHECK(mem, addr, t1);                                           \
+  static inline void name##_unchecked(wasm_rt_memory_t* mem, u64 addr, \
+                                      t2 value) {                      \
     t1 wrapped = (t1)value;                                            \
     wasm_rt_memcpy(MEM_ADDR_MEMOP(mem, addr, sizeof(t1)), &wrapped,    \
                    sizeof(t1));                                        \
-  }
+  }                                                                    \
+  DEF_MEM_CHECKS1(name, _, t1, , void, t2)
 
 DEFINE_LOAD(i32_load, u32, u32, u32, FORCE_READ_INT)
 DEFINE_LOAD(i64_load, u64, u64, u64, FORCE_READ_INT)

--- a/wasm2c/examples/fac/fac.c
+++ b/wasm2c/examples/fac/fac.c
@@ -108,20 +108,22 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
   (CHECK_CALL_INDIRECT(table, ft, x),       \
    DO_CALL_INDIRECT(table, t, x, __VA_ARGS__))
 
-#ifdef SUPPORT_MEMORY64
+#if __has_builtin(__builtin_add_overflow)
+#define add_overflow(a, b, resptr) __builtin_add_overflow(a, b, resptr)
+#else /* MSVC */
+static inline bool add_overflow(uint64_t a, uint64_t b, uint64_t* resptr) {
+  return _addcarry_u64(0, a, b, resptr);
+}
+#endif
+
 #define RANGE_CHECK(mem, offset, len)              \
   do {                                             \
     uint64_t res;                                  \
-    if (__builtin_add_overflow(offset, len, &res)) \
+    if (UNLIKELY(add_overflow(offset, len, &res))) \
       TRAP(OOB);                                   \
     if (UNLIKELY(res > mem->size))                 \
       TRAP(OOB);                                   \
   } while (0);
-#else
-#define RANGE_CHECK(mem, offset, len)               \
-  if (UNLIKELY(offset + (uint64_t)len > mem->size)) \
-    TRAP(OOB);
-#endif
 
 #if WASM_RT_USE_SEGUE_FOR_THIS_MODULE && WASM_RT_SANITY_CHECKS
 #include <stdio.h>
@@ -542,16 +544,16 @@ static float wasm_sqrtf(float x) {
   return sqrtf(x);
 }
 
-static inline void memory_fill(wasm_rt_memory_t* mem, u32 d, u32 val, u32 n) {
+static inline void memory_fill(wasm_rt_memory_t* mem, u64 d, u32 val, u64 n) {
   RANGE_CHECK(mem, d, n);
   memset(MEM_ADDR(mem, d, n), val, n);
 }
 
 static inline void memory_copy(wasm_rt_memory_t* dest,
                                const wasm_rt_memory_t* src,
-                               u32 dest_addr,
-                               u32 src_addr,
-                               u32 n) {
+                               u64 dest_addr,
+                               u64 src_addr,
+                               u64 n) {
   RANGE_CHECK(dest, dest_addr, n);
   RANGE_CHECK(src, src_addr, n);
   memmove(MEM_ADDR(dest, dest_addr, n), MEM_ADDR(src, src_addr, n), n);
@@ -560,7 +562,7 @@ static inline void memory_copy(wasm_rt_memory_t* dest,
 static inline void memory_init(wasm_rt_memory_t* dest,
                                const u8* src,
                                u32 src_size,
-                               u32 dest_addr,
+                               u64 dest_addr,
                                u32 src_addr,
                                u32 n) {
   if (UNLIKELY(src_addr + (uint64_t)n > src_size))
@@ -579,14 +581,13 @@ typedef struct {
 static inline void funcref_table_init(wasm_rt_funcref_table_t* dest,
                                       const wasm_elem_segment_expr_t* src,
                                       u32 src_size,
-                                      u32 dest_addr,
+                                      u64 dest_addr,
                                       u32 src_addr,
                                       u32 n,
                                       void* module_instance) {
   if (UNLIKELY(src_addr + (uint64_t)n > src_size))
     TRAP(OOB);
-  if (UNLIKELY(dest_addr + (uint64_t)n > dest->size))
-    TRAP(OOB);
+  RANGE_CHECK(dest, dest_addr, n);
   for (u32 i = 0; i < n; i++) {
     const wasm_elem_segment_expr_t* const src_expr = &src[src_addr + i];
     wasm_rt_funcref_t* const dest_val = &(dest->data[dest_addr + i]);
@@ -610,13 +611,12 @@ static inline void funcref_table_init(wasm_rt_funcref_table_t* dest,
 // Currently wasm2c only supports initializing externref tables with ref.null.
 static inline void externref_table_init(wasm_rt_externref_table_t* dest,
                                         u32 src_size,
-                                        u32 dest_addr,
+                                        u64 dest_addr,
                                         u32 src_addr,
                                         u32 n) {
   if (UNLIKELY(src_addr + (uint64_t)n > src_size))
     TRAP(OOB);
-  if (UNLIKELY(dest_addr + (uint64_t)n > dest->size))
-    TRAP(OOB);
+  RANGE_CHECK(dest, dest_addr, n);
   for (u32 i = 0; i < n; i++) {
     dest->data[dest_addr + i] = wasm_rt_externref_null_value;
   }
@@ -625,12 +625,9 @@ static inline void externref_table_init(wasm_rt_externref_table_t* dest,
 #define DEFINE_TABLE_COPY(type)                                              \
   static inline void type##_table_copy(wasm_rt_##type##_table_t* dest,       \
                                        const wasm_rt_##type##_table_t* src,  \
-                                       u32 dest_addr, u32 src_addr, u32 n) { \
-    if (UNLIKELY(dest_addr + (uint64_t)n > dest->size))                      \
-      TRAP(OOB);                                                             \
-    if (UNLIKELY(src_addr + (uint64_t)n > src->size))                        \
-      TRAP(OOB);                                                             \
-                                                                             \
+                                       u64 dest_addr, u64 src_addr, u64 n) { \
+    RANGE_CHECK(dest, dest_addr, n);                                         \
+    RANGE_CHECK(src, src_addr, n);                                           \
     memmove(dest->data + dest_addr, src->data + src_addr,                    \
             n * sizeof(wasm_rt_##type##_t));                                 \
   }
@@ -640,7 +637,7 @@ DEFINE_TABLE_COPY(externref)
 
 #define DEFINE_TABLE_GET(type)                        \
   static inline wasm_rt_##type##_t type##_table_get(  \
-      const wasm_rt_##type##_table_t* table, u32 i) { \
+      const wasm_rt_##type##_table_t* table, u64 i) { \
     if (UNLIKELY(i >= table->size))                   \
       TRAP(OOB);                                      \
     return table->data[i];                            \
@@ -651,7 +648,7 @@ DEFINE_TABLE_GET(externref)
 
 #define DEFINE_TABLE_SET(type)                                               \
   static inline void type##_table_set(const wasm_rt_##type##_table_t* table, \
-                                      u32 i, const wasm_rt_##type##_t val) { \
+                                      u64 i, const wasm_rt_##type##_t val) { \
     if (UNLIKELY(i >= table->size))                                          \
       TRAP(OOB);                                                             \
     table->data[i] = val;                                                    \
@@ -662,10 +659,9 @@ DEFINE_TABLE_SET(externref)
 
 #define DEFINE_TABLE_FILL(type)                                               \
   static inline void type##_table_fill(const wasm_rt_##type##_table_t* table, \
-                                       u32 d, const wasm_rt_##type##_t val,   \
-                                       u32 n) {                               \
-    if (UNLIKELY((uint64_t)d + n > table->size))                              \
-      TRAP(OOB);                                                              \
+                                       u64 d, const wasm_rt_##type##_t val,   \
+                                       u64 n) {                               \
+    RANGE_CHECK(table, d, n);                                                 \
     for (uint32_t i = d; i < d + n; i++) {                                    \
       table->data[i] = val;                                                   \
     }                                                                         \

--- a/wasm2c/examples/fac/fac.c
+++ b/wasm2c/examples/fac/fac.c
@@ -108,15 +108,15 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
   (CHECK_CALL_INDIRECT(table, ft, x),       \
    DO_CALL_INDIRECT(table, t, x, __VA_ARGS__))
 
-#if __has_builtin(__builtin_add_overflow)
-#define add_overflow(a, b, resptr) __builtin_add_overflow(a, b, resptr)
-#elif defined(_MSC_VER)
 static inline bool add_overflow(uint64_t a, uint64_t b, uint64_t* resptr) {
+#if __has_builtin(__builtin_add_overflow)
+  return __builtin_add_overflow(a, b, resptr);
+#elif defined(_MSC_VER)
   return _addcarry_u64(0, a, b, resptr);
-}
 #else
 #error "Missing implementation of __builtin_add_overflow or _addcarry_u64"
 #endif
+}
 
 #define RANGE_CHECK(mem, offset, len)              \
   do {                                             \

--- a/wasm2c/examples/fac/fac.c
+++ b/wasm2c/examples/fac/fac.c
@@ -110,10 +110,12 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
 
 #if __has_builtin(__builtin_add_overflow)
 #define add_overflow(a, b, resptr) __builtin_add_overflow(a, b, resptr)
-#else /* MSVC */
+#elif defined(_MSC_VER)
 static inline bool add_overflow(uint64_t a, uint64_t b, uint64_t* resptr) {
   return _addcarry_u64(0, a, b, resptr);
 }
+#else
+#error "Missing implementation of __builtin_add_overflow or _addcarry_u64"
 #endif
 
 #define RANGE_CHECK(mem, offset, len)              \

--- a/wasm2c/examples/fac/fac.c
+++ b/wasm2c/examples/fac/fac.c
@@ -138,13 +138,23 @@ static inline bool add_overflow(uint64_t a, uint64_t b, uint64_t* resptr) {
 #define WASM_RT_CHECK_BASE(mem)
 #endif
 
+// MEMCHECK_DEFAULT32 is an "accelerated" MEMCHECK used only for
+// default-page-size, 32-bit memories. It may do nothing at all
+// (if hardware bounds-checking is enabled via guard pages)
+// or it may do a slightly faster RANGE_CHECK.
 #if WASM_RT_MEMCHECK_GUARD_PAGES
-#define MEMCHECK(mem, a, t) WASM_RT_CHECK_BASE(mem);
+#define MEMCHECK_DEFAULT32(mem, a, t) WASM_RT_CHECK_BASE(mem);
 #else
-#define MEMCHECK(mem, a, t) \
-  WASM_RT_CHECK_BASE(mem);  \
-  RANGE_CHECK(mem, a, sizeof(t))
+#define MEMCHECK_DEFAULT32(mem, a, t)                \
+  WASM_RT_CHECK_BASE(mem);                           \
+  if (UNLIKELY(a + (uint64_t)sizeof(t) > mem->size)) \
+    TRAP(OOB);
 #endif
+
+// MEMCHECK_GENERAL can be used for any memory
+#define MEMCHECK_GENERAL(mem, a, t) \
+  WASM_RT_CHECK_BASE(mem);          \
+  RANGE_CHECK(mem, a, sizeof(t));
 
 #ifdef __GNUC__
 #define FORCE_READ_INT(var) __asm__("" ::"r"(var));
@@ -182,23 +192,62 @@ static inline void load_data(void* dest, const void* src, size_t n) {
     load_data(MEM_ADDR(&m, o, s), i, s); \
   } while (0)
 
-#define DEFINE_LOAD(name, t1, t2, t3, force_read)                  \
-  static inline t3 name(wasm_rt_memory_t* mem, u64 addr) {         \
-    MEMCHECK(mem, addr, t1);                                       \
-    t1 result;                                                     \
-    wasm_rt_memcpy(&result, MEM_ADDR_MEMOP(mem, addr, sizeof(t1)), \
-                   sizeof(t1));                                    \
-    force_read(result);                                            \
-    return (t3)(t2)result;                                         \
+#define DEF_MEM_CHECKS0(name, shared, mem_type, ret_kw, return_type)         \
+  static inline return_type name##_default32(wasm_rt##shared##memory_t* mem, \
+                                             u64 addr) {                     \
+    MEMCHECK_DEFAULT32(mem, addr, mem_type);                                 \
+    ret_kw name##_unchecked(mem, addr);                                      \
+  }                                                                          \
+  static inline return_type name(wasm_rt##shared##memory_t* mem, u64 addr) { \
+    MEMCHECK_GENERAL(mem, addr, mem_type);                                   \
+    ret_kw name##_unchecked(mem, addr);                                      \
   }
 
+#define DEF_MEM_CHECKS1(name, shared, mem_type, ret_kw, return_type,         \
+                        val_type1)                                           \
+  static inline return_type name##_default32(wasm_rt##shared##memory_t* mem, \
+                                             u64 addr, val_type1 val1) {     \
+    MEMCHECK_DEFAULT32(mem, addr, mem_type);                                 \
+    ret_kw name##_unchecked(mem, addr, val1);                                \
+  }                                                                          \
+  static inline return_type name(wasm_rt##shared##memory_t* mem, u64 addr,   \
+                                 val_type1 val1) {                           \
+    MEMCHECK_GENERAL(mem, addr, mem_type);                                   \
+    ret_kw name##_unchecked(mem, addr, val1);                                \
+  }
+
+#define DEF_MEM_CHECKS2(name, shared, mem_type, ret_kw, return_type,         \
+                        val_type1, val_type2)                                \
+  static inline return_type name##_default32(wasm_rt##shared##memory_t* mem, \
+                                             u64 addr, val_type1 val1,       \
+                                             val_type2 val2) {               \
+    MEMCHECK_DEFAULT32(mem, addr, mem_type);                                 \
+    ret_kw name##_unchecked(mem, addr, val1, val2);                          \
+  }                                                                          \
+  static inline return_type name(wasm_rt##shared##memory_t* mem, u64 addr,   \
+                                 val_type1 val1, val_type2 val2) {           \
+    MEMCHECK_GENERAL(mem, addr, mem_type);                                   \
+    ret_kw name##_unchecked(mem, addr, val1, val2);                          \
+  }
+
+#define DEFINE_LOAD(name, t1, t2, t3, force_read)                      \
+  static inline t3 name##_unchecked(wasm_rt_memory_t* mem, u64 addr) { \
+    t1 result;                                                         \
+    wasm_rt_memcpy(&result, MEM_ADDR_MEMOP(mem, addr, sizeof(t1)),     \
+                   sizeof(t1));                                        \
+    force_read(result);                                                \
+    return (t3)(t2)result;                                             \
+  }                                                                    \
+  DEF_MEM_CHECKS0(name, _, t1, return, t3)
+
 #define DEFINE_STORE(name, t1, t2)                                     \
-  static inline void name(wasm_rt_memory_t* mem, u64 addr, t2 value) { \
-    MEMCHECK(mem, addr, t1);                                           \
+  static inline void name##_unchecked(wasm_rt_memory_t* mem, u64 addr, \
+                                      t2 value) {                      \
     t1 wrapped = (t1)value;                                            \
     wasm_rt_memcpy(MEM_ADDR_MEMOP(mem, addr, sizeof(t1)), &wrapped,    \
                    sizeof(t1));                                        \
-  }
+  }                                                                    \
+  DEF_MEM_CHECKS1(name, _, t1, , void, t2)
 
 DEFINE_LOAD(i32_load, u32, u32, u32, FORCE_READ_INT)
 DEFINE_LOAD(i64_load, u64, u64, u64, FORCE_READ_INT)

--- a/wasm2c/wasm-rt-mem-impl-helper.inc
+++ b/wasm2c/wasm-rt-mem-impl-helper.inc
@@ -74,23 +74,25 @@ void MEMORY_API_NAME(wasm_rt_allocate_memory)(MEMORY_TYPE* memory,
   memory->is64 = is64;
   MEMORY_LOCK_VAR_INIT(memory->mem_lock);
 
-#if WASM_RT_USE_MMAP
-  const uint64_t mmap_size =
-      get_alloc_size_for_mmap(memory->max_pages, memory->is64);
-  void* addr = os_mmap(mmap_size);
-  if (!addr) {
-    os_print_last_error("os_mmap failed.");
-    abort();
-  }
-  int ret = os_mprotect(addr, byte_length);
-  if (ret != 0) {
-    os_print_last_error("os_mprotect failed.");
-    abort();
-  }
-  memory->data = addr;
-#else
-  memory->data = calloc(byte_length, 1);
+  if (WASM_RT_USE_MMAP && !is64) {
+#if WASM_RT_USE_MMAP  // mmap-related functions don't exist unless this is set
+    const uint64_t mmap_size =
+        get_alloc_size_for_mmap(memory->max_pages, memory->is64);
+    void* addr = os_mmap(mmap_size);
+    if (!addr) {
+      os_print_last_error("os_mmap failed.");
+      abort();
+    }
+    int ret = os_mprotect(addr, byte_length);
+    if (ret != 0) {
+      os_print_last_error("os_mprotect failed.");
+      abort();
+    }
+    memory->data = addr;
 #endif
+  } else {
+    memory->data = calloc(byte_length, 1);
+  }
 }
 
 static uint64_t MEMORY_API_NAME(grow_memory_impl)(MEMORY_TYPE* memory,
@@ -106,21 +108,24 @@ static uint64_t MEMORY_API_NAME(grow_memory_impl)(MEMORY_TYPE* memory,
   uint64_t old_size = old_pages * WASM_PAGE_SIZE;
   uint64_t new_size = new_pages * WASM_PAGE_SIZE;
   uint64_t delta_size = delta * WASM_PAGE_SIZE;
+  MEMORY_CELL_TYPE new_data;
+  if (WASM_RT_USE_MMAP && !memory->is64) {
 #if WASM_RT_USE_MMAP
-  MEMORY_CELL_TYPE new_data = memory->data;
-  int ret = os_mprotect((void*)(new_data + old_size), delta_size);
-  if (ret != 0) {
-    return (uint64_t)-1;
-  }
-#else
-  MEMORY_CELL_TYPE new_data = realloc((void*)memory->data, new_size);
-  if (new_data == NULL) {
-    return (uint64_t)-1;
-  }
+    new_data = memory->data;
+    int ret = os_mprotect((void*)(new_data + old_size), delta_size);
+    if (ret != 0) {
+      return (uint64_t)-1;
+    }
+#endif
+  } else {
+    new_data = realloc((void*)memory->data, new_size);
+    if (new_data == NULL) {
+      return (uint64_t)-1;
+    }
 #if !WABT_BIG_ENDIAN
-  memset((void*)(new_data + old_size), 0, delta_size);
+    memset((void*)(new_data + old_size), 0, delta_size);
 #endif
-#endif
+  }
 #if WABT_BIG_ENDIAN
   memmove((void*)(new_data + new_size - old_size), (void*)new_data, old_size);
   memset((void*)new_data, 0, delta_size);
@@ -145,13 +150,15 @@ uint64_t MEMORY_API_NAME(wasm_rt_grow_memory)(MEMORY_TYPE* memory,
 }
 
 void MEMORY_API_NAME(wasm_rt_free_memory)(MEMORY_TYPE* memory) {
+  if (WASM_RT_USE_MMAP && !memory->is64) {
 #if WASM_RT_USE_MMAP
-  const uint64_t mmap_size =
-      get_alloc_size_for_mmap(memory->max_pages, memory->is64);
-  os_munmap((void*)memory->data, mmap_size);  // ignore error
-#else
-  free((void*)memory->data);
+    const uint64_t mmap_size =
+        get_alloc_size_for_mmap(memory->max_pages, memory->is64);
+    os_munmap((void*)memory->data, mmap_size);  // ignore error
 #endif
+  } else {
+    free((void*)memory->data);
+  }
 }
 
 #undef MEMORY_LOCK_RELEASE

--- a/wasm2c/wasm-rt.h
+++ b/wasm2c/wasm-rt.h
@@ -129,7 +129,7 @@ extern "C" {
  * needed (so we can use the guard based range checks below).
  */
 #ifndef WASM_RT_USE_MMAP
-#if UINTPTR_MAX > 0xffffffff && !SUPPORT_MEMORY64
+#if UINTPTR_MAX > 0xffffffff
 #define WASM_RT_USE_MMAP 1
 #else
 #define WASM_RT_USE_MMAP 0
@@ -151,8 +151,7 @@ extern "C" {
  */
 
 /** Check if Guard checks are supported */
-#if UINTPTR_MAX > 0xffffffff && WASM_RT_USE_MMAP && !SUPPORT_MEMORY64 && \
-    !WABT_BIG_ENDIAN
+#if UINTPTR_MAX > 0xffffffff && WASM_RT_USE_MMAP && !WABT_BIG_ENDIAN
 #define WASM_RT_GUARD_PAGES_SUPPORTED 1
 #else
 #define WASM_RT_GUARD_PAGES_SUPPORTED 0


### PR DESCRIPTION
The PR updates the bulk memory operations (memory.fill, memory.copy, table.fill, etc.) to support 64-bit addresses and counts, and standardizes on a 64-bit version of RANGE_CHECK everywhere.

Previously we were only taking u32's for these arguments, even with memory64 enabled. (I don't think the memory64 tests check the ability to use memory.copy or the other operations beyond the first 4 GiB of a memory -- I wonder if there would be a way to add this as an "intensive" test if people don't mind having to allocate >4 GiB to run the test.)

This is a stepping-stone to being able to mix software-bounds-checked i64 memories and "guard-page-checked" i32 memories in the same module (#2507) and supporting custom-page-sizes (#2508).