### PR TITLE
wasm2c: remove use of inline enum declarations

### DIFF
--- a/src/prebuilt/wasm2c_source_declarations.cc
+++ b/src/prebuilt/wasm2c_source_declarations.cc
@@ -1126,9 +1126,12 @@ R"w2c_template(  LOAD_DATA((*dest), dest_addr, src + src_addr, n);
 R"w2c_template(}
 )w2c_template"
 R"w2c_template(
+typedef enum { RefFunc, RefNull, GlobalGet } wasm_elem_segment_expr_type_t;
+)w2c_template"
+R"w2c_template(
 typedef struct {
 )w2c_template"
-R"w2c_template(  enum { RefFunc, RefNull, GlobalGet } expr_type;
+R"w2c_template(  wasm_elem_segment_expr_type_t expr_type;
 )w2c_template"
 R"w2c_template(  wasm_rt_func_type_t type;
 )w2c_template"

--- a/src/template/wasm2c.declarations.c
+++ b/src/template/wasm2c.declarations.c
@@ -602,8 +602,10 @@ static inline void memory_init(wasm_rt_memory_t* dest,
   LOAD_DATA((*dest), dest_addr, src + src_addr, n);
 }
 
+typedef enum { RefFunc, RefNull, GlobalGet } wasm_elem_segment_expr_type_t;
+
 typedef struct {
-  enum { RefFunc, RefNull, GlobalGet } expr_type;
+  wasm_elem_segment_expr_type_t expr_type;
   wasm_rt_func_type_t type;
   wasm_rt_function_ptr_t func;
   wasm_rt_tailcallee_t func_tailcallee;

--- a/test/wasm2c/add.txt
+++ b/test/wasm2c/add.txt
@@ -669,8 +669,10 @@ static inline void memory_init(wasm_rt_memory_t* dest,
   LOAD_DATA((*dest), dest_addr, src + src_addr, n);
 }
 
+typedef enum { RefFunc, RefNull, GlobalGet } wasm_elem_segment_expr_type_t;
+
 typedef struct {
-  enum { RefFunc, RefNull, GlobalGet } expr_type;
+  wasm_elem_segment_expr_type_t expr_type;
   wasm_rt_func_type_t type;
   wasm_rt_function_ptr_t func;
   wasm_rt_tailcallee_t func_tailcallee;

--- a/test/wasm2c/check-imports.txt
+++ b/test/wasm2c/check-imports.txt
@@ -694,8 +694,10 @@ static inline void memory_init(wasm_rt_memory_t* dest,
   LOAD_DATA((*dest), dest_addr, src + src_addr, n);
 }
 
+typedef enum { RefFunc, RefNull, GlobalGet } wasm_elem_segment_expr_type_t;
+
 typedef struct {
-  enum { RefFunc, RefNull, GlobalGet } expr_type;
+  wasm_elem_segment_expr_type_t expr_type;
   wasm_rt_func_type_t type;
   wasm_rt_function_ptr_t func;
   wasm_rt_tailcallee_t func_tailcallee;

--- a/test/wasm2c/export-names.txt
+++ b/test/wasm2c/export-names.txt
@@ -694,8 +694,10 @@ static inline void memory_init(wasm_rt_memory_t* dest,
   LOAD_DATA((*dest), dest_addr, src + src_addr, n);
 }
 
+typedef enum { RefFunc, RefNull, GlobalGet } wasm_elem_segment_expr_type_t;
+
 typedef struct {
-  enum { RefFunc, RefNull, GlobalGet } expr_type;
+  wasm_elem_segment_expr_type_t expr_type;
   wasm_rt_func_type_t type;
   wasm_rt_function_ptr_t func;
   wasm_rt_tailcallee_t func_tailcallee;

--- a/test/wasm2c/hello.txt
+++ b/test/wasm2c/hello.txt
@@ -701,8 +701,10 @@ static inline void memory_init(wasm_rt_memory_t* dest,
   LOAD_DATA((*dest), dest_addr, src + src_addr, n);
 }
 
+typedef enum { RefFunc, RefNull, GlobalGet } wasm_elem_segment_expr_type_t;
+
 typedef struct {
-  enum { RefFunc, RefNull, GlobalGet } expr_type;
+  wasm_elem_segment_expr_type_t expr_type;
   wasm_rt_func_type_t type;
   wasm_rt_function_ptr_t func;
   wasm_rt_tailcallee_t func_tailcallee;

--- a/test/wasm2c/minimal.txt
+++ b/test/wasm2c/minimal.txt
@@ -663,8 +663,10 @@ static inline void memory_init(wasm_rt_memory_t* dest,
   LOAD_DATA((*dest), dest_addr, src + src_addr, n);
 }
 
+typedef enum { RefFunc, RefNull, GlobalGet } wasm_elem_segment_expr_type_t;
+
 typedef struct {
-  enum { RefFunc, RefNull, GlobalGet } expr_type;
+  wasm_elem_segment_expr_type_t expr_type;
   wasm_rt_func_type_t type;
   wasm_rt_function_ptr_t func;
   wasm_rt_tailcallee_t func_tailcallee;

--- a/test/wasm2c/tail-calls.txt
+++ b/test/wasm2c/tail-calls.txt
@@ -693,8 +693,10 @@ static inline void memory_init(wasm_rt_memory_t* dest,
   LOAD_DATA((*dest), dest_addr, src + src_addr, n);
 }
 
+typedef enum { RefFunc, RefNull, GlobalGet } wasm_elem_segment_expr_type_t;
+
 typedef struct {
-  enum { RefFunc, RefNull, GlobalGet } expr_type;
+  wasm_elem_segment_expr_type_t expr_type;
   wasm_rt_func_type_t type;
   wasm_rt_function_ptr_t func;
   wasm_rt_tailcallee_t func_tailcallee;


### PR DESCRIPTION
Removing the use of inline enum definitions to (1) improve readability and (2) improve compatibility with some source analysis tools we are playing with. 
