### PR TITLE
Move parser related data from IR to the parser and improve reference type parsing

### DIFF
--- a/include/wabt/ir.h
+++ b/include/wabt/ir.h
@@ -255,13 +255,6 @@ struct FuncSignature {
   TypeVector param_types;
   TypeVector result_types;
 
-  // Some types can have names, for example (ref $foo) has type $foo.
-  // So to use this type we need to translate its name into
-  // a proper index from the module type section.
-  // This is the mapping from parameter/result index to its name.
-  std::unordered_map<uint32_t, std::string> param_type_names;
-  std::unordered_map<uint32_t, std::string> result_type_names;
-
   Index GetNumParams() const { return param_types.size(); }
   Index GetNumResults() const { return result_types.size(); }
   Type GetParamType(Index index) const { return param_types[index]; }

--- a/test/dump/typed-func-refs-locals.txt
+++ b/test/dump/typed-func-refs-locals.txt
@@ -1,0 +1,79 @@
+;;; TOOL: run-objdump
+;;; ARGS0: -v --enable-function-references
+
+(module
+  (type $t0 (func))
+
+  ;; Self reference
+  (type $t1 (func (param (ref $t0) (ref $t1) (ref 1))))
+
+  (func $f1 (param (ref $t0) (ref 0))
+    (local (ref $t0) (ref 0)
+           (ref $t1) (ref 1))
+  )
+)
+
+(;; STDERR ;;;
+0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
+0000004: 0100 0000                                 ; WASM_BINARY_VERSION
+; section "Type" (1)
+0000008: 01                                        ; section code
+0000009: 00                                        ; section size (guess)
+000000a: 03                                        ; num types
+; func type 0
+000000b: 60                                        ; func
+000000c: 00                                        ; num params
+000000d: 00                                        ; num results
+; func type 1
+000000e: 60                                        ; func
+000000f: 03                                        ; num params
+0000010: 6b                                        ; (ref 0)
+0000011: 00                                        ; (ref 0)
+0000012: 6b                                        ; (ref 1)
+0000013: 01                                        ; (ref 1)
+0000014: 6b                                        ; (ref 1)
+0000015: 01                                        ; (ref 1)
+0000016: 00                                        ; num results
+; func type 2
+0000017: 60                                        ; func
+0000018: 02                                        ; num params
+0000019: 6b                                        ; (ref 0)
+000001a: 00                                        ; (ref 0)
+000001b: 6b                                        ; (ref 0)
+000001c: 00                                        ; (ref 0)
+000001d: 00                                        ; num results
+0000009: 14                                        ; FIXUP section size
+; section "Function" (3)
+000001e: 03                                        ; section code
+000001f: 00                                        ; section size (guess)
+0000020: 01                                        ; num functions
+0000021: 02                                        ; function 0 signature index
+000001f: 02                                        ; FIXUP section size
+; section "Code" (10)
+0000022: 0a                                        ; section code
+0000023: 00                                        ; section size (guess)
+0000024: 01                                        ; num functions
+; function body 0
+0000025: 00                                        ; func body size (guess)
+0000026: 02                                        ; local decl count
+0000027: 02                                        ; local type count
+0000028: 6b                                        ; (ref 0)
+0000029: 00                                        ; (ref 0)
+000002a: 02                                        ; local type count
+000002b: 6b                                        ; (ref 1)
+000002c: 01                                        ; (ref 1)
+000002d: 0b                                        ; end
+0000025: 08                                        ; FIXUP func body size
+0000023: 0a                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
+
+typed-func-refs-locals.wasm:	file format wasm 0x1
+
+Code Disassembly:
+
+000026 func[0]:
+ 000027: 02 6b 00                   | local[2..3] type=(ref 0)
+ 00002a: 02 6b 01                   | local[4..5] type=(ref 1)
+ 00002d: 0b                         | end
+;;; STDOUT ;;)

--- a/test/roundtrip/typed-func-refs.txt
+++ b/test/roundtrip/typed-func-refs.txt
@@ -1,0 +1,21 @@
+;;; TOOL: run-roundtrip
+;;; ARGS: --stdout --enable-function-references --debug-names
+(module
+  (type $t0 (func))
+
+  ;; Self reference
+  (type $t1 (func (param (ref $t0) (ref $t1) (ref 1))))
+
+  (func $f1 (param (ref $t0) (ref 0))
+    (local (ref $t0) (ref 0)
+           (ref $t1) (ref 1))
+  )
+)
+(;; STDOUT ;;;
+(module
+  (type $t0 (func))
+  (type $t1 (func (param (ref 0) (ref 1) (ref 1))))
+  (type (;2;) (func (param (ref 0) (ref 0))))
+  (func $f1 (type 2) (param (ref 0) (ref 0))
+    (local (ref 0) (ref 0) (ref 1) (ref 1))))
+;;; STDOUT ;;)

--- a/test/typecheck/missing-ref.txt
+++ b/test/typecheck/missing-ref.txt
@@ -1,0 +1,25 @@
+;;; TOOL: wat2wasm
+;;; ARGS*: --enable-function-references
+;;; ERROR: 1
+(module
+  (type $t0 (func (param (ref $first_type))))
+
+  (func $f (param (ref $second_type))
+           (result (ref $third_type))
+    (local (ref $fourth_type))
+  )
+)
+(;; STDERR ;;;
+out/test/typecheck/missing-ref.txt:5:31: error: undefined reference type name $first_type
+  (type $t0 (func (param (ref $first_type))))
+                              ^^^^^^^^^^^
+out/test/typecheck/missing-ref.txt:7:24: error: undefined reference type name $second_type
+  (func $f (param (ref $second_type))
+                       ^^^^^^^^^^^^
+out/test/typecheck/missing-ref.txt:8:25: error: undefined reference type name $third_type
+           (result (ref $third_type))
+                        ^^^^^^^^^^^
+out/test/typecheck/missing-ref.txt:9:17: error: undefined reference type name $fourth_type
+    (local (ref $fourth_type))
+                ^^^^^^^^^^^^
+;;; STDERR ;;)


### PR DESCRIPTION
This patch moves (and reworks) param_type_names / result_type_names out of IR to the parser, and fix the following issues:

Parse (ref index) form, not just (ref $name) form
Resolve references in types and locals
Display location when a named reference is not found