### PR TITLE
libwabt.js: Add `check` option, equiv to wasm2wat's --no-check

### DIFF
--- a/docs/demo/wasm2wat/demo.js
+++ b/docs/demo/wasm2wat/demo.js
@@ -35,6 +35,7 @@ var uploadInputEl = document.getElementById('uploadInput');
 var generateNamesEl = document.getElementById('generateNames');
 var foldExprsEl = document.getElementById('foldExprs');
 var inlineExportEl = document.getElementById('inlineExport');
+var checkEl = document.getElementById('check');
 var readDebugNamesEl = document.getElementById('readDebugNames');
 var options = {mode: 'wast', lineNumbers: true};
 var editor = CodeMirror.fromTextArea(editorEl, options);
@@ -69,13 +70,14 @@ function compile(contents) {
   }
 
   var readDebugNames = readDebugNamesEl.checked;
+  var check = checkEl.checked;
   var generateNames = generateNamesEl.checked;
   var foldExprs = foldExprsEl.checked;
   var inlineExport = inlineExportEl.checked;
 
   try {
     var module =
-        wabt.readWasm(contents, {readDebugNames: readDebugNames, ...features});
+        wabt.readWasm(contents, {readDebugNames: readDebugNames, check: check, ...features});
     if (generateNames) {
       module.generateNames();
       module.applyNames();

--- a/docs/demo/wasm2wat/index.html
+++ b/docs/demo/wasm2wat/index.html
@@ -76,6 +76,10 @@
 
       <input type="checkbox" id="readDebugNames" checked>
       <label for="readDebugNames">Read Debug Names</label>
+
+      <input type="checkbox" id="check" checked>
+      <label for="check">Check for invalid modules</label>
+
       <div class="right">
         <input type="file" id="uploadInput" class="hidden"></a>
         <label>example:</label>

--- a/src/wabt.post.js
+++ b/src/wabt.post.js
@@ -238,6 +238,7 @@ function readWasm(buffer, options) {
   var bufferObj = allocateBuffer(buffer);
   var errors = new Errors('binary');
   var readDebugNames = booleanOrDefault(options.readDebugNames, false);
+  var check = booleanOrDefault(options.check, true);
   var features = new Features(options);
 
   try {
@@ -247,7 +248,8 @@ function readWasm(buffer, options) {
 
     var result =
         Module._wabt_read_binary_result_get_result(readBinaryResult_addr);
-    if (result !== WABT_OK) {
+    console.log({ check });
+    if (check && result !== WABT_OK) {
       throw new Error('readWasm failed:\n' + errors.format());
     }
 


### PR DESCRIPTION
## Description

When using the JS API, there's currently no way to get the equivalent of wasm2wat's `--no-check` option. This adds support for that.

- Add a property named `check` to the`options` arg  of`readWasm` (in wasm.post.js)
- Add a checkbox to the demo to control the `check` option.

## Screenshots

Here's the wasm2wat demo showing the new option, and with an example of wasm2wat on an invalid module:

![CleanShot 2025-04-09 at 13 35 57@2x](https://github.com/user-attachments/assets/40077a89-7676-4934-8323-a10c32001f08)

(Note that the function body doesn't end with `end`.)