### PR TITLE
wast-parser.cc: Fix a crash from failing (module quote ...)

### DIFF
--- a/src/wast-parser.cc
+++ b/src/wast-parser.cc
@@ -3481,7 +3481,7 @@ Result WastParser::ParseModuleCommand(Script* script, CommandPtr* out_command) {
       std::unique_ptr<Module> m;
       std::unique_ptr<WastLexer> lexer = WastLexer::CreateBufferLexer(
           filename, qsm->data.data(), qsm->data.size(), &errors);
-      ParseWatModule(lexer.get(), &m, &errors, options_);
+      auto result = ParseWatModule(lexer.get(), &m, &errors, options_);
       for (const auto& error : errors) {
         if (error.loc.offset == kInvalidOffset) {
           Error(qsm->loc, "error in quoted module: %s", error.message.c_str());
@@ -3490,7 +3490,9 @@ Result WastParser::ParseModuleCommand(Script* script, CommandPtr* out_command) {
                 error.loc.offset, error.message.c_str());
         }
       }
-      *module = std::move(*m.get());
+      if (Succeeded(result)) {
+        *module = std::move(*m.get());
+      }
       *out_command = std::move(command);
       break;
   }

--- a/test/regress/regress-quote.txt
+++ b/test/regress/regress-quote.txt
@@ -1,0 +1,8 @@
+;;; TOOL: wast2json
+;;; ERROR: 1
+(module quote "invalid")
+(;; STDERR ;;;
+out/test/regress/regress-quote.txt:3:2: error: error in quoted module: @0x100000001: unexpected token "invalid", expected a module field or a module.
+(module quote "invalid")
+ ^^^^^^
+;;; STDERR ;;)

--- a/test/regress/regress-quote.txt
+++ b/test/regress/regress-quote.txt
@@ -1,8 +1,0 @@
-;;; TOOL: wast2json
-;;; ERROR: 1
-(module quote "invalid")
-(;; STDERR ;;;
-out/test/regress/regress-quote.txt:3:2: error: error in quoted module: @0x100000001: unexpected token "invalid", expected a module field or a module.
-(module quote "invalid")
- ^^^^^^
-;;; STDERR ;;)

--- a/test/wast2json/test-invalid-quoted-modules.txt
+++ b/test/wast2json/test-invalid-quoted-modules.txt
@@ -1,0 +1,8 @@
+;;; TOOL: wast2json
+;;; ERROR: 1
+(module quote "invalid")
+(;; STDERR ;;;
+out/test/wast2json/test-invalid-quoted-modules.txt:3:2: error: error in quoted module: @0x100000001: unexpected token "invalid", expected a module field or a module.
+(module quote "invalid")
+ ^^^^^^
+;;; STDERR ;;)


### PR DESCRIPTION
`ParseWatModule` leaves the module as a nullptr on failure. The attached test could cause a segfault in `wast2json` before this PR.