### PR TITLE
CI: Update to upload-artifact v4

### DIFF
--- a/.github/actions/release-archive/action.yml
+++ b/.github/actions/release-archive/action.yml
@@ -25,7 +25,7 @@ runs:
         echo "::set-output name=shasum::$SHASUM"
 
     - name: upload tarball to CI
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ steps.archive.outputs.tarball }}
         path: ./${{ steps.archive.outputs.tarball }}

--- a/.github/workflows/wabt-cifuzz.yml
+++ b/.github/workflows/wabt-cifuzz.yml
@@ -15,7 +15,7 @@ jobs:
         oss-fuzz-project-name: 'wabt'
         fuzz-seconds: 300
     - name: Upload Crash
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: failure() && steps.build.outcome == 'success'
       with:
         name: artifacts


### PR DESCRIPTION
Since v3 is no longer usable, this changes it to v4