### PR TITLE
Add missing in_function_body check to objdump

### DIFF
--- a/src/binary-reader-objdump.cc
+++ b/src/binary-reader-objdump.cc
@@ -797,8 +797,9 @@ Result BinaryReaderObjdumpDisassemble::OnOpcodeUint32(uint32_t value) {
 
 Result BinaryReaderObjdumpDisassemble::OnOpcodeUint32Uint32(uint32_t value,
                                                             uint32_t value2) {
-  if (!in_function_body)
+  if (!in_function_body) {
     return Result::Ok;
+  }
   std::string_view name;
   if (current_opcode == Opcode::MemoryInit &&
       !(name = GetSegmentName(value)).empty()) {
@@ -813,6 +814,9 @@ Result BinaryReaderObjdumpDisassemble::OnOpcodeUint32Uint32(uint32_t value,
 Result BinaryReaderObjdumpDisassemble::OnCallIndirectExpr(
     uint32_t sig_index,
     uint32_t table_index) {
+  if (!in_function_body) {
+    return Result::Ok;
+  }
   std::string_view table_name = GetTableName(table_index);
   std::string_view type_name = GetTypeName(sig_index);
   if (!type_name.empty() && !table_name.empty()) {

--- a/test/binary/bad-init-expr-callindirect.txt
+++ b/test/binary/bad-init-expr-callindirect.txt
@@ -1,0 +1,20 @@
+;;; TOOL: run-objdump-gen-wasm
+;;; ARGS1: -x
+magic
+version
+section(GLOBAL) {
+  count[1]
+  type[i32] mut[0] init_expr[call_indirect 0 0 end]
+}
+(;; STDOUT ;;;
+
+bad-init-expr-callindirect.wasm:	file format wasm 0x1
+
+Section Details:
+
+Global[1]:
+ - global[0] i32 mutable=0 - init <INVALID>
+
+Code Disassembly:
+
+;;; STDOUT ;;)


### PR DESCRIPTION
Fixes the fuzzer bug in #2567

I noticed all objdump logs are guarded by `if (!in_function_body)`. The code crashes without this check.
