### PR TITLE
CI: Use safer GITHUB_OUTPUT

### DIFF
--- a/.github/actions/release-archive/action.yml
+++ b/.github/actions/release-archive/action.yml
@@ -21,8 +21,8 @@ runs:
         mv install wabt-$VERSION
         tar -czf $TARBALL wabt-$VERSION
         scripts/sha256sum.py $TARBALL > $SHASUM
-        echo "::set-output name=tarball::$TARBALL"
-        echo "::set-output name=shasum::$SHASUM"
+        echo "tarball=$TARBALL" >> $GITHUB_OUTPUT
+        echo "shasum=$SHASUM" >> $GITHUB_OUTPUT
 
     - name: upload tarball to CI
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
apparently this is a thing https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

tho they did go back on it https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/

but it seems like a good idea to switch anyway