### PR TITLE
optimize in for low memory device

### DIFF
--- a/include/wabt/binary-reader-logging.h
+++ b/include/wabt/binary-reader-logging.h
@@ -188,6 +188,7 @@ class BinaryReaderLogging : public BinaryReaderDelegate {
   Result OnDropExpr() override;
   Result OnElseExpr() override;
   Result OnEndExpr() override;
+  Result OnSkipFunctionBodyExpr(std::vector<uint8_t>& opcode_buffer) override;
   Result OnF32ConstExpr(uint32_t value_bits) override;
   Result OnF64ConstExpr(uint64_t value_bits) override;
   Result OnV128ConstExpr(v128 value_bits) override;

--- a/include/wabt/binary-reader-nop.h
+++ b/include/wabt/binary-reader-nop.h
@@ -259,7 +259,9 @@ class BinaryReaderNop : public BinaryReaderDelegate {
   Result OnDropExpr() override { return Result::Ok; }
   Result OnElseExpr() override { return Result::Ok; }
   Result OnEndExpr() override { return Result::Ok; }
-  Result OnSkipFunctionBodyExpr(std::vector<uint8_t>& opcode_buffer) override { return Result::Ok; }
+  Result OnSkipFunctionBodyExpr(std::vector<uint8_t>& opcode_buffer) override {
+    return Result::Ok;
+  }
   Result OnF32ConstExpr(uint32_t value_bits) override { return Result::Ok; }
   Result OnF64ConstExpr(uint64_t value_bits) override { return Result::Ok; }
   Result OnV128ConstExpr(v128 value_bits) override { return Result::Ok; }

--- a/include/wabt/binary-reader-nop.h
+++ b/include/wabt/binary-reader-nop.h
@@ -259,6 +259,7 @@ class BinaryReaderNop : public BinaryReaderDelegate {
   Result OnDropExpr() override { return Result::Ok; }
   Result OnElseExpr() override { return Result::Ok; }
   Result OnEndExpr() override { return Result::Ok; }
+  Result OnSkipFunctionBodyExpr(std::vector<uint8_t>& opcode_buffer) override { return Result::Ok; }
   Result OnF32ConstExpr(uint32_t value_bits) override { return Result::Ok; }
   Result OnF64ConstExpr(uint64_t value_bits) override { return Result::Ok; }
   Result OnV128ConstExpr(v128 value_bits) override { return Result::Ok; }

--- a/include/wabt/binary-reader.h
+++ b/include/wabt/binary-reader.h
@@ -264,6 +264,7 @@ class BinaryReaderDelegate {
   virtual Result OnDropExpr() = 0;
   virtual Result OnElseExpr() = 0;
   virtual Result OnEndExpr() = 0;
+  virtual Result OnSkipFunctionBodyExpr(std::vector<uint8_t>& opcode_buffer) = 0;
   virtual Result OnF32ConstExpr(uint32_t value_bits) = 0;
   virtual Result OnF64ConstExpr(uint64_t value_bits) = 0;
   virtual Result OnV128ConstExpr(v128 value_bits) = 0;

--- a/include/wabt/binary-reader.h
+++ b/include/wabt/binary-reader.h
@@ -264,7 +264,8 @@ class BinaryReaderDelegate {
   virtual Result OnDropExpr() = 0;
   virtual Result OnElseExpr() = 0;
   virtual Result OnEndExpr() = 0;
-  virtual Result OnSkipFunctionBodyExpr(std::vector<uint8_t>& opcode_buffer) = 0;
+  virtual Result OnSkipFunctionBodyExpr(
+      std::vector<uint8_t>& opcode_buffer) = 0;
   virtual Result OnF32ConstExpr(uint32_t value_bits) = 0;
   virtual Result OnF64ConstExpr(uint64_t value_bits) = 0;
   virtual Result OnV128ConstExpr(v128 value_bits) = 0;

--- a/include/wabt/expr-visitor.h
+++ b/include/wabt/expr-visitor.h
@@ -43,6 +43,7 @@ class ExprVisitor {
     Try,
     TryTable,
     Catch,
+    OpcodeRaw
   };
 
   Result HandleDefaultState(Expr*);
@@ -141,6 +142,7 @@ class ExprVisitor::Delegate {
   virtual Result OnSimdShuffleOpExpr(SimdShuffleOpExpr*) = 0;
   virtual Result OnLoadSplatExpr(LoadSplatExpr*) = 0;
   virtual Result OnLoadZeroExpr(LoadZeroExpr*) = 0;
+  virtual Result OnOpcodeRawExpr(OpcodeRawExpr*) = 0;
 };
 
 class ExprVisitor::DelegateNop : public ExprVisitor::Delegate {
@@ -222,6 +224,8 @@ class ExprVisitor::DelegateNop : public ExprVisitor::Delegate {
   Result OnSimdShuffleOpExpr(SimdShuffleOpExpr*) override { return Result::Ok; }
   Result OnLoadSplatExpr(LoadSplatExpr*) override { return Result::Ok; }
   Result OnLoadZeroExpr(LoadZeroExpr*) override { return Result::Ok; }
+  Result OnOpcodeRawExpr(OpcodeRawExpr*) override { return Result::Ok; }
+
 };
 
 }  // namespace wabt

--- a/include/wabt/expr-visitor.h
+++ b/include/wabt/expr-visitor.h
@@ -225,7 +225,6 @@ class ExprVisitor::DelegateNop : public ExprVisitor::Delegate {
   Result OnLoadSplatExpr(LoadSplatExpr*) override { return Result::Ok; }
   Result OnLoadZeroExpr(LoadZeroExpr*) override { return Result::Ok; }
   Result OnOpcodeRawExpr(OpcodeRawExpr*) override { return Result::Ok; }
-
 };
 
 }  // namespace wabt

--- a/include/wabt/ir.h
+++ b/include/wabt/ir.h
@@ -430,7 +430,7 @@ enum class ExprType {
 
   First = AtomicLoad,
   Last = Unreachable,
-  OpCodeRaw = Last + 1, // virual type
+  OpCodeRaw = Last + 1,  // virual type
 };
 
 const char* GetExprTypeName(ExprType type);
@@ -842,9 +842,13 @@ class AtomicFenceExpr : public ExprMixin<ExprType::AtomicFence> {
 
 class OpcodeRawExpr : public ExprMixin<ExprType::OpCodeRaw> {
  public:
-  explicit OpcodeRawExpr(std::vector<uint8_t>&& in_opcode_buffer, FuncSignature& in_func_sig, const Location& loc = Location())
-  : ExprMixin<ExprType::OpCodeRaw>(loc), opcode_buffer(std::move(in_opcode_buffer)), is_extracted(false), func_sig(&in_func_sig) {
-  }
+  explicit OpcodeRawExpr(std::vector<uint8_t>&& in_opcode_buffer,
+                         FuncSignature& in_func_sig,
+                         const Location& loc = Location())
+      : ExprMixin<ExprType::OpCodeRaw>(loc),
+        opcode_buffer(std::move(in_opcode_buffer)),
+        is_extracted(false),
+        func_sig(&in_func_sig) {}
 
   std::vector<uint8_t> opcode_buffer;
   bool is_extracted;

--- a/include/wabt/ir.h
+++ b/include/wabt/ir.h
@@ -429,7 +429,8 @@ enum class ExprType {
   Unreachable,
 
   First = AtomicLoad,
-  Last = Unreachable
+  Last = Unreachable,
+  OpCodeRaw = Last + 1, // virual type
 };
 
 const char* GetExprTypeName(ExprType type);
@@ -837,6 +838,18 @@ class AtomicFenceExpr : public ExprMixin<ExprType::AtomicFence> {
         consistency_model(consistency_model) {}
 
   uint32_t consistency_model;
+};
+
+class OpcodeRawExpr : public ExprMixin<ExprType::OpCodeRaw> {
+ public:
+  explicit OpcodeRawExpr(std::vector<uint8_t>&& in_opcode_buffer, FuncSignature& in_func_sig, const Location& loc = Location())
+  : ExprMixin<ExprType::OpCodeRaw>(loc), opcode_buffer(std::move(in_opcode_buffer)), is_extracted(false), func_sig(&in_func_sig) {
+  }
+
+  std::vector<uint8_t> opcode_buffer;
+  bool is_extracted;
+  ExprList extracted_exprs;
+  const FuncSignature* func_sig;
 };
 
 struct Tag {

--- a/include/wabt/stream.h
+++ b/include/wabt/stream.h
@@ -196,26 +196,23 @@ class MemoryStream : public Stream {
 };
 
 class MemoryAllocStream : public wabt::Stream {
-  public:
-  typedef void* (*wabt_realloc)(void * __ptr, size_t __size);
+ public:
+  typedef void* (*wabt_realloc)(void* __ptr, size_t __size);
 
-
-  MemoryAllocStream(uint8_t* _output_data = nullptr, size_t _total_size = 0, wabt_realloc _realloc_fn = nullptr)
-  : output_data(_output_data), total_size(_total_size), used_size(0) {
-        if (_realloc_fn) {
-            realloc_fn = _realloc_fn;
-        } else {
-            realloc_fn = std::realloc;
-        }
+  MemoryAllocStream(uint8_t* _output_data = nullptr,
+                    size_t _total_size = 0,
+                    wabt_realloc _realloc_fn = nullptr)
+      : output_data(_output_data), total_size(_total_size), used_size(0) {
+    if (_realloc_fn) {
+      realloc_fn = _realloc_fn;
+    } else {
+      realloc_fn = std::realloc;
+    }
   }
 
-  wabt::Result WriteDataImpl(size_t dst_offset,
-                              const void* src,
-                              size_t size);
+  wabt::Result WriteDataImpl(size_t dst_offset, const void* src, size_t size);
 
-  wabt::Result MoveDataImpl(size_t dst_offset,
-                              size_t src_offset,
-                              size_t size);
+  wabt::Result MoveDataImpl(size_t dst_offset, size_t src_offset, size_t size);
 
   wabt::Result TruncateImpl(size_t size);
   inline size_t GetSize() const { return used_size; }
@@ -225,7 +222,7 @@ class MemoryAllocStream : public wabt::Stream {
   uint8_t* output_data;
   size_t total_size;
   size_t used_size;
-  wabt_realloc realloc_fn;      
+  wabt_realloc realloc_fn;
 };
 
 class FileStream : public Stream {

--- a/include/wabt/stream.h
+++ b/include/wabt/stream.h
@@ -195,6 +195,39 @@ class MemoryStream : public Stream {
   std::unique_ptr<OutputBuffer> buf_;
 };
 
+class MemoryAllocStream : public wabt::Stream {
+  public:
+  typedef void* (*wabt_realloc)(void * __ptr, size_t __size);
+
+
+  MemoryAllocStream(uint8_t* _output_data = nullptr, size_t _total_size = 0, wabt_realloc _realloc_fn = nullptr)
+  : output_data(_output_data), total_size(_total_size), used_size(0) {
+        if (_realloc_fn) {
+            realloc_fn = _realloc_fn;
+        } else {
+            realloc_fn = std::realloc;
+        }
+  }
+
+  wabt::Result WriteDataImpl(size_t dst_offset,
+                              const void* src,
+                              size_t size);
+
+  wabt::Result MoveDataImpl(size_t dst_offset,
+                              size_t src_offset,
+                              size_t size);
+
+  wabt::Result TruncateImpl(size_t size);
+  inline size_t GetSize() const { return used_size; }
+  inline uint8_t* GetData() { return output_data; }
+
+ private:
+  uint8_t* output_data;
+  size_t total_size;
+  size_t used_size;
+  wabt_realloc realloc_fn;      
+};
+
 class FileStream : public Stream {
  public:
   WABT_DISALLOW_COPY_AND_ASSIGN(FileStream);

--- a/src/binary-reader-ir.cc
+++ b/src/binary-reader-ir.cc
@@ -33,16 +33,17 @@ namespace wabt {
 
 #ifdef WABT_OVERRIDE_ALLOC_EXPR
 template <class _Tp, class... _Args>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 typename std::__unique_if<_Tp>::__unique_single
-wabt_expr_make_unique(_Args&&... __args) {
-    // static_assert(sizeof(_Tp) <= 128);
-    return std::unique_ptr<_Tp>(new ((wabt::Module*)(nullptr))_Tp(std::forward<_Args>(__args)...));
+inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23
+    typename std::__unique_if<_Tp>::__unique_single
+    wabt_expr_make_unique(_Args&&... __args) {
+  // static_assert(sizeof(_Tp) <= 128);
+  return std::unique_ptr<_Tp>(new ((wabt::Module*)(nullptr))
+                                  _Tp(std::forward<_Args>(__args)...));
 }
 extern void* operator new(size_t size, wabt::Module* m);
 #else
 #define wabt_expr_make_unique std::make_unique
 #endif
-
 
 namespace {
 
@@ -924,7 +925,8 @@ Result BinaryReaderIR::OnBrTableExpr(Index num_targets,
 }
 
 Result BinaryReaderIR::OnCallExpr(Index func_index) {
-  return AppendExpr(wabt_expr_make_unique<CallExpr>(Var(func_index, GetLocation())));
+  return AppendExpr(
+      wabt_expr_make_unique<CallExpr>(Var(func_index, GetLocation())));
 }
 
 Result BinaryReaderIR::OnCallIndirectExpr(Index sig_index, Index table_index) {
@@ -1030,12 +1032,15 @@ Result BinaryReaderIR::OnEndExpr() {
   return PopLabel();
 }
 
-Result BinaryReaderIR::OnSkipFunctionBodyExpr(std::vector<uint8_t>& opcode_buffer) {
-  Result result_append = AppendExpr(
-      wabt_expr_make_unique<OpcodeRawExpr>(std::move(opcode_buffer), current_func_->decl.sig, GetLocation()));
+Result BinaryReaderIR::OnSkipFunctionBodyExpr(
+    std::vector<uint8_t>& opcode_buffer) {
+  Result result_append = AppendExpr(wabt_expr_make_unique<OpcodeRawExpr>(
+      std::move(opcode_buffer), current_func_->decl.sig, GetLocation()));
   Result result_pop = PopLabel();
 
-  return (result_append == Result::Ok && result_pop == Result::Ok) ? Result::Ok : Result::Error;
+  return (result_append == Result::Ok && result_pop == Result::Ok)
+             ? Result::Ok
+             : Result::Error;
 }
 
 Result BinaryReaderIR::OnF32ConstExpr(uint32_t value_bits) {
@@ -1124,7 +1129,7 @@ Result BinaryReaderIR::OnMemoryInitExpr(Index segment, Index memidx) {
 
 Result BinaryReaderIR::OnMemorySizeExpr(Index memidx) {
   return AppendExpr(
-     wabt_expr_make_unique<MemorySizeExpr>(Var(memidx, GetLocation())));
+      wabt_expr_make_unique<MemorySizeExpr>(Var(memidx, GetLocation())));
 }
 
 Result BinaryReaderIR::OnTableCopyExpr(Index dst_index, Index src_index) {
@@ -1187,7 +1192,8 @@ Result BinaryReaderIR::OnNopExpr() {
 }
 
 Result BinaryReaderIR::OnRethrowExpr(Index depth) {
-  return AppendExpr(wabt_expr_make_unique<RethrowExpr>(Var(depth, GetLocation())));
+  return AppendExpr(
+      wabt_expr_make_unique<RethrowExpr>(Var(depth, GetLocation())));
 }
 
 Result BinaryReaderIR::OnReturnExpr() {
@@ -1220,7 +1226,8 @@ Result BinaryReaderIR::OnStoreExpr(Opcode opcode,
 
 Result BinaryReaderIR::OnThrowExpr(Index tag_index) {
   module_->features_used.exceptions = true;
-  return AppendExpr(wabt_expr_make_unique<ThrowExpr>(Var(tag_index, GetLocation())));
+  return AppendExpr(
+      wabt_expr_make_unique<ThrowExpr>(Var(tag_index, GetLocation())));
 }
 
 Result BinaryReaderIR::OnThrowRefExpr() {
@@ -1735,7 +1742,7 @@ Result BinaryReaderIR::OnCodeMetadata(Offset offset,
   std::vector<uint8_t> data_(static_cast<const uint8_t*>(data),
                              static_cast<const uint8_t*>(data) + size);
   auto meta = wabt_expr_make_unique<CodeMetadataExpr>(current_metadata_name_,
-                                                 std::move(data_));
+                                                      std::move(data_));
   meta->loc.offset = offset;
   code_metadata_queue_.push_metadata(std::move(meta));
   return Result::Ok;

--- a/src/binary-reader-logging.cc
+++ b/src/binary-reader-logging.cc
@@ -781,6 +781,12 @@ Result BinaryReaderLogging::OnGenericCustomSection(std::string_view name,
     return reader_->name(opcode, memidx, alignment_log2, offset, value);     \
   }
 
+#define DEFINE_SKIP(name)                                                    \
+  Result BinaryReaderLogging::name(std::vector<uint8_t>& opcode_buffer) { \
+    LOGF(#name " length: %lu""\n", opcode_buffer.size());                     \
+    return reader_->name(opcode_buffer);                                     \
+  }
+
 #define DEFINE0(name)                  \
   Result BinaryReaderLogging::name() { \
     LOGF(#name "\n");                  \
@@ -851,6 +857,8 @@ DEFINE_INDEX_DESC(OnDelegateExpr, "depth");
 DEFINE0(OnDropExpr)
 DEFINE0(OnElseExpr)
 DEFINE0(OnEndExpr)
+DEFINE_SKIP(OnSkipFunctionBodyExpr)
+
 DEFINE_INDEX_DESC(OnGlobalGetExpr, "index")
 DEFINE_INDEX_DESC(OnGlobalSetExpr, "index")
 DEFINE_LOAD_STORE_OPCODE(OnLoadExpr);

--- a/src/binary-reader-logging.cc
+++ b/src/binary-reader-logging.cc
@@ -781,10 +781,13 @@ Result BinaryReaderLogging::OnGenericCustomSection(std::string_view name,
     return reader_->name(opcode, memidx, alignment_log2, offset, value);     \
   }
 
-#define DEFINE_SKIP(name)                                                    \
+#define DEFINE_SKIP(name)                                                 \
   Result BinaryReaderLogging::name(std::vector<uint8_t>& opcode_buffer) { \
-    LOGF(#name " length: %lu""\n", opcode_buffer.size());                     \
-    return reader_->name(opcode_buffer);                                     \
+    LOGF(#name                                                            \
+         " length: %lu"                                                   \
+         "\n",                                                            \
+         opcode_buffer.size());                                           \
+    return reader_->name(opcode_buffer);                                  \
   }
 
 #define DEFINE0(name)                  \

--- a/src/binary-writer.cc
+++ b/src/binary-writer.cc
@@ -1151,17 +1151,16 @@ void BinaryWriter::WriteExpr(const Func* func, const Expr* expr) {
       break;
     }
     case ExprType::OpCodeRaw: {
-        auto* opcode_raw_expr = cast<OpcodeRawExpr>(expr);
-        if (opcode_raw_expr->is_extracted) {
-          WriteExprList(func, opcode_raw_expr->extracted_exprs);
-        } else {
-          auto& opcode_buffer = opcode_raw_expr->opcode_buffer;
-          // Opcode::End 0x0b
-          assert(opcode_buffer[opcode_buffer.size() - 1] == 0x0b);
-          stream_->WriteData(opcode_buffer.data(), opcode_buffer.size() - 1);
-        }
+      auto* opcode_raw_expr = cast<OpcodeRawExpr>(expr);
+      if (opcode_raw_expr->is_extracted) {
+        WriteExprList(func, opcode_raw_expr->extracted_exprs);
+      } else {
+        auto& opcode_buffer = opcode_raw_expr->opcode_buffer;
+        // Opcode::End 0x0b
+        assert(opcode_buffer[opcode_buffer.size() - 1] == 0x0b);
+        stream_->WriteData(opcode_buffer.data(), opcode_buffer.size() - 1);
+      }
     }
-
   }
 }
 

--- a/src/binary-writer.cc
+++ b/src/binary-writer.cc
@@ -1150,6 +1150,18 @@ void BinaryWriter::WriteExpr(const Func* func, const Expr* expr) {
       a.entries.emplace_back(code_offset, meta_expr->data);
       break;
     }
+    case ExprType::OpCodeRaw: {
+        auto* opcode_raw_expr = cast<OpcodeRawExpr>(expr);
+        if (opcode_raw_expr->is_extracted) {
+          WriteExprList(func, opcode_raw_expr->extracted_exprs);
+        } else {
+          auto& opcode_buffer = opcode_raw_expr->opcode_buffer;
+          // Opcode::End 0x0b
+          assert(opcode_buffer[opcode_buffer.size() - 1] == 0x0b);
+          stream_->WriteData(opcode_buffer.data(), opcode_buffer.size() - 1);
+        }
+    }
+
   }
 }
 

--- a/src/c-writer.cc
+++ b/src/c-writer.cc
@@ -4267,6 +4267,8 @@ void CWriter::Write(const ExprList& exprs) {
       case ExprType::AtomicWait:
       case ExprType::AtomicNotify:
       case ExprType::CallRef:
+      case ExprType::OpCodeRaw:
+
         UNIMPLEMENTED("...");
         break;
     }

--- a/src/expr-visitor.cc
+++ b/src/expr-visitor.cc
@@ -151,7 +151,8 @@ Result ExprVisitor::VisitExpr(Expr* root_expr) {
       }
       case State::OpcodeRaw: {
         auto opcode_raw_expr = cast<OpcodeRawExpr>(expr);
-        // ERROR_UNLESS(opcode_raw_expr->is_extracted, "opcode_raw could not compile when in visiting")
+        // ERROR_UNLESS(opcode_raw_expr->is_extracted, "opcode_raw could not
+        // compile when in visiting")
         if (opcode_raw_expr->is_extracted) {
           auto& iter = expr_iter_stack_.back();
           if (iter != opcode_raw_expr->extracted_exprs.end()) {
@@ -160,7 +161,7 @@ Result ExprVisitor::VisitExpr(Expr* root_expr) {
             PopExprlist();
           }
         }
-        
+
         break;
       }
     }

--- a/src/interp/binary-reader-interp.cc
+++ b/src/interp/binary-reader-interp.cc
@@ -1089,7 +1089,8 @@ Result BinaryReaderInterp::OnEndExpr() {
   return Result::Ok;
 }
 
-Result BinaryReaderInterp::OnSkipFunctionBodyExpr(std::vector<uint8_t>& opcode_buffer) {
+Result BinaryReaderInterp::OnSkipFunctionBodyExpr(
+    std::vector<uint8_t>& opcode_buffer) {
   PopLabel();
   return Result::Ok;
 }

--- a/src/interp/binary-reader-interp.cc
+++ b/src/interp/binary-reader-interp.cc
@@ -197,6 +197,7 @@ class BinaryReaderInterp : public BinaryReaderNop {
   Result OnDropExpr() override;
   Result OnElseExpr() override;
   Result OnEndExpr() override;
+  Result OnSkipFunctionBodyExpr(std::vector<uint8_t>& opcode_buffer) override;
   Result OnF32ConstExpr(uint32_t value_bits) override;
   Result OnF64ConstExpr(uint64_t value_bits) override;
   Result OnV128ConstExpr(v128 value_bits) override;
@@ -1084,6 +1085,11 @@ Result BinaryReaderInterp::OnEndExpr() {
     istream_.EmitCatchDrop(1);
   }
   FixupTopLabel();
+  PopLabel();
+  return Result::Ok;
+}
+
+Result BinaryReaderInterp::OnSkipFunctionBodyExpr(std::vector<uint8_t>& opcode_buffer) {
   PopLabel();
   return Result::Ok;
 }

--- a/src/ir-util.cc
+++ b/src/ir-util.cc
@@ -273,7 +273,7 @@ ModuleContext::Arities ModuleContext::GetExprArity(const Expr& expr) const {
     case ExprType::SimdShuffleOp:
       return {2, 1};
     case ExprType::OpCodeRaw:
-      return {0, cast<OpcodeRawExpr>(&expr)->func_sig->GetNumResults()};    
+      return {0, cast<OpcodeRawExpr>(&expr)->func_sig->GetNumResults()};
   }
 
   WABT_UNREACHABLE;

--- a/src/ir-util.cc
+++ b/src/ir-util.cc
@@ -272,6 +272,8 @@ ModuleContext::Arities ModuleContext::GetExprArity(const Expr& expr) const {
 
     case ExprType::SimdShuffleOp:
       return {2, 1};
+    case ExprType::OpCodeRaw:
+      return {0, cast<OpcodeRawExpr>(&expr)->func_sig->GetNumResults()};    
   }
 
   WABT_UNREACHABLE;

--- a/src/stream.cc
+++ b/src/stream.cc
@@ -229,72 +229,69 @@ Result MemoryStream::TruncateImpl(size_t size) {
   return Result::Ok;
 }
 
-
 Result MemoryAllocStream::WriteDataImpl(size_t dst_offset,
-                            const void* src,
-                            size_t size) {
+                                        const void* src,
+                                        size_t size) {
   if (size == 0) {
-      return wabt::Result::Ok;
+    return wabt::Result::Ok;
   }
   size_t end = dst_offset + size;
   bool needRealloc = false;
   while (end > total_size) {
-      total_size = total_size << 1;
-      needRealloc = true;
+    total_size = total_size << 1;
+    needRealloc = true;
   }
   if (needRealloc) {
-      output_data = static_cast<uint8_t*>(realloc_fn(output_data, total_size));
+    output_data = static_cast<uint8_t*>(realloc_fn(output_data, total_size));
   }
 
   if (end > used_size) {
-      used_size = end;
+    used_size = end;
   }
 
   memcpy(output_data + dst_offset, src, size);
   return wabt::Result::Ok;
-
 }
 
 Result MemoryAllocStream::MoveDataImpl(size_t dst_offset,
-                            size_t src_offset,
-                            size_t size) {
-    if (size == 0) {
-        return wabt::Result::Ok;
-    }
-    size_t src_end = src_offset + size;
-    size_t dst_end = dst_offset + size;
-    size_t end = src_end > dst_end ? src_end : dst_end;
-
-    bool needRealloc = false;
-    while (end > total_size) {
-        total_size = total_size << 1;
-        needRealloc = true;
-    }
-    if (needRealloc) {
-        output_data = static_cast<uint8_t*>(realloc_fn(output_data, total_size));
-    }
-
-      if (end > used_size) {
-        used_size = end;
-    }
-
-    uint8_t* dst = output_data + dst_offset;
-    uint8_t* src = output_data + src_offset;
-    memmove(dst, src, size);
+                                       size_t src_offset,
+                                       size_t size) {
+  if (size == 0) {
     return wabt::Result::Ok;
+  }
+  size_t src_end = src_offset + size;
+  size_t dst_end = dst_offset + size;
+  size_t end = src_end > dst_end ? src_end : dst_end;
 
+  bool needRealloc = false;
+  while (end > total_size) {
+    total_size = total_size << 1;
+    needRealloc = true;
+  }
+  if (needRealloc) {
+    output_data = static_cast<uint8_t*>(realloc_fn(output_data, total_size));
+  }
+
+  if (end > used_size) {
+    used_size = end;
+  }
+
+  uint8_t* dst = output_data + dst_offset;
+  uint8_t* src = output_data + src_offset;
+  memmove(dst, src, size);
+  return wabt::Result::Ok;
 }
 
 Result MemoryAllocStream::TruncateImpl(size_t size) {
-    if (size > used_size) {
-        return wabt::Result::Error;
-    }
-    used_size = size;
+  if (size > used_size) {
+    return wabt::Result::Error;
+  }
+  used_size = size;
 
-    // will not truncate size, we can truncate it at end
-    // output_data = (uint8_t*)realloc_fn(output_data, size);
-    // total_size = size;
-    return wabt::Result::Ok;
+  // will not truncate size, we can truncate it at end
+  // output_data = (uint8_t*)realloc_fn(output_data, size);
+  // total_size = size;
+  return wabt::Result::Ok;
 }
 
 FileStream::FileStream(std::string_view filename, Stream* log_stream)

--- a/src/stream.cc
+++ b/src/stream.cc
@@ -229,6 +229,74 @@ Result MemoryStream::TruncateImpl(size_t size) {
   return Result::Ok;
 }
 
+
+Result MemoryAllocStream::WriteDataImpl(size_t dst_offset,
+                            const void* src,
+                            size_t size) {
+  if (size == 0) {
+      return wabt::Result::Ok;
+  }
+  size_t end = dst_offset + size;
+  bool needRealloc = false;
+  while (end > total_size) {
+      total_size = total_size << 1;
+      needRealloc = true;
+  }
+  if (needRealloc) {
+      output_data = static_cast<uint8_t*>(realloc_fn(output_data, total_size));
+  }
+
+  if (end > used_size) {
+      used_size = end;
+  }
+
+  memcpy(output_data + dst_offset, src, size);
+  return wabt::Result::Ok;
+
+}
+
+Result MemoryAllocStream::MoveDataImpl(size_t dst_offset,
+                            size_t src_offset,
+                            size_t size) {
+    if (size == 0) {
+        return wabt::Result::Ok;
+    }
+    size_t src_end = src_offset + size;
+    size_t dst_end = dst_offset + size;
+    size_t end = src_end > dst_end ? src_end : dst_end;
+
+    bool needRealloc = false;
+    while (end > total_size) {
+        total_size = total_size << 1;
+        needRealloc = true;
+    }
+    if (needRealloc) {
+        output_data = static_cast<uint8_t*>(realloc_fn(output_data, total_size));
+    }
+
+      if (end > used_size) {
+        used_size = end;
+    }
+
+    uint8_t* dst = output_data + dst_offset;
+    uint8_t* src = output_data + src_offset;
+    memmove(dst, src, size);
+    return wabt::Result::Ok;
+
+}
+
+Result MemoryAllocStream::TruncateImpl(size_t size) {
+    if (size > used_size) {
+        return wabt::Result::Error;
+    }
+    used_size = size;
+
+    // will not truncate size, we can truncate it at end
+    // output_data = (uint8_t*)realloc_fn(output_data, size);
+    // total_size = size;
+    return wabt::Result::Ok;
+}
+
 FileStream::FileStream(std::string_view filename, Stream* log_stream)
     : Stream(log_stream), file_(nullptr), offset_(0), should_close_(false) {
   std::string filename_str(filename);

--- a/src/validator.cc
+++ b/src/validator.cc
@@ -694,7 +694,6 @@ Result Validator::OnOpcodeRawExpr(OpcodeRawExpr* expr) {
   return Result::Ok;
 }
 
-
 Validator::Validator(Errors* errors,
                      const Module* module,
                      const ValidateOptions& options)

--- a/src/validator.cc
+++ b/src/validator.cc
@@ -166,6 +166,7 @@ class Validator : public ExprVisitor::Delegate {
   Result OnSimdShuffleOpExpr(SimdShuffleOpExpr*) override;
   Result OnLoadSplatExpr(LoadSplatExpr*) override;
   Result OnLoadZeroExpr(LoadZeroExpr*) override;
+  Result OnOpcodeRawExpr(OpcodeRawExpr* expr) override;
 
  private:
   Type GetDeclarationType(const FuncDeclaration&);
@@ -687,6 +688,12 @@ Result Validator::OnLoadZeroExpr(LoadZeroExpr* expr) {
                                    expr->offset);
   return Result::Ok;
 }
+
+Result Validator::OnOpcodeRawExpr(OpcodeRawExpr* expr) {
+  // data read from original wasm file, so just return OK;
+  return Result::Ok;
+}
+
 
 Validator::Validator(Errors* errors,
                      const Module* module,

--- a/src/wat-writer.cc
+++ b/src/wat-writer.cc
@@ -1162,7 +1162,6 @@ Result WatWriter::ExprVisitorDelegate::OnOpcodeRawExpr(OpcodeRawExpr* expr) {
   return Result::Error;
 }
 
-
 void WatWriter::WriteExpr(const Expr* expr) {
   WABT_TRACE(WriteExprList);
   ExprVisitorDelegate delegate(this);

--- a/src/wat-writer.cc
+++ b/src/wat-writer.cc
@@ -622,6 +622,7 @@ class WatWriter::ExprVisitorDelegate : public ExprVisitor::Delegate {
   Result OnSimdShuffleOpExpr(SimdShuffleOpExpr*) override;
   Result OnLoadSplatExpr(LoadSplatExpr*) override;
   Result OnLoadZeroExpr(LoadZeroExpr*) override;
+  Result OnOpcodeRawExpr(OpcodeRawExpr*) override;
 
  private:
   WatWriter* writer_;
@@ -1155,6 +1156,12 @@ Result WatWriter::ExprVisitorDelegate::OnLoadZeroExpr(LoadZeroExpr* expr) {
   writer_->WriteLoadStoreExpr<LoadZeroExpr>(expr);
   return Result::Ok;
 }
+
+Result WatWriter::ExprVisitorDelegate::OnOpcodeRawExpr(OpcodeRawExpr* expr) {
+  // WatWriter can't run in skip_function_bodies mode
+  return Result::Error;
+}
+
 
 void WatWriter::WriteExpr(const Expr* expr) {
   WABT_TRACE(WriteExprList);


### PR DESCRIPTION
+ add step OnSkipFunctionBodyExpr when read with skip_function_bodies
+ add virtual op code OpCodeRaw, when read with skip_function_bodies, the virtual struct will save byte code in a uint8 array, and will write directly on output
+ add macro wabt_expr_make_unique,  for override operator new
+ add MemoryAllocStream can output byte code in an allocated buffer