### PR TITLE
fix FORCE_READ for ez80

### DIFF
--- a/src/prebuilt/wasm2c_source_declarations.cc
+++ b/src/prebuilt/wasm2c_source_declarations.cc
@@ -256,7 +256,7 @@ R"w2c_template(  WASM_RT_CHECK_BASE(mem);          \
 R"w2c_template(  RANGE_CHECK(mem, a, sizeof(t));
 )w2c_template"
 R"w2c_template(
-#ifdef __GNUC__
+#if defined(__GNUC__) && __SIZEOF_POINTER__ >= 4
 )w2c_template"
 R"w2c_template(#define FORCE_READ_INT(var) __asm__("" ::"r"(var));
 )w2c_template"

--- a/src/prebuilt/wasm2c_source_declarations.cc
+++ b/src/prebuilt/wasm2c_source_declarations.cc
@@ -256,7 +256,7 @@ R"w2c_template(  WASM_RT_CHECK_BASE(mem);          \
 R"w2c_template(  RANGE_CHECK(mem, a, sizeof(t));
 )w2c_template"
 R"w2c_template(
-#if defined(__GNUC__) && __SIZEOF_POINTER__ >= 4
+#if defined(__GNUC__) && !(defined(_EZ80) || defined(__ez80) || defined(__ez80__))
 )w2c_template"
 R"w2c_template(#define FORCE_READ_INT(var) __asm__("" ::"r"(var));
 )w2c_template"

--- a/src/prebuilt/wasm2c_source_declarations.cc
+++ b/src/prebuilt/wasm2c_source_declarations.cc
@@ -256,7 +256,8 @@ R"w2c_template(  WASM_RT_CHECK_BASE(mem);          \
 R"w2c_template(  RANGE_CHECK(mem, a, sizeof(t));
 )w2c_template"
 R"w2c_template(
-#if defined(__GNUC__) && !(defined(_EZ80) || defined(__ez80) || defined(__ez80__))
+#if defined(__GNUC__) && \
+    !(defined(_EZ80) || defined(__ez80) || defined(__ez80__))
 )w2c_template"
 R"w2c_template(#define FORCE_READ_INT(var) __asm__("" ::"r"(var));
 )w2c_template"

