### PR TITLE
wasm2c: add check to avoid mprotect on zero sizes

### DIFF
--- a/wasm2c/wasm-rt-mem-impl.c
+++ b/wasm2c/wasm-rt-mem-impl.c
@@ -109,6 +109,9 @@ static int os_munmap(void* addr, size_t size) {
 }
 
 static int os_mprotect(void* addr, size_t size) {
+  if (size == 0) {
+    return 0;
+  }
   return mprotect(addr, size, PROT_READ | PROT_WRITE);
 }
 


### PR DESCRIPTION
QEmu's mprotect implementation doesn't seem to handle calls with a zero size