### PR TITLE
Fix wasm2c generating undeclared identifier errors with --num-outputs specified

### DIFF
--- a/src/prebuilt/wasm2c_source_declarations.cc
+++ b/src/prebuilt/wasm2c_source_declarations.cc
@@ -1126,9 +1126,12 @@ R"w2c_template(  LOAD_DATA((*dest), dest_addr, src + src_addr, n);
 R"w2c_template(}
 )w2c_template"
 R"w2c_template(
+typedef enum { RefFunc, RefNull, GlobalGet } expr_type_t;
+)w2c_template"
+R"w2c_template(
 typedef struct {
 )w2c_template"
-R"w2c_template(  enum { RefFunc, RefNull, GlobalGet } expr_type;
+R"w2c_template(  expr_type_t expr_type;
 )w2c_template"
 R"w2c_template(  wasm_rt_func_type_t type;
 )w2c_template"

--- a/src/template/wasm2c.declarations.c
+++ b/src/template/wasm2c.declarations.c
@@ -602,8 +602,10 @@ static inline void memory_init(wasm_rt_memory_t* dest,
   LOAD_DATA((*dest), dest_addr, src + src_addr, n);
 }
 
+typedef enum { RefFunc, RefNull, GlobalGet } expr_type_t;
+
 typedef struct {
-  enum { RefFunc, RefNull, GlobalGet } expr_type;
+  expr_type_t expr_type;
   wasm_rt_func_type_t type;
   wasm_rt_function_ptr_t func;
   wasm_rt_tailcallee_t func_tailcallee;


### PR DESCRIPTION
Without this change, building generated wasm2c headers results in the following errors:

```
crystallize-impl.h:647:12: error: use of undeclared identifier 'RefFunc'
  647 |       case RefFunc:
      |            ^
crystallize-impl.h:652:12: error: use of undeclared identifier 'RefNull'; did you mean 'default'?
  652 |       case RefNull:
      |            ^~~~~~~
      |            default
crystallize-impl.h:652:12: error: expected expression
crystallize-impl.h:655:12: error: use of undeclared identifier 'GlobalGet'
  655 |       case GlobalGet:
      |            ^

```