### PR TITLE
[wast-parser] Add parse_binary_modules option

### DIFF
--- a/include/wabt/wast-parser.h
+++ b/include/wabt/wast-parser.h
@@ -35,6 +35,7 @@ struct WastParseOptions {
 
   Features features;
   bool debug_parsing = false;
+  bool parse_binary_modules = true;
 };
 
 using TokenTypePair = std::array<TokenType, 2>;

--- a/src/wast-parser.cc
+++ b/src/wast-parser.cc
@@ -3527,8 +3527,10 @@ Result WastParser::ParseModuleCommand(Script* script, CommandPtr* out_command) {
       options.features = options_->features;
       Errors errors;
       const char* filename = "<text>";
-      ReadBinaryIr(filename, bsm->data.data(), bsm->data.size(), options,
-                   &errors, module);
+      if (options_->parse_binary_modules) {
+        ReadBinaryIr(filename, bsm->data.data(), bsm->data.size(), options,
+                     &errors, module);
+      }
       module->name = bsm->name;
       module->loc = bsm->loc;
       for (const auto& error : errors) {


### PR DESCRIPTION
Enabled by default, this option implements the current behavior of WABT when it encounters "(module binary ...)" script modules. That is, it parses the binary module, reporting any errors that it sees.

When disabled, the binary module will be passed back to the WAST parser as unvalidated raw bytes. This allows for the use of WABT in places which want to provide invalid modules to module loaders (e.g. spec test runners).

Fixes https://github.com/WebAssembly/wabt/issues/2561.