--- a/src/template/wasm2c.declarations.c
+++ b/src/template/wasm2c.declarations.c
@@ -137,7 +137,7 @@ static inline bool add_overflow(uint64_t a, uint64_t b, uint64_t* resptr) {
   WASM_RT_CHECK_BASE(mem);          \
   RANGE_CHECK(mem, a, sizeof(t));
 
-#if defined(__GNUC__) && __SIZEOF_POINTER__ >= 4
+#if defined(__GNUC__) && !(defined(_EZ80) || defined(__ez80) || defined(__ez80__))
 #define FORCE_READ_INT(var) __asm__("" ::"r"(var));
 // Clang on Mips requires "f" constraints on floats
 // See https://github.com/llvm/llvm-project/issues/64241

--- a/src/template/wasm2c.declarations.c
+++ b/src/template/wasm2c.declarations.c
@@ -137,7 +137,7 @@ static inline bool add_overflow(uint64_t a, uint64_t b, uint64_t* resptr) {
   WASM_RT_CHECK_BASE(mem);          \
   RANGE_CHECK(mem, a, sizeof(t));
 
-#ifdef __GNUC__
+#if defined(__GNUC__) && __SIZEOF_POINTER__ >= 4
 #define FORCE_READ_INT(var) __asm__("" ::"r"(var));
 // Clang on Mips requires "f" constraints on floats
 // See https://github.com/llvm/llvm-project/issues/64241

--- a/src/template/wasm2c.declarations.c
+++ b/src/template/wasm2c.declarations.c
@@ -137,7 +137,8 @@ static inline bool add_overflow(uint64_t a, uint64_t b, uint64_t* resptr) {
   WASM_RT_CHECK_BASE(mem);          \
   RANGE_CHECK(mem, a, sizeof(t));
 
-#if defined(__GNUC__) && !(defined(_EZ80) || defined(__ez80) || defined(__ez80__))
+#if defined(__GNUC__) && \
+    !(defined(_EZ80) || defined(__ez80) || defined(__ez80__))
 #define FORCE_READ_INT(var) __asm__("" ::"r"(var));
 // Clang on Mips requires "f" constraints on floats
 // See https://github.com/llvm/llvm-project/issues/64241

--- a/test/wasm2c/add.txt
+++ b/test/wasm2c/add.txt
@@ -204,7 +204,7 @@ static inline bool add_overflow(uint64_t a, uint64_t b, uint64_t* resptr) {
   WASM_RT_CHECK_BASE(mem);          \
   RANGE_CHECK(mem, a, sizeof(t));
 
-#ifdef __GNUC__
+#if defined(__GNUC__) && __SIZEOF_POINTER__ >= 4
 #define FORCE_READ_INT(var) __asm__("" ::"r"(var));
 // Clang on Mips requires "f" constraints on floats
 // See https://github.com/llvm/llvm-project/issues/64241

--- a/test/wasm2c/add.txt
+++ b/test/wasm2c/add.txt
@@ -204,7 +204,8 @@ static inline bool add_overflow(uint64_t a, uint64_t b, uint64_t* resptr) {
   WASM_RT_CHECK_BASE(mem);          \
   RANGE_CHECK(mem, a, sizeof(t));
 
-#if defined(__GNUC__) && !(defined(_EZ80) || defined(__ez80) || defined(__ez80__))
+#if defined(__GNUC__) && \
+    !(defined(_EZ80) || defined(__ez80) || defined(__ez80__))
 #define FORCE_READ_INT(var) __asm__("" ::"r"(var));
 // Clang on Mips requires "f" constraints on floats
 // See https://github.com/llvm/llvm-project/issues/64241

--- a/test/wasm2c/add.txt
+++ b/test/wasm2c/add.txt
@@ -204,7 +204,7 @@ static inline bool add_overflow(uint64_t a, uint64_t b, uint64_t* resptr) {
   WASM_RT_CHECK_BASE(mem);          \
   RANGE_CHECK(mem, a, sizeof(t));
 
-#if defined(__GNUC__) && __SIZEOF_POINTER__ >= 4
+#if defined(__GNUC__) && !(defined(_EZ80) || defined(__ez80) || defined(__ez80__))
 #define FORCE_READ_INT(var) __asm__("" ::"r"(var));
 // Clang on Mips requires "f" constraints on floats
 // See https://github.com/llvm/llvm-project/issues/64241

--- a/test/wasm2c/check-imports.txt
+++ b/test/wasm2c/check-imports.txt
@@ -229,7 +229,7 @@ static inline bool add_overflow(uint64_t a, uint64_t b, uint64_t* resptr) {
   WASM_RT_CHECK_BASE(mem);          \
   RANGE_CHECK(mem, a, sizeof(t));
 
-#ifdef __GNUC__
+#if defined(__GNUC__) && __SIZEOF_POINTER__ >= 4
 #define FORCE_READ_INT(var) __asm__("" ::"r"(var));
 // Clang on Mips requires "f" constraints on floats
 // See https://github.com/llvm/llvm-project/issues/64241

--- a/test/wasm2c/check-imports.txt
+++ b/test/wasm2c/check-imports.txt
@@ -229,7 +229,7 @@ static inline bool add_overflow(uint64_t a, uint64_t b, uint64_t* resptr) {
   WASM_RT_CHECK_BASE(mem);          \
   RANGE_CHECK(mem, a, sizeof(t));
 
-#if defined(__GNUC__) && __SIZEOF_POINTER__ >= 4
+#if defined(__GNUC__) && !(defined(_EZ80) || defined(__ez80) || defined(__ez80__))
 #define FORCE_READ_INT(var) __asm__("" ::"r"(var));
 // Clang on Mips requires "f" constraints on floats
 // See https://github.com/llvm/llvm-project/issues/64241

--- a/test/wasm2c/check-imports.txt
+++ b/test/wasm2c/check-imports.txt
@@ -229,7 +229,8 @@ static inline bool add_overflow(uint64_t a, uint64_t b, uint64_t* resptr) {
   WASM_RT_CHECK_BASE(mem);          \
   RANGE_CHECK(mem, a, sizeof(t));
 
-#if defined(__GNUC__) && !(defined(_EZ80) || defined(__ez80) || defined(__ez80__))
+#if defined(__GNUC__) && \
+    !(defined(_EZ80) || defined(__ez80) || defined(__ez80__))
 #define FORCE_READ_INT(var) __asm__("" ::"r"(var));
 // Clang on Mips requires "f" constraints on floats
 // See https://github.com/llvm/llvm-project/issues/64241

--- a/test/wasm2c/export-names.txt
+++ b/test/wasm2c/export-names.txt
@@ -229,7 +229,7 @@ static inline bool add_overflow(uint64_t a, uint64_t b, uint64_t* resptr) {
   WASM_RT_CHECK_BASE(mem);          \
   RANGE_CHECK(mem, a, sizeof(t));
 
-#ifdef __GNUC__
+#if defined(__GNUC__) && __SIZEOF_POINTER__ >= 4
 #define FORCE_READ_INT(var) __asm__("" ::"r"(var));
 // Clang on Mips requires "f" constraints on floats
 // See https://github.com/llvm/llvm-project/issues/64241

--- a/test/wasm2c/export-names.txt
+++ b/test/wasm2c/export-names.txt
@@ -229,7 +229,7 @@ static inline bool add_overflow(uint64_t a, uint64_t b, uint64_t* resptr) {
   WASM_RT_CHECK_BASE(mem);          \
   RANGE_CHECK(mem, a, sizeof(t));
 
-#if defined(__GNUC__) && __SIZEOF_POINTER__ >= 4
+#if defined(__GNUC__) && !(defined(_EZ80) || defined(__ez80) || defined(__ez80__))
 #define FORCE_READ_INT(var) __asm__("" ::"r"(var));
 // Clang on Mips requires "f" constraints on floats
 // See https://github.com/llvm/llvm-project/issues/64241

--- a/test/wasm2c/export-names.txt
+++ b/test/wasm2c/export-names.txt
@@ -229,7 +229,8 @@ static inline bool add_overflow(uint64_t a, uint64_t b, uint64_t* resptr) {
   WASM_RT_CHECK_BASE(mem);          \
   RANGE_CHECK(mem, a, sizeof(t));
 
-#if defined(__GNUC__) && !(defined(_EZ80) || defined(__ez80) || defined(__ez80__))
+#if defined(__GNUC__) && \
+    !(defined(_EZ80) || defined(__ez80) || defined(__ez80__))
 #define FORCE_READ_INT(var) __asm__("" ::"r"(var));
 // Clang on Mips requires "f" constraints on floats
 // See https://github.com/llvm/llvm-project/issues/64241

--- a/test/wasm2c/hello.txt
+++ b/test/wasm2c/hello.txt
@@ -236,7 +236,7 @@ static inline bool add_overflow(uint64_t a, uint64_t b, uint64_t* resptr) {
   WASM_RT_CHECK_BASE(mem);          \
   RANGE_CHECK(mem, a, sizeof(t));
 
-#if defined(__GNUC__) && __SIZEOF_POINTER__ >= 4
+#if defined(__GNUC__) && !(defined(_EZ80) || defined(__ez80) || defined(__ez80__))
 #define FORCE_READ_INT(var) __asm__("" ::"r"(var));
 // Clang on Mips requires "f" constraints on floats
 // See https://github.com/llvm/llvm-project/issues/64241

--- a/test/wasm2c/hello.txt
+++ b/test/wasm2c/hello.txt
@@ -236,7 +236,8 @@ static inline bool add_overflow(uint64_t a, uint64_t b, uint64_t* resptr) {
   WASM_RT_CHECK_BASE(mem);          \
   RANGE_CHECK(mem, a, sizeof(t));
 
-#if defined(__GNUC__) && !(defined(_EZ80) || defined(__ez80) || defined(__ez80__))
+#if defined(__GNUC__) && \
+    !(defined(_EZ80) || defined(__ez80) || defined(__ez80__))
 #define FORCE_READ_INT(var) __asm__("" ::"r"(var));
 // Clang on Mips requires "f" constraints on floats
 // See https://github.com/llvm/llvm-project/issues/64241

--- a/test/wasm2c/hello.txt
+++ b/test/wasm2c/hello.txt
@@ -236,7 +236,7 @@ static inline bool add_overflow(uint64_t a, uint64_t b, uint64_t* resptr) {
   WASM_RT_CHECK_BASE(mem);          \
   RANGE_CHECK(mem, a, sizeof(t));
 
-#ifdef __GNUC__
+#if defined(__GNUC__) && __SIZEOF_POINTER__ >= 4
 #define FORCE_READ_INT(var) __asm__("" ::"r"(var));
 // Clang on Mips requires "f" constraints on floats
 // See https://github.com/llvm/llvm-project/issues/64241

--- a/test/wasm2c/minimal.txt
+++ b/test/wasm2c/minimal.txt
@@ -198,7 +198,8 @@ static inline bool add_overflow(uint64_t a, uint64_t b, uint64_t* resptr) {
   WASM_RT_CHECK_BASE(mem);          \
   RANGE_CHECK(mem, a, sizeof(t));
 
-#if defined(__GNUC__) && !(defined(_EZ80) || defined(__ez80) || defined(__ez80__))
+#if defined(__GNUC__) && \
+    !(defined(_EZ80) || defined(__ez80) || defined(__ez80__))
 #define FORCE_READ_INT(var) __asm__("" ::"r"(var));
 // Clang on Mips requires "f" constraints on floats
 // See https://github.com/llvm/llvm-project/issues/64241

--- a/test/wasm2c/minimal.txt
+++ b/test/wasm2c/minimal.txt
@@ -198,7 +198,7 @@ static inline bool add_overflow(uint64_t a, uint64_t b, uint64_t* resptr) {
   WASM_RT_CHECK_BASE(mem);          \
   RANGE_CHECK(mem, a, sizeof(t));
 
-#ifdef __GNUC__
+#if defined(__GNUC__) && __SIZEOF_POINTER__ >= 4
 #define FORCE_READ_INT(var) __asm__("" ::"r"(var));
 // Clang on Mips requires "f" constraints on floats
 // See https://github.com/llvm/llvm-project/issues/64241

--- a/test/wasm2c/minimal.txt
+++ b/test/wasm2c/minimal.txt
@@ -198,7 +198,7 @@ static inline bool add_overflow(uint64_t a, uint64_t b, uint64_t* resptr) {
   WASM_RT_CHECK_BASE(mem);          \
   RANGE_CHECK(mem, a, sizeof(t));
 
-#if defined(__GNUC__) && __SIZEOF_POINTER__ >= 4
+#if defined(__GNUC__) && !(defined(_EZ80) || defined(__ez80) || defined(__ez80__))
 #define FORCE_READ_INT(var) __asm__("" ::"r"(var));
 // Clang on Mips requires "f" constraints on floats
 // See https://github.com/llvm/llvm-project/issues/64241

--- a/test/wasm2c/tail-calls.txt
+++ b/test/wasm2c/tail-calls.txt
@@ -228,7 +228,8 @@ static inline bool add_overflow(uint64_t a, uint64_t b, uint64_t* resptr) {
   WASM_RT_CHECK_BASE(mem);          \
   RANGE_CHECK(mem, a, sizeof(t));
 
-#if defined(__GNUC__) && !(defined(_EZ80) || defined(__ez80) || defined(__ez80__))
+#if defined(__GNUC__) && \
+    !(defined(_EZ80) || defined(__ez80) || defined(__ez80__))
 #define FORCE_READ_INT(var) __asm__("" ::"r"(var));
 // Clang on Mips requires "f" constraints on floats
 // See https://github.com/llvm/llvm-project/issues/64241

--- a/test/wasm2c/tail-calls.txt
+++ b/test/wasm2c/tail-calls.txt
@@ -228,7 +228,7 @@ static inline bool add_overflow(uint64_t a, uint64_t b, uint64_t* resptr) {
   WASM_RT_CHECK_BASE(mem);          \
   RANGE_CHECK(mem, a, sizeof(t));
 
-#ifdef __GNUC__
+#if defined(__GNUC__) && __SIZEOF_POINTER__ >= 4
 #define FORCE_READ_INT(var) __asm__("" ::"r"(var));
 // Clang on Mips requires "f" constraints on floats
 // See https://github.com/llvm/llvm-project/issues/64241

--- a/test/wasm2c/tail-calls.txt
+++ b/test/wasm2c/tail-calls.txt
@@ -228,7 +228,7 @@ static inline bool add_overflow(uint64_t a, uint64_t b, uint64_t* resptr) {
   WASM_RT_CHECK_BASE(mem);          \
   RANGE_CHECK(mem, a, sizeof(t));
 
-#if defined(__GNUC__) && __SIZEOF_POINTER__ >= 4
+#if defined(__GNUC__) && !(defined(_EZ80) || defined(__ez80) || defined(__ez80__))
 #define FORCE_READ_INT(var) __asm__("" ::"r"(var));
 // Clang on Mips requires "f" constraints on floats
 // See https://github.com/llvm/llvm-project/issues/64241

--- a/wasm2c/benchmarks/dhrystone/main.c
+++ b/wasm2c/benchmarks/dhrystone/main.c
@@ -38,7 +38,8 @@ static inline void memory_fill(wasm_rt_memory_t* mem, u32 d, u32 val, u32 n) {
 
 #define MEMCHECK(mem, a, t) RANGE_CHECK(mem, a, sizeof(t))
 
-#if defined(__GNUC__) && !(defined(_EZ80) || defined(__ez80) || defined(__ez80__))
+#if defined(__GNUC__) && \
+    !(defined(_EZ80) || defined(__ez80) || defined(__ez80__))
 #define FORCE_READ_INT(var) __asm__("" ::"r"(var));
 #else
 #define FORCE_READ_INT(var)

--- a/wasm2c/benchmarks/dhrystone/main.c
+++ b/wasm2c/benchmarks/dhrystone/main.c
@@ -38,7 +38,7 @@ static inline void memory_fill(wasm_rt_memory_t* mem, u32 d, u32 val, u32 n) {
 
 #define MEMCHECK(mem, a, t) RANGE_CHECK(mem, a, sizeof(t))
 
-#if defined(__GNUC__) && __SIZEOF_POINTER__ >= 4
+#if defined(__GNUC__) && !(defined(_EZ80) || defined(__ez80) || defined(__ez80__))
 #define FORCE_READ_INT(var) __asm__("" ::"r"(var));
 #else
 #define FORCE_READ_INT(var)

--- a/wasm2c/benchmarks/dhrystone/main.c
+++ b/wasm2c/benchmarks/dhrystone/main.c
@@ -38,7 +38,7 @@ static inline void memory_fill(wasm_rt_memory_t* mem, u32 d, u32 val, u32 n) {
 
 #define MEMCHECK(mem, a, t) RANGE_CHECK(mem, a, sizeof(t))
 
-#ifdef __GNUC__
+#if defined(__GNUC__) && __SIZEOF_POINTER__ >= 4
 #define FORCE_READ_INT(var) __asm__("" ::"r"(var));
 #else
 #define FORCE_READ_INT(var)

--- a/wasm2c/examples/fac/fac.c
+++ b/wasm2c/examples/fac/fac.c
@@ -156,7 +156,7 @@ static inline bool add_overflow(uint64_t a, uint64_t b, uint64_t* resptr) {
   WASM_RT_CHECK_BASE(mem);          \
   RANGE_CHECK(mem, a, sizeof(t));
 
-#if defined(__GNUC__) && __SIZEOF_POINTER__ >= 4
+#if defined(__GNUC__) && !(defined(_EZ80) || defined(__ez80) || defined(__ez80__))
 #define FORCE_READ_INT(var) __asm__("" ::"r"(var));
 // Clang on Mips requires "f" constraints on floats
 // See https://github.com/llvm/llvm-project/issues/64241

--- a/wasm2c/examples/fac/fac.c
+++ b/wasm2c/examples/fac/fac.c
@@ -156,7 +156,8 @@ static inline bool add_overflow(uint64_t a, uint64_t b, uint64_t* resptr) {
   WASM_RT_CHECK_BASE(mem);          \
   RANGE_CHECK(mem, a, sizeof(t));
 
-#if defined(__GNUC__) && !(defined(_EZ80) || defined(__ez80) || defined(__ez80__))
+#if defined(__GNUC__) && \
+    !(defined(_EZ80) || defined(__ez80) || defined(__ez80__))
 #define FORCE_READ_INT(var) __asm__("" ::"r"(var));
 // Clang on Mips requires "f" constraints on floats
 // See https://github.com/llvm/llvm-project/issues/64241

--- a/wasm2c/examples/fac/fac.c
+++ b/wasm2c/examples/fac/fac.c
@@ -156,7 +156,7 @@ static inline bool add_overflow(uint64_t a, uint64_t b, uint64_t* resptr) {
   WASM_RT_CHECK_BASE(mem);          \
   RANGE_CHECK(mem, a, sizeof(t));
 
-#ifdef __GNUC__
+#if defined(__GNUC__) && __SIZEOF_POINTER__ >= 4
 #define FORCE_READ_INT(var) __asm__("" ::"r"(var));
 // Clang on Mips requires "f" constraints on floats
 // See https://github.com/llvm/llvm-project/issues/64241


### PR DESCRIPTION
Allow to compile the output code on architecture who have register of less then 32-bit (like ez80)