### PR TITLE
fix mismatch between ExprTypeName and ExprType

### DIFF
--- a/src/ir.cc
+++ b/src/ir.cc
@@ -25,12 +25,12 @@
 namespace {
 
 const char* ExprTypeName[] = {
-    "AtomicFence",
     "AtomicLoad",
     "AtomicRmw",
     "AtomicRmwCmpxchg",
     "AtomicStore",
     "AtomicNotify",
+    "AtomicFence",
     "AtomicWait",
     "Binary",
     "Block",


### PR DESCRIPTION
There is an inconsistency between the order of enum values in `ExprType` (defined in `ir.h`) and the corresponding string names in `ExprTypeName` array (defined in `ir.cc`). This causes `GetExprTypeName()` to return incorrect string representations for atomic operation related expression types.
In `ir.h` (`ExprType` enum):
```cpp
enum class ExprType {
  AtomicLoad,        // index 0
  AtomicRmw,         // index 1  
  AtomicRmwCmpxchg,  // index 2
  AtomicStore,       // index 3
  AtomicNotify,      // index 4
  AtomicFence,       // index 5
  AtomicWait,        // index 6
  // ... rest of enum values
};
```
In `ir.cc` (`ExprTypeName` array):
```cpp
const char* ExprTypeName[] = {
    "AtomicFence",     // index 0 - should correspond to AtomicLoad
    "AtomicLoad",      // index 1 - should correspond to AtomicRmw
    "AtomicRmw",       // index 2 - should correspond to AtomicRmwCmpxchg
    "AtomicRmwCmpxchg", // index 3 - should correspond to AtomicStore
    "AtomicStore",     // index 4 - should correspond to AtomicNotify
    "AtomicNotify",    // index 5 - should correspond to AtomicFence
    "AtomicWait",      // index 6 - correct position
    // ... rest matches correctly
};
```
The error occurs in these functions:
In `ir.cc`:
```cpp
const char* GetExprTypeName(ExprType type) {
  static_assert(WABT_ENUM_COUNT(ExprType) == WABT_ARRAY_SIZE(ExprTypeName),
                "Malformed ExprTypeName array");
  return ExprTypeName[size_t(type)];  // Returns wrong name due to index mismatch
}

const char* GetExprTypeName(const Expr& expr) {
  return GetExprTypeName(expr.type());  // Inherits the same issue
}
```