### PR TITLE
wasm2c: Remove enum types from variadic get_func_type API

### DIFF
--- a/src/c-writer.cc
+++ b/src/c-writer.cc
@@ -2807,10 +2807,10 @@ void CWriter::WriteGetFuncType() {
     Write("va_start(args, result_count);", Newline());
     Write("if (true");
     for (const auto& t : signature.param_types) {
-      Write(" && va_arg(args, wasm_rt_type_t) == ", TypeEnum(t));
+      Write(" && va_arg(args, int) == ", TypeEnum(t));
     }
     for (const auto& t : signature.result_types) {
-      Write(" && va_arg(args, wasm_rt_type_t) == ", TypeEnum(t));
+      Write(" && va_arg(args, int) == ", TypeEnum(t));
     }
     Write(") ", OpenBrace());
     Write("va_end(args);", Newline());

--- a/test/wasm2c/add.txt
+++ b/test/wasm2c/add.txt
@@ -821,7 +821,7 @@ wasm_rt_func_type_t wasm2c_test_get_func_type(uint32_t param_count, uint32_t res
   
   if (param_count == 2 && result_count == 1) {
     va_start(args, result_count);
-    if (true && va_arg(args, wasm_rt_type_t) == WASM_RT_I32 && va_arg(args, wasm_rt_type_t) == WASM_RT_I32 && va_arg(args, wasm_rt_type_t) == WASM_RT_I32) {
+    if (true && va_arg(args, int) == WASM_RT_I32 && va_arg(args, int) == WASM_RT_I32 && va_arg(args, int) == WASM_RT_I32) {
       va_end(args);
       return w2c_test_t0;
     }

--- a/test/wasm2c/check-imports.txt
+++ b/test/wasm2c/check-imports.txt
@@ -887,7 +887,7 @@ wasm_rt_func_type_t wasm2c_test_get_func_type(uint32_t param_count, uint32_t res
   
   if (param_count == 1 && result_count == 1) {
     va_start(args, result_count);
-    if (true && va_arg(args, wasm_rt_type_t) == WASM_RT_I32 && va_arg(args, wasm_rt_type_t) == WASM_RT_I32) {
+    if (true && va_arg(args, int) == WASM_RT_I32 && va_arg(args, int) == WASM_RT_I32) {
       va_end(args);
       return w2c_test_t0;
     }
@@ -896,7 +896,7 @@ wasm_rt_func_type_t wasm2c_test_get_func_type(uint32_t param_count, uint32_t res
   
   if (param_count == 0 && result_count == 1) {
     va_start(args, result_count);
-    if (true && va_arg(args, wasm_rt_type_t) == WASM_RT_I32) {
+    if (true && va_arg(args, int) == WASM_RT_I32) {
       va_end(args);
       return w2c_test_t1;
     }
@@ -905,7 +905,7 @@ wasm_rt_func_type_t wasm2c_test_get_func_type(uint32_t param_count, uint32_t res
   
   if (param_count == 2 && result_count == 1) {
     va_start(args, result_count);
-    if (true && va_arg(args, wasm_rt_type_t) == WASM_RT_I32 && va_arg(args, wasm_rt_type_t) == WASM_RT_I32 && va_arg(args, wasm_rt_type_t) == WASM_RT_I32) {
+    if (true && va_arg(args, int) == WASM_RT_I32 && va_arg(args, int) == WASM_RT_I32 && va_arg(args, int) == WASM_RT_I32) {
       va_end(args);
       return w2c_test_t2;
     }

--- a/test/wasm2c/hello.txt
+++ b/test/wasm2c/hello.txt
@@ -917,7 +917,7 @@ wasm_rt_func_type_t wasm2c_test_get_func_type(uint32_t param_count, uint32_t res
   
   if (param_count == 4 && result_count == 1) {
     va_start(args, result_count);
-    if (true && va_arg(args, wasm_rt_type_t) == WASM_RT_I32 && va_arg(args, wasm_rt_type_t) == WASM_RT_I32 && va_arg(args, wasm_rt_type_t) == WASM_RT_I32 && va_arg(args, wasm_rt_type_t) == WASM_RT_I32 && va_arg(args, wasm_rt_type_t) == WASM_RT_I32) {
+    if (true && va_arg(args, int) == WASM_RT_I32 && va_arg(args, int) == WASM_RT_I32 && va_arg(args, int) == WASM_RT_I32 && va_arg(args, int) == WASM_RT_I32 && va_arg(args, int) == WASM_RT_I32) {
       va_end(args);
       return w2c_test_t0;
     }
@@ -926,7 +926,7 @@ wasm_rt_func_type_t wasm2c_test_get_func_type(uint32_t param_count, uint32_t res
   
   if (param_count == 1 && result_count == 0) {
     va_start(args, result_count);
-    if (true && va_arg(args, wasm_rt_type_t) == WASM_RT_I32) {
+    if (true && va_arg(args, int) == WASM_RT_I32) {
       va_end(args);
       return w2c_test_t1;
     }

--- a/test/wasm2c/tail-calls.txt
+++ b/test/wasm2c/tail-calls.txt
@@ -895,7 +895,7 @@ wasm_rt_func_type_t wasm2c_test_get_func_type(uint32_t param_count, uint32_t res
   
   if (param_count == 2 && result_count == 0) {
     va_start(args, result_count);
-    if (true && va_arg(args, wasm_rt_type_t) == WASM_RT_I32 && va_arg(args, wasm_rt_type_t) == WASM_RT_F32) {
+    if (true && va_arg(args, int) == WASM_RT_I32 && va_arg(args, int) == WASM_RT_F32) {
       va_end(args);
       return w2c_test_i32_f32;
     }
@@ -913,7 +913,7 @@ wasm_rt_func_type_t wasm2c_test_get_func_type(uint32_t param_count, uint32_t res
   
   if (param_count == 2 && result_count == 2) {
     va_start(args, result_count);
-    if (true && va_arg(args, wasm_rt_type_t) == WASM_RT_I32 && va_arg(args, wasm_rt_type_t) == WASM_RT_F64 && va_arg(args, wasm_rt_type_t) == WASM_RT_I32 && va_arg(args, wasm_rt_type_t) == WASM_RT_F64) {
+    if (true && va_arg(args, int) == WASM_RT_I32 && va_arg(args, int) == WASM_RT_F64 && va_arg(args, int) == WASM_RT_I32 && va_arg(args, int) == WASM_RT_F64) {
       va_end(args);
       return w2c_test_t2;
     }


### PR DESCRIPTION
Enum types in variadic functions aren't guaranteed to work. This is because enums for variadics undergo default argument promotion (promotion to int), and thus the user of `va_arg` should always get the argument as an `int`. Thus enums in varargs function would break on any compiler whose underlying representation is not an int (e.g., when using gcc's `-fshort-enums` flag)

https://stackoverflow.com/questions/73278375/do-enum-types-undergo-default-argument-promotion
https://stackoverflow.com/questions/24580503/error-when-pass-enum-in-a-function-with-variable-arguments/24580800#24580800

This pattern is used in the get_func_type function emitted as part of wasm2c modules. This PR changes this API to always use `int` for the var args.
