### PR TITLE
Remove --enable-gc from help text

### DIFF
--- a/test/help/wat2wasm.txt
+++ b/test/help/wat2wasm.txt
@@ -36,7 +36,6 @@ options:
       --disable-reference-types                Disable Reference types (externref)
       --enable-annotations                     Enable Custom annotation syntax
       --enable-code-metadata                   Enable Code metadata
-      --enable-gc                              Enable Garbage collection
       --enable-memory64                        Enable 64-bit memory
       --enable-multi-memory                    Enable Multi-memory
       --enable-extended-const                  Enable Extended constant expressions


### PR DESCRIPTION
According to issue #2530 the GC proposal is not supported by wat2asm. Having --enable-gc in the help text gives a false impression.