### PR TITLE
CI: Use latest macOS images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-12, macos-14, windows-latest]
+        os: [ubuntu-latest, macos-13, macos-latest, windows-latest]
     steps:
     - uses: actions/setup-python@v5
       with:
@@ -43,7 +43,7 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
     - name: install ninja (osx)
       run: brew install ninja
-      if: matrix.os == 'macos-12' || matrix.os == 'macos-14'
+      if: matrix.os == 'macos-13' || matrix.os == 'macos-latest'
     - name: install ninja (win)
       run: choco install ninja
       if: matrix.os == 'windows-latest'


### PR DESCRIPTION
macos-12 is no longer available, this changes it to macos-13 (latest available x64 macos)

macos-14 is changed to macos-latest (arm64)