### PR TITLE
Remove implicit Enum conversion of types

### DIFF
--- a/include/wabt/common.h
+++ b/include/wabt/common.h
@@ -389,7 +389,7 @@ struct Limits {
         has_max(true),
         is_shared(is_shared),
         is_64(is_64) {}
-  Type IndexType() const { return is_64 ? Type::I64 : Type::I32; }
+  Type IndexType() const { return Type(is_64 ? Type::I64 : Type::I32); }
 
   uint64_t initial = 0;
   uint64_t max = 0;

--- a/include/wabt/decompiler-ls.h
+++ b/include/wabt/decompiler-ls.h
@@ -26,7 +26,7 @@ namespace wabt {
 
 // Names starting with "u" are unsigned, the rest are "signed or doesn't matter"
 inline const char* GetDecompTypeName(Type t) {
-  switch (t) {
+  switch (t.code()) {
     case Type::I8: return "byte";
     case Type::I8U: return "ubyte";
     case Type::I16: return "short";
@@ -56,9 +56,9 @@ inline Type GetMemoryType(Type operand_type, Opcode opc) {
     // FIXME: change into a new column in opcode.def instead?
     auto is_unsigned = name.substr(name.size() - 2) == "_u";
     switch (opc.GetMemorySize()) {
-      case 1: return is_unsigned ? Type::I8U : Type::I8;
-      case 2: return is_unsigned ? Type::I16U : Type::I16;
-      case 4: return is_unsigned ? Type::I32U : Type::I32;
+      case 1: return Type(is_unsigned ? Type::I8U : Type::I8);
+      case 2: return Type(is_unsigned ? Type::I16U : Type::I16);
+      case 4: return Type(is_unsigned ? Type::I32U : Type::I32);
     }
   }
   return operand_type;
@@ -70,7 +70,7 @@ inline Type GetMemoryType(Type operand_type, Opcode opc) {
 struct LoadStoreTracking {
   struct LSAccess {
     Address byte_size = 0;
-    Type type = Type::Any;
+    Type type = Type(Type::Any);
     Address align = 0;
     uint32_t idx = 0;
     bool is_uniform = true;
@@ -79,7 +79,7 @@ struct LoadStoreTracking {
   struct LSVar {
     std::map<uint64_t, LSAccess> accesses;
     bool struct_layout = true;
-    Type same_type = Type::Any;
+    Type same_type = Type(Type::Any);
     Address same_align = kInvalidAddress;
     Opcode last_opc;
   };
@@ -155,7 +155,7 @@ struct LoadStoreTracking {
       var.same_align = align;
       var.last_opc = opc;
     } else {
-      var.same_type = Type::Void;
+      var.same_type = Type(Type::Void);
       var.same_align = kInvalidAddress;
     }
   }

--- a/include/wabt/interp/interp-inl.h
+++ b/include/wabt/interp/interp-inl.h
@@ -429,54 +429,54 @@ inline bool TypesMatch(ValueType expected, ValueType actual) {
 }
 
 //// Value ////
-inline Value WABT_VECTORCALL Value::Make(s32 val) { Value res; res.i32_ = val; res.SetType(ValueType::I32); return res; }
-inline Value WABT_VECTORCALL Value::Make(u32 val) { Value res; res.i32_ = val; res.SetType(ValueType::I32); return res; }
-inline Value WABT_VECTORCALL Value::Make(s64 val) { Value res; res.i64_ = val; res.SetType(ValueType::I64); return res; }
-inline Value WABT_VECTORCALL Value::Make(u64 val) { Value res; res.i64_ = val; res.SetType(ValueType::I64); return res; }
-inline Value WABT_VECTORCALL Value::Make(f32 val) { Value res; res.f32_ = val; res.SetType(ValueType::F32); return res; }
-inline Value WABT_VECTORCALL Value::Make(f64 val) { Value res; res.f64_ = val; res.SetType(ValueType::F64); return res; }
-inline Value WABT_VECTORCALL Value::Make(v128 val) { Value res; res.v128_ = val; res.SetType(ValueType::V128); return res; }
-inline Value WABT_VECTORCALL Value::Make(Ref val) { Value res; res.ref_ = val; res.SetType(ValueType::ExternRef); return res; }
+inline Value WABT_VECTORCALL Value::Make(s32 val) { Value res; res.i32_ = val; res.SetType(Type(ValueType::I32)); return res; }
+inline Value WABT_VECTORCALL Value::Make(u32 val) { Value res; res.i32_ = val; res.SetType(Type(ValueType::I32)); return res; }
+inline Value WABT_VECTORCALL Value::Make(s64 val) { Value res; res.i64_ = val; res.SetType(Type(ValueType::I64)); return res; }
+inline Value WABT_VECTORCALL Value::Make(u64 val) { Value res; res.i64_ = val; res.SetType(Type(ValueType::I64)); return res; }
+inline Value WABT_VECTORCALL Value::Make(f32 val) { Value res; res.f32_ = val; res.SetType(Type(ValueType::F32)); return res; }
+inline Value WABT_VECTORCALL Value::Make(f64 val) { Value res; res.f64_ = val; res.SetType(Type(ValueType::F64)); return res; }
+inline Value WABT_VECTORCALL Value::Make(v128 val) { Value res; res.v128_ = val; res.SetType(Type(ValueType::V128)); return res; }
+inline Value WABT_VECTORCALL Value::Make(Ref val) { Value res; res.ref_ = val; res.SetType(Type(ValueType::ExternRef)); return res; }
 template <typename T, u8 L>
 Value WABT_VECTORCALL Value::Make(Simd<T, L> val) {
   Value res;
   res.v128_ = Bitcast<v128>(val);
-  res.SetType(ValueType::V128);
+  res.SetType(Type(ValueType::V128));
   return res;
 }
 
-template <> inline s8 WABT_VECTORCALL Value::Get<s8>() const { CheckType(ValueType::I32); return i32_; }
-template <> inline u8 WABT_VECTORCALL Value::Get<u8>() const { CheckType(ValueType::I32); return i32_; }
-template <> inline s16 WABT_VECTORCALL Value::Get<s16>() const { CheckType(ValueType::I32); return i32_; }
-template <> inline u16 WABT_VECTORCALL Value::Get<u16>() const { CheckType(ValueType::I32); return i32_; }
-template <> inline s32 WABT_VECTORCALL Value::Get<s32>() const { CheckType(ValueType::I32); return i32_; }
-template <> inline u32 WABT_VECTORCALL Value::Get<u32>() const { CheckType(ValueType::I32); return i32_; }
-template <> inline s64 WABT_VECTORCALL Value::Get<s64>() const { CheckType(ValueType::I64); return i64_; }
-template <> inline u64 WABT_VECTORCALL Value::Get<u64>() const { CheckType(ValueType::I64); return i64_; }
-template <> inline f32 WABT_VECTORCALL Value::Get<f32>() const { CheckType(ValueType::F32); return f32_; }
-template <> inline f64 WABT_VECTORCALL Value::Get<f64>() const { CheckType(ValueType::F64); return f64_; }
-template <> inline v128 WABT_VECTORCALL Value::Get<v128>() const { CheckType(ValueType::V128); return v128_; }
-template <> inline Ref WABT_VECTORCALL Value::Get<Ref>() const { CheckType(ValueType::ExternRef); return ref_; }
+template <> inline s8 WABT_VECTORCALL Value::Get<s8>() const { CheckType(Type(ValueType::I32)); return i32_; }
+template <> inline u8 WABT_VECTORCALL Value::Get<u8>() const { CheckType(Type(ValueType::I32)); return i32_; }
+template <> inline s16 WABT_VECTORCALL Value::Get<s16>() const { CheckType(Type(ValueType::I32)); return i32_; }
+template <> inline u16 WABT_VECTORCALL Value::Get<u16>() const { CheckType(Type(ValueType::I32)); return i32_; }
+template <> inline s32 WABT_VECTORCALL Value::Get<s32>() const { CheckType(Type(ValueType::I32)); return i32_; }
+template <> inline u32 WABT_VECTORCALL Value::Get<u32>() const { CheckType(Type(ValueType::I32)); return i32_; }
+template <> inline s64 WABT_VECTORCALL Value::Get<s64>() const { CheckType(Type(ValueType::I64)); return i64_; }
+template <> inline u64 WABT_VECTORCALL Value::Get<u64>() const { CheckType(Type(ValueType::I64)); return i64_; }
+template <> inline f32 WABT_VECTORCALL Value::Get<f32>() const { CheckType(Type(ValueType::F32)); return f32_; }
+template <> inline f64 WABT_VECTORCALL Value::Get<f64>() const { CheckType(Type(ValueType::F64)); return f64_; }
+template <> inline v128 WABT_VECTORCALL Value::Get<v128>() const { CheckType(Type(ValueType::V128)); return v128_; }
+template <> inline Ref WABT_VECTORCALL Value::Get<Ref>() const { CheckType(Type(ValueType::ExternRef)); return ref_; }
 
-template <> inline s8x16 WABT_VECTORCALL Value::Get<s8x16>() const { CheckType(ValueType::V128); return Bitcast<s8x16>(v128_); }
-template <> inline u8x16 WABT_VECTORCALL Value::Get<u8x16>() const { CheckType(ValueType::V128); return Bitcast<u8x16>(v128_); }
-template <> inline s16x8 WABT_VECTORCALL Value::Get<s16x8>() const { CheckType(ValueType::V128); return Bitcast<s16x8>(v128_); }
-template <> inline u16x8 WABT_VECTORCALL Value::Get<u16x8>() const { CheckType(ValueType::V128); return Bitcast<u16x8>(v128_); }
-template <> inline s32x4 WABT_VECTORCALL Value::Get<s32x4>() const { CheckType(ValueType::V128); return Bitcast<s32x4>(v128_); }
-template <> inline u32x4 WABT_VECTORCALL Value::Get<u32x4>() const { CheckType(ValueType::V128); return Bitcast<u32x4>(v128_); }
-template <> inline s64x2 WABT_VECTORCALL Value::Get<s64x2>() const { CheckType(ValueType::V128); return Bitcast<s64x2>(v128_); }
-template <> inline u64x2 WABT_VECTORCALL Value::Get<u64x2>() const { CheckType(ValueType::V128); return Bitcast<u64x2>(v128_); }
-template <> inline f32x4 WABT_VECTORCALL Value::Get<f32x4>() const { CheckType(ValueType::V128); return Bitcast<f32x4>(v128_); }
-template <> inline f64x2 WABT_VECTORCALL Value::Get<f64x2>() const { CheckType(ValueType::V128); return Bitcast<f64x2>(v128_); }
+template <> inline s8x16 WABT_VECTORCALL Value::Get<s8x16>() const { CheckType(Type(ValueType::V128)); return Bitcast<s8x16>(v128_); }
+template <> inline u8x16 WABT_VECTORCALL Value::Get<u8x16>() const { CheckType(Type(ValueType::V128)); return Bitcast<u8x16>(v128_); }
+template <> inline s16x8 WABT_VECTORCALL Value::Get<s16x8>() const { CheckType(Type(ValueType::V128)); return Bitcast<s16x8>(v128_); }
+template <> inline u16x8 WABT_VECTORCALL Value::Get<u16x8>() const { CheckType(Type(ValueType::V128)); return Bitcast<u16x8>(v128_); }
+template <> inline s32x4 WABT_VECTORCALL Value::Get<s32x4>() const { CheckType(Type(ValueType::V128)); return Bitcast<s32x4>(v128_); }
+template <> inline u32x4 WABT_VECTORCALL Value::Get<u32x4>() const { CheckType(Type(ValueType::V128)); return Bitcast<u32x4>(v128_); }
+template <> inline s64x2 WABT_VECTORCALL Value::Get<s64x2>() const { CheckType(Type(ValueType::V128)); return Bitcast<s64x2>(v128_); }
+template <> inline u64x2 WABT_VECTORCALL Value::Get<u64x2>() const { CheckType(Type(ValueType::V128)); return Bitcast<u64x2>(v128_); }
+template <> inline f32x4 WABT_VECTORCALL Value::Get<f32x4>() const { CheckType(Type(ValueType::V128)); return Bitcast<f32x4>(v128_); }
+template <> inline f64x2 WABT_VECTORCALL Value::Get<f64x2>() const { CheckType(Type(ValueType::V128)); return Bitcast<f64x2>(v128_); }
 
-template <> inline void WABT_VECTORCALL Value::Set<s32>(s32 val) { i32_ = val; SetType(ValueType::I32); }
-template <> inline void WABT_VECTORCALL Value::Set<u32>(u32 val) { i32_ = val; SetType(ValueType::I32); }
-template <> inline void WABT_VECTORCALL Value::Set<s64>(s64 val) { i64_ = val; SetType(ValueType::I64); }
-template <> inline void WABT_VECTORCALL Value::Set<u64>(u64 val) { i64_ = val; SetType(ValueType::I64); }
-template <> inline void WABT_VECTORCALL Value::Set<f32>(f32 val) { f32_ = val; SetType(ValueType::F32); }
-template <> inline void WABT_VECTORCALL Value::Set<f64>(f64 val) { f64_ = val; SetType(ValueType::F64); }
-template <> inline void WABT_VECTORCALL Value::Set<v128>(v128 val) { v128_ = val; SetType(ValueType::V128); }
-template <> inline void WABT_VECTORCALL Value::Set<Ref>(Ref val) { ref_ = val; SetType(ValueType::ExternRef); }
+template <> inline void WABT_VECTORCALL Value::Set<s32>(s32 val) { i32_ = val; SetType(Type(ValueType::I32)); }
+template <> inline void WABT_VECTORCALL Value::Set<u32>(u32 val) { i32_ = val; SetType(Type(ValueType::I32)); }
+template <> inline void WABT_VECTORCALL Value::Set<s64>(s64 val) { i64_ = val; SetType(Type(ValueType::I64)); }
+template <> inline void WABT_VECTORCALL Value::Set<u64>(u64 val) { i64_ = val; SetType(Type(ValueType::I64)); }
+template <> inline void WABT_VECTORCALL Value::Set<f32>(f32 val) { f32_ = val; SetType(Type(ValueType::F32)); }
+template <> inline void WABT_VECTORCALL Value::Set<f64>(f64 val) { f64_ = val; SetType(Type(ValueType::F64)); }
+template <> inline void WABT_VECTORCALL Value::Set<v128>(v128 val) { v128_ = val; SetType(Type(ValueType::V128)); }
+template <> inline void WABT_VECTORCALL Value::Set<Ref>(Ref val) { ref_ = val; SetType(Type(ValueType::ExternRef)); }
 
 //// Store ////
 inline bool Store::IsValid(Ref ref) const {

--- a/include/wabt/ir.h
+++ b/include/wabt/ir.h
@@ -84,22 +84,22 @@ using VarVector = std::vector<Var>;
 struct Const {
   static constexpr uintptr_t kRefNullBits = ~uintptr_t(0);
 
-  Const() : Const(Type::I32, uint32_t(0)) {}
+  Const() : Const(Type(Type::I32), uint32_t(0)) {}
 
   static Const I32(uint32_t val = 0, const Location& loc = Location()) {
-    return Const(Type::I32, val, loc);
+    return Const(Type(Type::I32), val, loc);
   }
   static Const I64(uint64_t val = 0, const Location& loc = Location()) {
-    return Const(Type::I64, val, loc);
+    return Const(Type(Type::I64), val, loc);
   }
   static Const F32(uint32_t val = 0, const Location& loc = Location()) {
-    return Const(Type::F32, val, loc);
+    return Const(Type(Type::F32), val, loc);
   }
   static Const F64(uint64_t val = 0, const Location& loc = Location()) {
-    return Const(Type::F64, val, loc);
+    return Const(Type(Type::F64), val, loc);
   }
   static Const V128(v128 val, const Location& loc = Location()) {
-    return Const(Type::V128, val, loc);
+    return Const(Type(Type::V128), val, loc);
   }
 
   Type type() const { return type_; }
@@ -109,7 +109,7 @@ struct Const {
   }
 
   int lane_count() const {
-    switch (lane_type()) {
+    switch (lane_type().code()) {
       case Type::I8:  return 16;
       case Type::I16: return 8;
       case Type::I32: return 4;
@@ -132,17 +132,17 @@ struct Const {
     return data_.To<T>(lane);
   }
 
-  void set_u32(uint32_t x) { From(Type::I32, x); }
-  void set_u64(uint64_t x) { From(Type::I64, x); }
-  void set_f32(uint32_t x) { From(Type::F32, x); }
-  void set_f64(uint64_t x) { From(Type::F64, x); }
+  void set_u32(uint32_t x) { From(Type(Type::I32), x); }
+  void set_u64(uint64_t x) { From(Type(Type::I64), x); }
+  void set_f32(uint32_t x) { From(Type(Type::F32), x); }
+  void set_f64(uint64_t x) { From(Type(Type::F64), x); }
 
-  void set_v128_u8(int lane, uint8_t x) { set_v128_lane(lane, Type::I8, x); }
-  void set_v128_u16(int lane, uint16_t x) { set_v128_lane(lane, Type::I16, x); }
-  void set_v128_u32(int lane, uint32_t x) { set_v128_lane(lane, Type::I32, x); }
-  void set_v128_u64(int lane, uint64_t x) { set_v128_lane(lane, Type::I64, x); }
-  void set_v128_f32(int lane, uint32_t x) { set_v128_lane(lane, Type::F32, x); }
-  void set_v128_f64(int lane, uint64_t x) { set_v128_lane(lane, Type::F64, x); }
+  void set_v128_u8(int lane, uint8_t x) { set_v128_lane(lane, Type(Type::I8), x); }
+  void set_v128_u16(int lane, uint16_t x) { set_v128_lane(lane, Type(Type::I16), x); }
+  void set_v128_u32(int lane, uint32_t x) { set_v128_lane(lane, Type(Type::I32), x); }
+  void set_v128_u64(int lane, uint64_t x) { set_v128_lane(lane, Type(Type::I64), x); }
+  void set_v128_f32(int lane, uint32_t x) { set_v128_lane(lane, Type(Type::F32), x); }
+  void set_v128_f64(int lane, uint64_t x) { set_v128_lane(lane, Type(Type::F64), x); }
 
   // Only used for expectations. (e.g. wast assertions)
   void set_f32(ExpectedNan nan) {
@@ -153,8 +153,8 @@ struct Const {
     set_f64(0);
     set_expected_nan(0, nan);
   }
-  void set_funcref() { From<uintptr_t>(Type::FuncRef, 0); }
-  void set_externref(uintptr_t x) { From(Type::ExternRef, x); }
+  void set_funcref() { From<uintptr_t>(Type(Type::FuncRef), 0); }
+  void set_externref(uintptr_t x) { From(Type(Type::ExternRef), x); }
   void set_null(Type type) { From<uintptr_t>(type, kRefNullBits); }
 
   bool is_expected_nan(int lane = 0) const {
@@ -178,7 +178,7 @@ struct Const {
   template <typename T>
   void set_v128_lane(int lane, Type lane_type, T x) {
     lane_type_ = lane_type;
-    From(Type::V128, x, lane);
+    From(Type(Type::V128), x, lane);
     set_expected_nan(lane, ExpectedNan::None);
   }
 
@@ -322,7 +322,7 @@ class FuncType : public TypeEntry {
 
 struct Field {
   std::string name;
-  Type type = Type::Void;
+  Type type = Type(Type::Void);
   bool mutable_ = false;
 };
 
@@ -941,7 +941,7 @@ struct Global {
   explicit Global(std::string_view name) : name(name) {}
 
   std::string name;
-  Type type = Type::Void;
+  Type type = Type(Type::Void);
   bool mutable_ = false;
   ExprList init_expr;
 };

--- a/include/wabt/shared-validator.h
+++ b/include/wabt/shared-validator.h
@@ -250,7 +250,7 @@ class SharedValidator {
     TableType() = default;
     TableType(Type element, Limits limits) : element(element), limits(limits) {}
 
-    Type element = Type::Any;
+    Type element = Type(Type::Any);
     Limits limits;
   };
 
@@ -265,7 +265,7 @@ class SharedValidator {
     GlobalType() = default;
     GlobalType(Type type, bool mutable_) : type(type), mutable_(mutable_) {}
 
-    Type type = Type::Any;
+    Type type = Type(Type::Any);
     bool mutable_ = true;
   };
 

--- a/include/wabt/string-format.h
+++ b/include/wabt/string-format.h
@@ -29,7 +29,7 @@
 
 #define PRItypecode "%s%#x"
 #define WABT_PRINTF_TYPE_CODE(x) \
-  (static_cast<int32_t>(x) < 0 ? "-" : ""), std::abs(static_cast<int32_t>(x))
+  ((x).code() < 0 ? "-" : ""), std::abs((x).code())
 
 #define WABT_DEFAULT_SNPRINTF_ALLOCA_BUFSIZE 128
 #define WABT_SNPRINTF_ALLOCA(buffer, len, format)                          \

--- a/include/wabt/type.h
+++ b/include/wabt/type.h
@@ -59,13 +59,38 @@ class Type {
   };
 
   Type() = default;  // Provided so Type can be member of a union.
-  Type(int32_t code)
+  explicit Type(int32_t code)
       : enum_(static_cast<Enum>(code)), type_index_(kInvalidIndex) {}
-  Type(Enum e) : enum_(e), type_index_(kInvalidIndex) {}
-  Type(Enum e, Index type_index) : enum_(e), type_index_(type_index) {
+  explicit Type(Enum e) : enum_(e), type_index_(kInvalidIndex) {}
+  explicit Type(Enum e, Index type_index) : enum_(e), type_index_(type_index) {
     assert(e == Enum::Reference);
   }
-  constexpr operator Enum() const { return enum_; }
+  constexpr Enum code() const { return enum_; }
+
+  // TODO: These comparisons could be removed in = default in C++20.
+  bool operator==(const Type& other) const {
+    return enum_ == other.enum_ && type_index_ == other.type_index_;
+  }
+
+  bool operator!=(const Type& other) const {
+    return !(*this == other);
+  }
+
+  bool operator<(const Type& other) const {
+    return (enum_ != other.enum_) ? enum_ < other.enum_
+                                  : type_index_ < other.type_index_;
+  }
+
+  bool operator==(const Type::Enum& other) const {
+    // Disallow non-intended comparisons, where the
+    // other argument should have a valid type_index_.
+    assert(!Type(other).IsReferenceWithIndex());
+    return enum_ == other;
+  }
+
+  bool operator!=(const Type::Enum& other) const {
+    return !(*this == other);
+  }
 
   bool IsRef() const {
     return enum_ == Type::ExternRef || enum_ == Type::FuncRef ||

--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -555,7 +555,7 @@ Result BinaryReader::ReadField(TypeMut* out_value) {
 }
 
 bool BinaryReader::IsConcreteType(Type type) {
-  switch (type) {
+  switch (type.code()) {
     case Type::I32:
     case Type::I64:
     case Type::F32:
@@ -683,11 +683,11 @@ Result BinaryReader::ReadMemory(Limits* out_page_limits,
 }
 
 Result BinaryReader::ReadGlobalHeader(Type* out_type, bool* out_mutable) {
-  Type global_type = Type::Void;
+  Type global_type(Type::Void);
   uint8_t mutable_ = 0;
   CHECK_RESULT(ReadType(&global_type, "global type"));
   ERROR_UNLESS(IsConcreteType(global_type), "invalid global type: %#x",
-               static_cast<int>(global_type));
+               global_type.code());
 
   CHECK_RESULT(ReadU8(&mutable_, "global mutability"));
   ERROR_UNLESS(mutable_ <= 1, "global mutability must be 0 or 1");
@@ -2537,10 +2537,10 @@ Result BinaryReader::ReadTypeSection(Offset section_size) {
       uint8_t type;
       CHECK_RESULT(ReadU8(&type, "type form"));
       ERROR_UNLESS(type == 0x60, "unexpected type form (got %#x)", type);
-      form = Type::Func;
+      form = Type(Type::Func);
     }
 
-    switch (form) {
+    switch (form.code()) {
       case Type::Func: {
         Index num_params;
         CHECK_RESULT(ReadCount(&num_params, "function param count"));
@@ -2803,7 +2803,7 @@ Result BinaryReader::ReadElemSection(Offset section_size) {
     if ((flags & (SegPassive | SegExplicitIndex)) == SegExplicitIndex) {
       CHECK_RESULT(ReadIndex(&table_index, "elem segment table index"));
     }
-    Type elem_type = Type::FuncRef;
+    Type elem_type(Type::FuncRef);
 
     CALLBACK(BeginElemSegment, i, table_index, flags);
 
@@ -2823,7 +2823,7 @@ Result BinaryReader::ReadElemSection(Offset section_size) {
         ERROR_UNLESS(kind == ExternalKind::Func,
                      "segment elem type must be func (%s)",
                      elem_type.GetName().c_str());
-        elem_type = Type::FuncRef;
+        elem_type = Type(Type::FuncRef);
       }
     }
 

--- a/src/binary-writer-spec.cc
+++ b/src/binary-writer-spec.cc
@@ -211,7 +211,7 @@ void BinaryWriterSpec::WriteConst(const Const& const_) {
 
   /* Always write the values as strings, even though they may be representable
    * as JSON numbers. This way the formatting is consistent. */
-  switch (const_.type()) {
+  switch (const_.type().code()) {
     case Type::I32:
       WriteString("i32");
       WriteSeparator();
@@ -274,7 +274,7 @@ void BinaryWriterSpec::WriteConst(const Const& const_) {
       json_stream_->Writef("[");
 
       for (int lane = 0; lane < const_.lane_count(); ++lane) {
-        switch (const_.lane_type()) {
+        switch (const_.lane_type().code()) {
           case Type::I8:
             json_stream_->Writef("\"%u\"", const_.v128_lane<uint8_t>(lane));
             break;

--- a/src/binary-writer.cc
+++ b/src/binary-writer.cc
@@ -57,7 +57,7 @@ void WriteOpcode(Stream* stream, Opcode opcode) {
 }
 
 void WriteType(Stream* stream, Type type, const char* desc) {
-  WriteS32Leb128(stream, type, desc ? desc : type.GetName().c_str());
+  WriteS32Leb128(stream, type.code(), desc ? desc : type.GetName().c_str());
   if (type.IsReferenceWithIndex()) {
     WriteS32Leb128(stream, type.GetReferenceIndex(),
                    desc ? desc : type.GetName().c_str());
@@ -527,7 +527,7 @@ Offset BinaryWriter::WriteFixupU32Leb128Size(Offset offset,
 void BinaryWriter::WriteBlockDecl(const BlockDeclaration& decl) {
   if (decl.sig.GetNumParams() == 0 && decl.sig.GetNumResults() <= 1) {
     if (decl.sig.GetNumResults() == 0) {
-      WriteType(stream_, Type::Void);
+      WriteType(stream_, Type(Type::Void));
     } else if (decl.sig.GetNumResults() == 1) {
       WriteType(stream_, decl.sig.GetResultType(0));
     }
@@ -815,7 +815,7 @@ void BinaryWriter::WriteExpr(const Func* func, const Expr* expr) {
       break;
     case ExprType::Const: {
       const Const& const_ = cast<ConstExpr>(expr)->const_;
-      switch (const_.type()) {
+      switch (const_.type().code()) {
         case Type::I32: {
           WriteOpcode(stream_, Opcode::I32Const);
           WriteS32Leb128(stream_, const_.u32(), "i32 literal");
@@ -1369,7 +1369,7 @@ Result BinaryWriter::WriteModule() {
           const FuncType* func_type = cast<FuncType>(type);
           const FuncSignature* sig = &func_type->sig;
           WriteHeader("func type", i);
-          WriteType(stream_, Type::Func);
+          WriteType(stream_, Type(Type::Func));
 
           Index num_params = sig->param_types.size();
           Index num_results = sig->result_types.size();
@@ -1388,7 +1388,7 @@ Result BinaryWriter::WriteModule() {
         case TypeEntryKind::Struct: {
           const StructType* struct_type = cast<StructType>(type);
           WriteHeader("struct type", i);
-          WriteType(stream_, Type::Struct);
+          WriteType(stream_, Type(Type::Struct));
           Index num_fields = struct_type->fields.size();
           WriteU32Leb128(stream_, num_fields, "num fields");
           for (size_t j = 0; j < num_fields; ++j) {
@@ -1402,7 +1402,7 @@ Result BinaryWriter::WriteModule() {
         case TypeEntryKind::Array: {
           const ArrayType* array_type = cast<ArrayType>(type);
           WriteHeader("array type", i);
-          WriteType(stream_, Type::Array);
+          WriteType(stream_, Type(Type::Array));
           WriteType(stream_, array_type->field.type);
           stream_->WriteU8(array_type->field.mutable_, "field mutability");
           break;

--- a/src/decompiler.cc
+++ b/src/decompiler.cc
@@ -418,7 +418,7 @@ struct Decompiler {
     switch (n.etype) {
       case ExprType::Const: {
         auto& c = cast<ConstExpr>(n.e)->const_;
-        switch (c.type()) {
+        switch (c.type().code()) {
           case Type::I32:
             return Value{{std::to_string(static_cast<int32_t>(c.u32()))},
                          Precedence::Atomic};

--- a/src/interp/binary-reader-interp.cc
+++ b/src/interp/binary-reader-interp.cc
@@ -720,14 +720,14 @@ Result BinaryReaderInterp::BeginElemSegment(Index index,
   CHECK_RESULT(validator_.OnElemSegment(GetLocation(),
                                         Var(table_index, GetLocation()), mode));
 
-  ValueType offset_type = ValueType::I32;
+  ValueType offset_type(ValueType::I32);
   if (table_index < table_types_.size() &&
       table_types_[table_index].limits.is_64) {
-    offset_type = ValueType::I64;
+    offset_type = Type(ValueType::I64);
   }
   FuncDesc init_func{
       FuncType{{}, {offset_type}}, {}, Istream::kInvalidOffset, {}};
-  ElemDesc desc{{}, ValueType::Void, mode, table_index, init_func};
+  ElemDesc desc{{}, Type(ValueType::Void), mode, table_index, init_func};
   module_.elems.push_back(desc);
   return Result::Ok;
 }
@@ -789,10 +789,10 @@ Result BinaryReaderInterp::BeginDataSegment(Index index,
   CHECK_RESULT(validator_.OnDataSegment(
       GetLocation(), Var(memory_index, GetLocation()), mode));
 
-  ValueType offset_type = ValueType::I32;
+  ValueType offset_type(ValueType::I32);
   if (memory_index < memory_types_.size() &&
       memory_types_[memory_index].limits.is_64) {
-    offset_type = ValueType::I64;
+    offset_type = Type(ValueType::I64);
   }
   FuncDesc init_func{
       FuncType{{}, {offset_type}}, {}, Istream::kInvalidOffset, {}};
@@ -1250,31 +1250,31 @@ Result BinaryReaderInterp::OnDropExpr() {
 }
 
 Result BinaryReaderInterp::OnI32ConstExpr(uint32_t value) {
-  CHECK_RESULT(validator_.OnConst(GetLocation(), Type::I32));
+  CHECK_RESULT(validator_.OnConst(GetLocation(), Type(Type::I32)));
   istream_.Emit(Opcode::I32Const, value);
   return Result::Ok;
 }
 
 Result BinaryReaderInterp::OnI64ConstExpr(uint64_t value) {
-  CHECK_RESULT(validator_.OnConst(GetLocation(), Type::I64));
+  CHECK_RESULT(validator_.OnConst(GetLocation(), Type(Type::I64)));
   istream_.Emit(Opcode::I64Const, value);
   return Result::Ok;
 }
 
 Result BinaryReaderInterp::OnF32ConstExpr(uint32_t value_bits) {
-  CHECK_RESULT(validator_.OnConst(GetLocation(), Type::F32));
+  CHECK_RESULT(validator_.OnConst(GetLocation(), Type(Type::F32)));
   istream_.Emit(Opcode::F32Const, value_bits);
   return Result::Ok;
 }
 
 Result BinaryReaderInterp::OnF64ConstExpr(uint64_t value_bits) {
-  CHECK_RESULT(validator_.OnConst(GetLocation(), Type::F64));
+  CHECK_RESULT(validator_.OnConst(GetLocation(), Type(Type::F64)));
   istream_.Emit(Opcode::F64Const, value_bits);
   return Result::Ok;
 }
 
 Result BinaryReaderInterp::OnV128ConstExpr(v128 value_bits) {
-  CHECK_RESULT(validator_.OnConst(GetLocation(), Type::V128));
+  CHECK_RESULT(validator_.OnConst(GetLocation(), Type(Type::V128)));
   istream_.Emit(Opcode::V128Const, value_bits);
   return Result::Ok;
 }

--- a/src/interp/interp-util.cc
+++ b/src/interp/interp-util.cc
@@ -24,7 +24,7 @@ namespace wabt {
 namespace interp {
 
 std::string TypedValueToString(const TypedValue& tv) {
-  switch (tv.type) {
+  switch (tv.type.code()) {
     case Type::I32:
       return StringPrintf("i32:%u", tv.value.Get<s32>());
 

--- a/src/interp/interp-wasm-c-api.cc
+++ b/src/interp/interp-wasm-c-api.cc
@@ -329,17 +329,17 @@ struct wasm_instance_t : wasm_ref_t {
 static ValueType ToWabtValueType(wasm_valkind_t kind) {
   switch (kind) {
     case WASM_I32:
-      return ValueType::I32;
+      return Type(ValueType::I32);
     case WASM_I64:
-      return ValueType::I64;
+      return Type(ValueType::I64);
     case WASM_F32:
-      return ValueType::F32;
+      return Type(ValueType::F32);
     case WASM_F64:
-      return ValueType::F64;
+      return Type(ValueType::F64);
     case WASM_ANYREF:
-      return ValueType::ExternRef;
+      return Type(ValueType::ExternRef);
     case WASM_FUNCREF:
-      return ValueType::FuncRef;
+      return Type(ValueType::FuncRef);
     default:
       TRACE("unexpected wasm_valkind_t: %d", kind);
       WABT_UNREACHABLE;
@@ -348,7 +348,7 @@ static ValueType ToWabtValueType(wasm_valkind_t kind) {
 }
 
 static wasm_valkind_t FromWabtValueType(ValueType type) {
-  switch (type) {
+  switch (type.code()) {
     case ValueType::I32:
       return WASM_I32;
     case ValueType::I64:
@@ -439,7 +439,7 @@ static TypedValue ToWabtValue(const wasm_val_t& value) {
 static wasm_val_t FromWabtValue(Store& store, const TypedValue& tv) {
   TRACE("%s", TypedValueToString(tv).c_str());
   wasm_val_t out_value;
-  switch (tv.type) {
+  switch (tv.type.code()) {
     case Type::I32:
       out_value.kind = WASM_I32;
       out_value.of.i32 = tv.value.Get<s32>();
@@ -469,7 +469,7 @@ static wasm_val_t FromWabtValue(Store& store, const TypedValue& tv) {
       break;
     }
     default:
-      TRACE("unexpected wabt type: %d", static_cast<int>(tv.type));
+      TRACE("unexpected wabt type: %d", tv.type.code());
       assert(false);
   }
   return out_value;

--- a/src/interp/interp.cc
+++ b/src/interp/interp.cc
@@ -235,7 +235,7 @@ bool Store::HasValueType(Ref ref, ValueType type) const {
   }
 
   Object* obj = objects_.Get(ref.index);
-  switch (type) {
+  switch (type.code()) {
     case ValueType::FuncRef:
       return obj->kind() == ObjectKind::DefinedFunc ||
              obj->kind() == ObjectKind::HostFunc;
@@ -1983,7 +1983,7 @@ RunResult Thread::StepInternal(Trap::Ptr* out_trap) {
     }
     case O::ThrowRef: {
       Ref ref = Pop<Ref>();
-      assert(store_.HasValueType(ref, ValueType::ExnRef));
+      assert(store_.HasValueType(ref, Type(ValueType::ExnRef)));
       // FIXME better error message?
       TRAP_IF(ref == Ref::Null, "expected exnref, got null");
       Exception::Ptr exn = store_.UnsafeGet<Exception>(ref);
@@ -2775,7 +2775,7 @@ std::string Thread::TraceSource::Pick(Index index, Instr instr) {
     }
   }
 
-  switch (type) {
+  switch (type.code()) {
     case ValueType::I32: return StringPrintf("%u", val.Get<u32>());
     case ValueType::I64: return StringPrintf("%" PRIu64, val.Get<u64>());
     case ValueType::F32: return StringPrintf("%g", val.Get<f32>());

--- a/src/ir.cc
+++ b/src/ir.cc
@@ -207,7 +207,7 @@ Type LocalTypes::operator[](Index i) const {
     count += decl.second;
   }
   assert(i < count);
-  return Type::Any;
+  return Type(Type::Any);
 }
 
 Type Func::GetLocalType(Index index) const {

--- a/src/lexer-keywords.txt
+++ b/src/lexer-keywords.txt
@@ -2,10 +2,10 @@ struct TokenInfo {
   TokenInfo(const char* name) : name(name) {}
   TokenInfo(const char* name, TokenType token_type)
       : name(name), token_type(token_type) {}
-  TokenInfo(const char* name, Type value_type)
-      : name(name), token_type(TokenType::ValueType), value_type(value_type) {}
-  TokenInfo(const char* name, Type value_type, TokenType token_type)
-      : name(name), token_type(token_type), value_type(value_type) {}
+  TokenInfo(const char* name, Type::Enum value_type)
+      : name(name), token_type(TokenType::ValueType), value_type(Type(value_type)) {}
+  TokenInfo(const char* name, Type::Enum value_type, TokenType token_type)
+      : name(name), token_type(token_type), value_type(Type(value_type)) {}
   TokenInfo(const char* name, TokenType token_type, Opcode opcode)
       : name(name), token_type(token_type), opcode(opcode) {}
 

--- a/src/opcode.cc
+++ b/src/opcode.cc
@@ -24,12 +24,25 @@ namespace wabt {
 Opcode::Info Opcode::infos_[] = {
 #define WABT_OPCODE(rtype, type1, type2, type3, mem_size, prefix, code, Name, \
                     text, decomp)                                             \
-  {text,     decomp, Type::rtype, {Type::type1, Type::type2, Type::type3},    \
-   mem_size, prefix, code,        PrefixCode(prefix, code)},
+  {text,                                                                      \
+   decomp,                                                                    \
+   Type(Type::rtype),                                                         \
+   {Type(Type::type1), Type(Type::type2), Type(Type::type3)},                 \
+   mem_size,                                                                  \
+   prefix,                                                                    \
+   code,                                                                      \
+   PrefixCode(prefix, code)},
 #include "wabt/opcode.def"
 #undef WABT_OPCODE
 
-  {"<invalid>", "", Type::Void, {Type::Void, Type::Void, Type::Void}, 0, 0, 0, 0},
+    {"<invalid>",
+     "",
+     Type(Type::Void),
+     {Type(Type::Void), Type(Type::Void), Type(Type::Void)},
+     0,
+     0,
+     0,
+     0},
 };
 
 #define WABT_OPCODE(rtype, type1, type2, type3, mem_size, prefix, code, Name, \

--- a/src/prebuilt/lexer-keywords.cc
+++ b/src/prebuilt/lexer-keywords.cc
@@ -34,10 +34,10 @@ struct TokenInfo {
   TokenInfo(const char* name) : name(name) {}
   TokenInfo(const char* name, TokenType token_type)
       : name(name), token_type(token_type) {}
-  TokenInfo(const char* name, Type value_type)
-      : name(name), token_type(TokenType::ValueType), value_type(value_type) {}
-  TokenInfo(const char* name, Type value_type, TokenType token_type)
-      : name(name), token_type(token_type), value_type(value_type) {}
+  TokenInfo(const char* name, Type::Enum value_type)
+      : name(name), token_type(TokenType::ValueType), value_type(Type(value_type)) {}
+  TokenInfo(const char* name, Type::Enum value_type, TokenType token_type)
+      : name(name), token_type(token_type), value_type(Type(value_type)) {}
   TokenInfo(const char* name, TokenType token_type, Opcode opcode)
       : name(name), token_type(token_type), opcode(opcode) {}
 

--- a/src/shared-validator.cc
+++ b/src/shared-validator.cc
@@ -270,8 +270,8 @@ Result SharedValidator::OnElemSegment(const Location& loc,
     result |= CheckTableIndex(table_var, &table_type);
   }
   // Type gets set later in OnElemSegmentElemType.
-  elems_.push_back(
-      ElemType{Type::Void, kind == SegmentKind::Active, table_type.element});
+  elems_.push_back(ElemType{Type(Type::Void), kind == SegmentKind::Active,
+                            table_type.element});
   return result;
 }
 
@@ -913,7 +913,7 @@ Result SharedValidator::OnLoadZero(const Location& loc,
 Result SharedValidator::OnLocalGet(const Location& loc, Var local_var) {
   CHECK_RESULT(CheckInstr(Opcode::LocalGet, loc));
   Result result = Result::Ok;
-  Type type = Type::Any;
+  Type type(Type::Any);
   result |= CheckLocalIndex(local_var, &type);
   result |= typechecker_.OnLocalGet(type);
   return result;
@@ -922,7 +922,7 @@ Result SharedValidator::OnLocalGet(const Location& loc, Var local_var) {
 Result SharedValidator::OnLocalSet(const Location& loc, Var local_var) {
   CHECK_RESULT(CheckInstr(Opcode::LocalSet, loc));
   Result result = Result::Ok;
-  Type type = Type::Any;
+  Type type(Type::Any);
   result |= CheckLocalIndex(local_var, &type);
   result |= typechecker_.OnLocalSet(type);
   return result;
@@ -931,7 +931,7 @@ Result SharedValidator::OnLocalSet(const Location& loc, Var local_var) {
 Result SharedValidator::OnLocalTee(const Location& loc, Var local_var) {
   CHECK_RESULT(CheckInstr(Opcode::LocalTee, loc));
   Result result = Result::Ok;
-  Type type = Type::Any;
+  Type type(Type::Any);
   result |= CheckLocalIndex(local_var, &type);
   result |= typechecker_.OnLocalTee(type);
   return result;
@@ -1252,7 +1252,7 @@ Result SharedValidator::OnTryTableCatch(const Location& loc,
     result |= CheckTagIndex(catch_.tag, &tag_type);
   }
   if (catch_.IsRef()) {
-    tag_type.params.push_back(Type::ExnRef);
+    tag_type.params.push_back(Type(Type::ExnRef));
   }
   result |=
       typechecker_.OnTryTableCatch(tag_type.params, catch_.target.index());

--- a/src/validator.cc
+++ b/src/validator.cc
@@ -256,7 +256,7 @@ Type Validator::GetDeclarationType(const FuncDeclaration& decl) {
   }
   if (decl.sig.param_types.empty()) {
     if (decl.sig.result_types.empty()) {
-      return Type::Void;
+      return Type(Type::Void);
     }
     if (decl.sig.result_types.size() == 1) {
       return decl.sig.result_types[0];
@@ -851,11 +851,11 @@ Result Validator::CheckModule() {
 
       // Init expr.
       if (f->elem_segment.kind == SegmentKind::Active) {
-        Type offset_type = Type::I32;
+        Type offset_type(Type::I32);
         Index table_index = module->GetTableIndex(f->elem_segment.table_var);
         if (table_index < module->tables.size() &&
             module->tables[table_index]->elem_limits.is_64) {
-          offset_type = Type::I64;
+          offset_type = Type(Type::I64);
         }
         result_ |= validator_.BeginInitExpr(field.loc, offset_type);
         ExprVisitor visitor(this);
@@ -905,11 +905,11 @@ Result Validator::CheckModule() {
 
       // Init expr.
       if (f->data_segment.kind == SegmentKind::Active) {
-        Type offset_type = Type::I32;
+        Type offset_type(Type::I32);
         Index memory_index = module->GetMemoryIndex(f->data_segment.memory_var);
         if (memory_index < module->memories.size() &&
             module->memories[memory_index]->page_limits.is_64) {
-          offset_type = Type::I64;
+          offset_type = Type(Type::I64);
         }
         result_ |= validator_.BeginInitExpr(field.loc, offset_type);
         ExprVisitor visitor(this);

--- a/src/wast-parser.cc
+++ b/src/wast-parser.cc
@@ -324,7 +324,8 @@ void ResolveTypeName(
     Type& type,
     Index index,
     const std::unordered_map<uint32_t, std::string>& bindings) {
-  if (type != Type::Reference || type.GetReferenceIndex() != kInvalidIndex) {
+  if (type.code() != Type::Reference ||
+      type.GetReferenceIndex() != kInvalidIndex) {
     return;
   }
 
@@ -935,7 +936,7 @@ Result WastParser::ParseValueType(Var* out_type) {
   Token token = Consume();
   Type type = token.type();
   bool is_enabled;
-  switch (type) {
+  switch (type.code()) {
     case Type::V128:
       is_enabled = options_->features.simd_enabled();
       break;
@@ -956,7 +957,7 @@ Result WastParser::ParseValueType(Var* out_type) {
     return Result::Error;
   }
 
-  *out_type = Var(type, GetLocation());
+  *out_type = Var(type.code(), GetLocation());
   return Result::Ok;
 }
 
@@ -1448,7 +1449,7 @@ Result WastParser::ParseElemModuleField(Module* module) {
   if (ParseRefTypeOpt(&field->elem_segment.elem_type)) {
     ParseElemExprListOpt(&field->elem_segment.elem_exprs);
   } else {
-    field->elem_segment.elem_type = Type::FuncRef;
+    field->elem_segment.elem_type = Type(Type::FuncRef);
     if (PeekMatch(TokenType::Func)) {
       EXPECT(Func);
     }

--- a/src/wat-writer.cc
+++ b/src/wat-writer.cc
@@ -470,7 +470,7 @@ void WatWriter::WriteEndBlock() {
 }
 
 void WatWriter::WriteConst(const Const& const_) {
-  switch (const_.type()) {
+  switch (const_.type().code()) {
     case Type::I32:
       WritePutsSpace(Opcode::I32Const_Opcode.GetName());
       Writef("%d", static_cast<int32_t>(const_.u32()));

--- a/test/dump/func-ref-type.txt
+++ b/test/dump/func-ref-type.txt
@@ -1,0 +1,79 @@
+;;; TOOL: run-objdump
+;;; ARGS0: -v --enable-function-references
+(module
+  (type $t1 (func (param (ref $t1))))
+  (type $t2 (func (param (ref $t2))))
+  (type $t3 (func (param (ref $t3))))
+
+  (func $f1 (type $t3))
+  (func $f2 (type $t2))
+  (func $f3 (type $t1))
+)
+(;; STDERR ;;;
+0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
+0000004: 0100 0000                                 ; WASM_BINARY_VERSION
+; section "Type" (1)
+0000008: 01                                        ; section code
+0000009: 00                                        ; section size (guess)
+000000a: 03                                        ; num types
+; func type 0
+000000b: 60                                        ; func
+000000c: 01                                        ; num params
+000000d: 6b                                        ; (ref -1)
+000000e: 7f                                        ; (ref -1)
+000000f: 00                                        ; num results
+; func type 1
+0000010: 60                                        ; func
+0000011: 01                                        ; num params
+0000012: 6b                                        ; (ref -1)
+0000013: 7f                                        ; (ref -1)
+0000014: 00                                        ; num results
+; func type 2
+0000015: 60                                        ; func
+0000016: 01                                        ; num params
+0000017: 6b                                        ; (ref -1)
+0000018: 7f                                        ; (ref -1)
+0000019: 00                                        ; num results
+0000009: 10                                        ; FIXUP section size
+; section "Function" (3)
+000001a: 03                                        ; section code
+000001b: 00                                        ; section size (guess)
+000001c: 03                                        ; num functions
+000001d: 02                                        ; function 0 signature index
+000001e: 01                                        ; function 1 signature index
+000001f: 00                                        ; function 2 signature index
+000001b: 04                                        ; FIXUP section size
+; section "Code" (10)
+0000020: 0a                                        ; section code
+0000021: 00                                        ; section size (guess)
+0000022: 03                                        ; num functions
+; function body 0
+0000023: 00                                        ; func body size (guess)
+0000024: 00                                        ; local decl count
+0000025: 0b                                        ; end
+0000023: 02                                        ; FIXUP func body size
+; function body 1
+0000026: 00                                        ; func body size (guess)
+0000027: 00                                        ; local decl count
+0000028: 0b                                        ; end
+0000026: 02                                        ; FIXUP func body size
+; function body 2
+0000029: 00                                        ; func body size (guess)
+000002a: 00                                        ; local decl count
+000002b: 0b                                        ; end
+0000029: 02                                        ; FIXUP func body size
+0000021: 0a                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
+
+func-ref-type.wasm:	file format wasm 0x1
+
+Code Disassembly:
+
+000024 func[0]:
+ 000025: 0b                         | end
+000027 func[1]:
+ 000028: 0b                         | end
+00002a func[2]:
+ 00002b: 0b                         | end
+;;; STDOUT ;;)


### PR DESCRIPTION
Based on #2571

Mostly switches needed the implicit conversion. Not that big patch.