### PR TITLE
Fix lint task

### DIFF
--- a/scripts/clang-format-diff.sh
+++ b/scripts/clang-format-diff.sh
@@ -25,8 +25,7 @@ else
 fi
 
 MERGE_BASE=$(git merge-base $BRANCH HEAD)
-if ! git clang-format $MERGE_BASE -q --diff -- src/ 2>&1 >/dev/null
-then
+if ! git clang-format $MERGE_BASE -q --diff -- src/ 2>&1 >/dev/null; then
   echo "Please run git clang-format before committing, or apply this diff:"
   echo
   # Run git clang-format again, this time with output.  This lets us add

--- a/scripts/clang-format-diff.sh
+++ b/scripts/clang-format-diff.sh
@@ -25,13 +25,12 @@ else
 fi
 
 MERGE_BASE=$(git merge-base $BRANCH HEAD)
-FORMAT_MSG=$(git clang-format $MERGE_BASE -q --diff -- src/ || true)
-if [ -n "$FORMAT_MSG" -a "$FORMAT_MSG" != "no modified files to format" ]
+if ! git clang-format $MERGE_BASE -q --diff -- src/ 2>&1 >/dev/null
 then
   echo "Please run git clang-format before committing, or apply this diff:"
   echo
-  # Run git clang-format again, this time without capruting stdout.  This way
-  # clang-format format the message nicely and add color.
+  # Run git clang-format again, this time with output.  This lets us add
+  # the above message.
   git clang-format $MERGE_BASE -q --diff -- src/
   exit 1
 fi

--- a/scripts/clang-format-diff.sh
+++ b/scripts/clang-format-diff.sh
@@ -25,7 +25,7 @@ else
 fi
 
 MERGE_BASE=$(git merge-base $BRANCH HEAD)
-FORMAT_MSG=$(git clang-format $MERGE_BASE -q --diff -- src/)
+FORMAT_MSG=$(git clang-format $MERGE_BASE -q --diff -- src/ || true)
 if [ -n "$FORMAT_MSG" -a "$FORMAT_MSG" != "no modified files to format" ]
 then
   echo "Please run git clang-format before committing, or apply this diff:"


### PR DESCRIPTION
git clang-format appears to now return an exit status instead of always succeeding, and the change broke the script. this fixes it.