### PR TITLE
ci: Add ubuntu-24.04-arm regular CI and release artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-13, macos-latest, windows-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-13, macos-latest, windows-latest]
     steps:
     - uses: actions/setup-python@v5
       with:
@@ -40,7 +40,7 @@ jobs:
         submodules: true
     - name: install ninja (linux)
       run: sudo apt-get install ninja-build
-      if: matrix.os == 'ubuntu-latest'
+      if: startsWith(matrix.os, 'ubuntu-')
     - name: install ninja (osx)
       run: brew install ninja
       if: matrix.os == 'macos-13' || matrix.os == 'macos-latest'

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-14, windows-latest]
+        os: [ubuntu-20.04, ubuntu-24.04-arm, macos-14, windows-latest]
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
Fixes #2533 

the arm64 artifact will be called `wabt-$VERSION-ubuntu-24.04-arm.tar.gz` without any changes to the release-archive action.