### PR TITLE
Disable uvwasi

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
     - name: mkdir
       run: mkdir -p out
     - name: cmake
-      run: cmake .. -G Ninja -DWITH_WASI=ON -DWERROR=ON -Werror=dev -Wno-deprecated
+      run: cmake .. -G Ninja -DWERROR=ON -Werror=dev -Wno-deprecated
       working-directory: out
       if: matrix.os != 'windows-latest'
     - name: cmake (windows)
@@ -255,7 +255,7 @@ jobs:
     - name: distcc symlink
       run: sudo ln -s /usr/bin/distcc /opt/bin/distcc_symlinks/${{matrix.arch}}-linux-gnu-gcc # only CC is needed
     - name: cmake
-      run: cmake -S . -B out -G Ninja -DCMAKE_TOOLCHAIN_FILE=../scripts/TC-${{matrix.arch}}.cmake -DWITH_WASI=ON -DWERROR=OFF -Werror=dev -Wno-deprecated
+      run: cmake -S . -B out -G Ninja -DCMAKE_TOOLCHAIN_FILE=../scripts/TC-${{matrix.arch}}.cmake -DWERROR=OFF -Werror=dev -Wno-deprecated
     - name: build
       run: cmake --build out
     - name: check if generated files are up-to-date


### PR DESCRIPTION
We haven't been running wasi interp tests since forever, and uvwasi is breaking the build. Let's get things working again and re-enable it later.

Note: This is about wasi support in the interpreter, not the wasi target.