### PR TITLE
Update HTML doc

### DIFF
--- a/docs/doc/spectest-interp.1.html
+++ b/docs/doc/spectest-interp.1.html
@@ -2,17 +2,17 @@
 <html>
 <head>
   <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <style>
     table.head, table.foot { width: 100%; }
     td.head-rtitle, td.foot-os { text-align: right; }
     td.head-vol { text-align: center; }
-    div.Pp { margin: 1ex 0ex; }
-    div.Nd, div.Bf, div.Op { display: inline; }
-    span.Pa, span.Ad { font-style: italic; }
-    span.Ms { font-weight: bold; }
-    dl.Bl-diag > dt { font-weight: bold; }
-    code.Nm, code.Fl, code.Cm, code.Ic, code.In, code.Fd, code.Fn,
-    code.Cd { font-weight: bold; font-family: inherit; }
+    .Nd, .Bf, .Op { display: inline; }
+    .Pa, .Ad { font-style: italic; }
+    .Ms { font-weight: bold; }
+    .Bl-diag > dt { font-weight: bold; }
+    code.Nm, .Fl, .Cm, .Ic, code.In, .Fd, .Fn, .Cd { font-weight: bold;
+      font-family: inherit; }
   </style>
   <title>WABT(1)</title>
 </head>
@@ -27,9 +27,9 @@
 <div class="manual-text">
 <section class="Sh">
 <h1 class="Sh" id="NAME"><a class="permalink" href="#NAME">NAME</a></h1>
-<code class="Nm">spectest-interp</code> &#x2014;
-<div class="Nd">read a Spectest JSON file, and run its tests in the
-  interpreter</div>
+<p class="Pp"><code class="Nm">spectest-interp</code> &#x2014;
+    <span class="Nd">read a Spectest JSON file, and run its tests in the
+    interpreter</span></p>
 </section>
 <section class="Sh">
 <h1 class="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h1>
@@ -42,45 +42,67 @@
 </section>
 <section class="Sh">
 <h1 class="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h1>
-<code class="Nm">spectest-interp</code> reads a Spectest JSON file, and runs its
-  tests in the interpreter.
+<p class="Pp"><code class="Nm">spectest-interp</code> Reads a Spectest JSON
+    file, and runs its tests in the interpreter.</p>
 <p class="Pp">The options are as follows:</p>
 <dl class="Bl-tag">
-  <dt><a class="permalink" href="#v"><code class="Fl" id="v">-v</code></a>,
-    <code class="Fl">-</code><code class="Fl">-verbose</code></dt>
+  <dt id="help"><a class="permalink" href="#help"><code class="Fl">--help</code></a></dt>
+  <dd>Print a help message</dd>
+  <dt id="version"><a class="permalink" href="#version"><code class="Fl">--version</code></a></dt>
+  <dd>Print version information</dd>
+  <dt id="v"><a class="permalink" href="#v"><code class="Fl">-v</code></a>,
+    <code class="Fl">--verbose</code></dt>
   <dd>Use multiple times for more info</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-help</code></dt>
-  <dd>Print this help message</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-enable-exceptions</code></dt>
+  <dt id="enable-exceptions"><a class="permalink" href="#enable-exceptions"><code class="Fl">--enable-exceptions</code></a></dt>
   <dd>Enable Experimental exception handling</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-disable-mutable-globals</code></dt>
+  <dt id="disable-mutable-globals"><a class="permalink" href="#disable-mutable-globals"><code class="Fl">--disable-mutable-globals</code></a></dt>
   <dd>Disable Import/export mutable globals</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-enable-saturating-float-to-int</code></dt>
-  <dd>Enable Saturating float-to-int operators</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-enable-sign-extension</code></dt>
-  <dd>Enable Sign-extension operators</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-disable-simd</code></dt>
+  <dt id="disable-saturating-float-to-int"><a class="permalink" href="#disable-saturating-float-to-int"><code class="Fl">--disable-saturating-float-to-int</code></a></dt>
+  <dd>Disable Saturating float-to-int operators</dd>
+  <dt id="disable-sign-extension"><a class="permalink" href="#disable-sign-extension"><code class="Fl">--disable-sign-extension</code></a></dt>
+  <dd>Disable Sign-extension operators</dd>
+  <dt id="disable-simd"><a class="permalink" href="#disable-simd"><code class="Fl">--disable-simd</code></a></dt>
   <dd>Disable SIMD support</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-enable-threads</code></dt>
+  <dt id="enable-threads"><a class="permalink" href="#enable-threads"><code class="Fl">--enable-threads</code></a></dt>
   <dd>Enable Threading support</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-enable-multi-value</code></dt>
-  <dd>Enable Multi-value</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-enable-tail-call</code></dt>
+  <dt id="enable-function-references"><a class="permalink" href="#enable-function-references"><code class="Fl">--enable-function-references</code></a></dt>
+  <dd>Enable Typed function references</dd>
+  <dt id="disable-multi-value"><a class="permalink" href="#disable-multi-value"><code class="Fl">--disable-multi-value</code></a></dt>
+  <dd>Disable Multi-value</dd>
+  <dt id="enable-tail-call"><a class="permalink" href="#enable-tail-call"><code class="Fl">--enable-tail-call</code></a></dt>
   <dd>Enable Tail-call support</dd>
-  <dt><a class="permalink" href="#V"><code class="Fl" id="V">-V</code></a>,
-    <code class="Fl">-</code><code class="Fl">-value-stack-size=SIZE</code></dt>
+  <dt id="disable-bulk-memory"><a class="permalink" href="#disable-bulk-memory"><code class="Fl">--disable-bulk-memory</code></a></dt>
+  <dd>Disable Bulk-memory operations</dd>
+  <dt id="disable-reference-types"><a class="permalink" href="#disable-reference-types"><code class="Fl">--disable-reference-types</code></a></dt>
+  <dd>Disable Reference types (externref)</dd>
+  <dt id="enable-annotations"><a class="permalink" href="#enable-annotations"><code class="Fl">--enable-annotations</code></a></dt>
+  <dd>Enable Custom annotation syntax</dd>
+  <dt id="enable-code-metadata"><a class="permalink" href="#enable-code-metadata"><code class="Fl">--enable-code-metadata</code></a></dt>
+  <dd>Enable Code metadata</dd>
+  <dt id="enable-gc"><a class="permalink" href="#enable-gc"><code class="Fl">--enable-gc</code></a></dt>
+  <dd>Enable Garbage collection</dd>
+  <dt id="enable-memory64"><a class="permalink" href="#enable-memory64"><code class="Fl">--enable-memory64</code></a></dt>
+  <dd>Enable 64-bit memory</dd>
+  <dt id="enable-multi-memory"><a class="permalink" href="#enable-multi-memory"><code class="Fl">--enable-multi-memory</code></a></dt>
+  <dd>Enable Multi-memory</dd>
+  <dt id="enable-extended-const"><a class="permalink" href="#enable-extended-const"><code class="Fl">--enable-extended-const</code></a></dt>
+  <dd>Enable Extended constant expressions</dd>
+  <dt id="enable-all"><a class="permalink" href="#enable-all"><code class="Fl">--enable-all</code></a></dt>
+  <dd>Enable all features</dd>
+  <dt id="V"><a class="permalink" href="#V"><code class="Fl">-V</code></a>,
+    <code class="Fl">--value-stack-size=SIZE</code></dt>
   <dd>Size in elements of the value stack</dd>
-  <dt><a class="permalink" href="#C"><code class="Fl" id="C">-C</code></a>,
-    <code class="Fl">-</code><code class="Fl">-call-stack-size=SIZE</code></dt>
+  <dt id="C"><a class="permalink" href="#C"><code class="Fl">-C</code></a>,
+    <code class="Fl">--call-stack-size=SIZE</code></dt>
   <dd>Size in elements of the call stack</dd>
-  <dt><a class="permalink" href="#t"><code class="Fl" id="t">-t</code></a>,
-    <code class="Fl">-</code><code class="Fl">-trace</code></dt>
+  <dt id="t"><a class="permalink" href="#t"><code class="Fl">-t</code></a>,
+    <code class="Fl">--trace</code></dt>
   <dd>Trace execution</dd>
 </dl>
 </section>
 <section class="Sh">
 <h1 class="Sh" id="EXAMPLES"><a class="permalink" href="#EXAMPLES">EXAMPLES</a></h1>
-Parse test.json and run the spec tests
+<p class="Pp">Parse test.json and run the spec tests</p>
 <p class="Pp"></p>
 <div class="Bd Bd-indent"><code class="Li">$ spectest-interp
   test.json</code></div>
@@ -88,27 +110,28 @@ Parse test.json and run the spec tests
 <section class="Sh">
 <h1 class="Sh" id="SEE_ALSO"><a class="permalink" href="#SEE_ALSO">SEE
   ALSO</a></h1>
-<a class="Xr" href="wasm-interp.1.html">wasm-interp(1)</a>,
-  <a class="Xr" href="wasm-objdump.1.html">wasm-objdump(1)</a>,
-  <a class="Xr" href="wasm-stats.1.html">wasm-stats(1)</a>,
-  <a class="Xr" href="wasm-strip.1.html">wasm-strip(1)</a>,
-  <a class="Xr" href="wasm-validate.1.html">wasm-validate(1)</a>,
-  <a class="Xr" href="wasm2c.1.html">wasm2c(1)</a>,
-  <a class="Xr" href="wasm2wat.1.html">wasm2wat(1)</a>,
-  <a class="Xr" href="wast2json.1.html">wast2json(1)</a>,
-  <a class="Xr" href="wat-desugar.1.html">wat-desugar(1)</a>,
-  <a class="Xr" href="wat2wasm.1.html">wat2wasm(1)</a>
+<p class="Pp"><a class="Xr" href="wasm-decompile.1.html">wasm-decompile(1)</a>,
+    <a class="Xr" href="wasm-interp.1.html">wasm-interp(1)</a>,
+    <a class="Xr" href="wasm-objdump.1.html">wasm-objdump(1)</a>,
+    <a class="Xr" href="wasm-stats.1.html">wasm-stats(1)</a>,
+    <a class="Xr" href="wasm-strip.1.html">wasm-strip(1)</a>,
+    <a class="Xr" href="wasm-validate.1.html">wasm-validate(1)</a>,
+    <a class="Xr" href="wasm2c.1.html">wasm2c(1)</a>,
+    <a class="Xr" href="wasm2wat.1.html">wasm2wat(1)</a>,
+    <a class="Xr" href="wast2json.1.html">wast2json(1)</a>,
+    <a class="Xr" href="wat-desugar.1.html">wat-desugar(1)</a>,
+    <a class="Xr" href="wat2wasm.1.html">wat2wasm(1)</a></p>
 </section>
 <section class="Sh">
 <h1 class="Sh" id="BUGS"><a class="permalink" href="#BUGS">BUGS</a></h1>
-If you find a bug, please report it at
-<br/>
-<a class="Lk" href="https://github.com/WebAssembly/wabt/issues">https://github.com/WebAssembly/wabt/issues</a>.
+<p class="Pp">If you find a bug, please report it at
+  <br/>
+  <a class="Lk" href="https://github.com/WebAssembly/wabt/issues">https://github.com/WebAssembly/wabt/issues</a>.</p>
 </section>
 </div>
 <table class="foot">
   <tr>
-    <td class="foot-date">October 7, 2021</td>
+    <td class="foot-date">September 23, 2025</td>
     <td class="foot-os">Debian</td>
   </tr>
 </table>

--- a/docs/doc/wasm-decompile.1.html
+++ b/docs/doc/wasm-decompile.1.html
@@ -2,17 +2,17 @@
 <html>
 <head>
   <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <style>
     table.head, table.foot { width: 100%; }
     td.head-rtitle, td.foot-os { text-align: right; }
     td.head-vol { text-align: center; }
-    div.Pp { margin: 1ex 0ex; }
-    div.Nd, div.Bf, div.Op { display: inline; }
-    span.Pa, span.Ad { font-style: italic; }
-    span.Ms { font-weight: bold; }
-    dl.Bl-diag > dt { font-weight: bold; }
-    code.Nm, code.Fl, code.Cm, code.Ic, code.In, code.Fd, code.Fn,
-    code.Cd { font-weight: bold; font-family: inherit; }
+    .Nd, .Bf, .Op { display: inline; }
+    .Pa, .Ad { font-style: italic; }
+    .Ms { font-weight: bold; }
+    .Bl-diag > dt { font-weight: bold; }
+    code.Nm, .Fl, .Cm, .Ic, code.In, .Fd, .Fn, .Cd { font-weight: bold;
+      font-family: inherit; }
   </style>
   <title>WABT(1)</title>
 </head>
@@ -27,8 +27,9 @@
 <div class="manual-text">
 <section class="Sh">
 <h1 class="Sh" id="NAME"><a class="permalink" href="#NAME">NAME</a></h1>
-<code class="Nm">wasm-decompile</code> &#x2014;
-<div class="Nd">translate from the binary format to readable C-like syntax</div>
+<p class="Pp"><code class="Nm">wasm-decompile</code> &#x2014;
+    <span class="Nd">translate from the binary format to readable C-like
+    syntax</span></p>
 </section>
 <section class="Sh">
 <h1 class="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h1>
@@ -41,35 +42,60 @@
 </section>
 <section class="Sh">
 <h1 class="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h1>
-<code class="Nm">wasm-decompile</code> translate from the binary format to
-  readable C-like syntax.
+<p class="Pp"><code class="Nm">wasm-decompile</code> Read a file in the
+    WebAssembly binary format, and convert it to a decompiled text file.</p>
 <p class="Pp">The options are as follows:</p>
 <dl class="Bl-tag">
-  <dt><a class="permalink" href="#v"><code class="Fl" id="v">-v</code></a>,
-    <code class="Fl">-</code><code class="Fl">-verbose</code></dt>
-  <dd>Use multiple times for more info</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-help</code></dt>
+  <dt id="help"><a class="permalink" href="#help"><code class="Fl">--help</code></a></dt>
   <dd>Print a help message</dd>
-  <dt><a class="permalink" href="#o"><code class="Fl" id="o">-o</code></a>,
-    <code class="Fl">-</code><code class="Fl">-output=FILENAME</code></dt>
-  <dd>Output file for the generated wast file, by default use stdout</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-enable-exceptions</code></dt>
-  <dd>Experimental exception handling</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-disable-mutable-globals</code></dt>
-  <dd>Import/export mutable globals</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-enable-saturating-float-to-int</code></dt>
-  <dd>Saturating float-to-int operators</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-enable-sign-extension</code></dt>
-  <dd>Sign-extension operators</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-disable-simd</code></dt>
-  <dd>SIMD support</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-enable-threads</code></dt>
-  <dd>Threading support</dd>
+  <dt id="version"><a class="permalink" href="#version"><code class="Fl">--version</code></a></dt>
+  <dd>Print version information</dd>
+  <dt id="o"><a class="permalink" href="#o"><code class="Fl">-o</code></a>,
+    <code class="Fl">--output=FILENAME</code></dt>
+  <dd>Output file for the decompiled file, by default use stdout</dd>
+  <dt id="enable-exceptions"><a class="permalink" href="#enable-exceptions"><code class="Fl">--enable-exceptions</code></a></dt>
+  <dd>Enable Experimental exception handling</dd>
+  <dt id="disable-mutable-globals"><a class="permalink" href="#disable-mutable-globals"><code class="Fl">--disable-mutable-globals</code></a></dt>
+  <dd>Disable Import/export mutable globals</dd>
+  <dt id="disable-saturating-float-to-int"><a class="permalink" href="#disable-saturating-float-to-int"><code class="Fl">--disable-saturating-float-to-int</code></a></dt>
+  <dd>Disable Saturating float-to-int operators</dd>
+  <dt id="disable-sign-extension"><a class="permalink" href="#disable-sign-extension"><code class="Fl">--disable-sign-extension</code></a></dt>
+  <dd>Disable Sign-extension operators</dd>
+  <dt id="disable-simd"><a class="permalink" href="#disable-simd"><code class="Fl">--disable-simd</code></a></dt>
+  <dd>Disable SIMD support</dd>
+  <dt id="enable-threads"><a class="permalink" href="#enable-threads"><code class="Fl">--enable-threads</code></a></dt>
+  <dd>Enable Threading support</dd>
+  <dt id="enable-function-references"><a class="permalink" href="#enable-function-references"><code class="Fl">--enable-function-references</code></a></dt>
+  <dd>Enable Typed function references</dd>
+  <dt id="disable-multi-value"><a class="permalink" href="#disable-multi-value"><code class="Fl">--disable-multi-value</code></a></dt>
+  <dd>Disable Multi-value</dd>
+  <dt id="enable-tail-call"><a class="permalink" href="#enable-tail-call"><code class="Fl">--enable-tail-call</code></a></dt>
+  <dd>Enable Tail-call support</dd>
+  <dt id="disable-bulk-memory"><a class="permalink" href="#disable-bulk-memory"><code class="Fl">--disable-bulk-memory</code></a></dt>
+  <dd>Disable Bulk-memory operations</dd>
+  <dt id="disable-reference-types"><a class="permalink" href="#disable-reference-types"><code class="Fl">--disable-reference-types</code></a></dt>
+  <dd>Disable Reference types (externref)</dd>
+  <dt id="enable-annotations"><a class="permalink" href="#enable-annotations"><code class="Fl">--enable-annotations</code></a></dt>
+  <dd>Enable Custom annotation syntax</dd>
+  <dt id="enable-code-metadata"><a class="permalink" href="#enable-code-metadata"><code class="Fl">--enable-code-metadata</code></a></dt>
+  <dd>Enable Code metadata</dd>
+  <dt id="enable-gc"><a class="permalink" href="#enable-gc"><code class="Fl">--enable-gc</code></a></dt>
+  <dd>Enable Garbage collection</dd>
+  <dt id="enable-memory64"><a class="permalink" href="#enable-memory64"><code class="Fl">--enable-memory64</code></a></dt>
+  <dd>Enable 64-bit memory</dd>
+  <dt id="enable-multi-memory"><a class="permalink" href="#enable-multi-memory"><code class="Fl">--enable-multi-memory</code></a></dt>
+  <dd>Enable Multi-memory</dd>
+  <dt id="enable-extended-const"><a class="permalink" href="#enable-extended-const"><code class="Fl">--enable-extended-const</code></a></dt>
+  <dd>Enable Extended constant expressions</dd>
+  <dt id="enable-all"><a class="permalink" href="#enable-all"><code class="Fl">--enable-all</code></a></dt>
+  <dd>Enable all features</dd>
+  <dt id="ignore-custom-section-errors"><a class="permalink" href="#ignore-custom-section-errors"><code class="Fl">--ignore-custom-section-errors</code></a></dt>
+  <dd>Ignore errors in custom sections</dd>
 </dl>
 </section>
 <section class="Sh">
 <h1 class="Sh" id="EXAMPLES"><a class="permalink" href="#EXAMPLES">EXAMPLES</a></h1>
-Parse binary file test.wasm and write text file test.dcmp
+<p class="Pp">Parse binary file test.wasm and write text file test.dcmp</p>
 <p class="Pp"></p>
 <div class="Bd Bd-indent"><code class="Li">$ wasm-decompile test.wasm -o
   test.dcmp</code></div>
@@ -77,28 +103,28 @@ Parse binary file test.wasm and write text file test.dcmp
 <section class="Sh">
 <h1 class="Sh" id="SEE_ALSO"><a class="permalink" href="#SEE_ALSO">SEE
   ALSO</a></h1>
-<a class="Xr" href="wasm2wat.1.html">wasm2wat(1)</a>,
-  <a class="Xr" href="wasm-interp.1.html">wasm-interp(1)</a>,
-  <a class="Xr" href="wasm-objdump.1.html">wasm-objdump(1)</a>,
-  <a class="Xr" href="wasm-stats.1.html">wasm-stats(1)</a>,
-  <a class="Xr" href="wasm-strip.1.html">wasm-strip(1)</a>,
-  <a class="Xr" href="wasm-validate.1.html">wasm-validate(1)</a>,
-  <a class="Xr" href="wasm2c.1.html">wasm2c(1)</a>,
-  <a class="Xr" href="wast2json.1.html">wast2json(1)</a>,
-  <a class="Xr" href="wat-desugar.1.html">wat-desugar(1)</a>,
-  <a class="Xr" href="wat2wasm.1.html">wat2wasm(1)</a>,
-  <a class="Xr" href="spectest-interp.1.html">spectest-interp(1)</a>
+<p class="Pp"><a class="Xr" href="wasm-interp.1.html">wasm-interp(1)</a>,
+    <a class="Xr" href="wasm-objdump.1.html">wasm-objdump(1)</a>,
+    <a class="Xr" href="wasm-stats.1.html">wasm-stats(1)</a>,
+    <a class="Xr" href="wasm-strip.1.html">wasm-strip(1)</a>,
+    <a class="Xr" href="wasm-validate.1.html">wasm-validate(1)</a>,
+    <a class="Xr" href="wasm2c.1.html">wasm2c(1)</a>,
+    <a class="Xr" href="wasm2wat.1.html">wasm2wat(1)</a>,
+    <a class="Xr" href="wast2json.1.html">wast2json(1)</a>,
+    <a class="Xr" href="wat-desugar.1.html">wat-desugar(1)</a>,
+    <a class="Xr" href="wat2wasm.1.html">wat2wasm(1)</a>,
+    <a class="Xr" href="spectest-interp.1.html">spectest-interp(1)</a></p>
 </section>
 <section class="Sh">
 <h1 class="Sh" id="BUGS"><a class="permalink" href="#BUGS">BUGS</a></h1>
-If you find a bug, please report it at
-<br/>
-<a class="Lk" href="https://github.com/WebAssembly/wabt/issues">https://github.com/WebAssembly/wabt/issues</a>.
+<p class="Pp">If you find a bug, please report it at
+  <br/>
+  <a class="Lk" href="https://github.com/WebAssembly/wabt/issues">https://github.com/WebAssembly/wabt/issues</a>.</p>
 </section>
 </div>
 <table class="foot">
   <tr>
-    <td class="foot-date">October 7, 2021</td>
+    <td class="foot-date">September 23, 2025</td>
     <td class="foot-os">Debian</td>
   </tr>
 </table>

--- a/docs/doc/wasm-interp.1.html
+++ b/docs/doc/wasm-interp.1.html
@@ -2,17 +2,17 @@
 <html>
 <head>
   <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <style>
     table.head, table.foot { width: 100%; }
     td.head-rtitle, td.foot-os { text-align: right; }
     td.head-vol { text-align: center; }
-    div.Pp { margin: 1ex 0ex; }
-    div.Nd, div.Bf, div.Op { display: inline; }
-    span.Pa, span.Ad { font-style: italic; }
-    span.Ms { font-weight: bold; }
-    dl.Bl-diag > dt { font-weight: bold; }
-    code.Nm, code.Fl, code.Cm, code.Ic, code.In, code.Fd, code.Fn,
-    code.Cd { font-weight: bold; font-family: inherit; }
+    .Nd, .Bf, .Op { display: inline; }
+    .Pa, .Ad { font-style: italic; }
+    .Ms { font-weight: bold; }
+    .Bl-diag > dt { font-weight: bold; }
+    code.Nm, .Fl, .Cm, .Ic, code.In, .Fd, .Fn, .Cd { font-weight: bold;
+      font-family: inherit; }
   </style>
   <title>WABT(1)</title>
 </head>
@@ -27,8 +27,8 @@
 <div class="manual-text">
 <section class="Sh">
 <h1 class="Sh" id="NAME"><a class="permalink" href="#NAME">NAME</a></h1>
-<code class="Nm">wasm-interp</code> &#x2014;
-<div class="Nd">decode and run a WebAssembly binary file</div>
+<p class="Pp"><code class="Nm">wasm-interp</code> &#x2014;
+    <span class="Nd">decode and run a WebAssembly binary file</span></p>
 </section>
 <section class="Sh">
 <h1 class="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h1>
@@ -41,46 +41,84 @@
 </section>
 <section class="Sh">
 <h1 class="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h1>
-<code class="Nm">wasm-interp</code> decodes and runs a WebAssembly binary file
-  using a stack-based interpreter.
+<p class="Pp"><code class="Nm">wasm-interp</code> Read a file in the wasm binary
+    format, and run it in a stack-based interpreter.</p>
 <p class="Pp">The options are as follows:</p>
 <dl class="Bl-tag">
-  <dt><a class="permalink" href="#v"><code class="Fl" id="v">-v</code></a>,
-    <code class="Fl">-</code><code class="Fl">-verbose</code></dt>
-  <dd>Use multiple times for more info</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-help</code></dt>
+  <dt id="help"><a class="permalink" href="#help"><code class="Fl">--help</code></a></dt>
   <dd>Print a help message</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-enable-exceptions</code></dt>
-  <dd>Experimental exception handling</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-disable-mutable-globals</code></dt>
-  <dd>Import/export mutable globals</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-enable-saturating-float-to-int</code></dt>
-  <dd>Saturating float-to-int operators</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-enable-sign-extension</code></dt>
-  <dd>Sign-extension operators</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-disable-simd</code></dt>
-  <dd>SIMD support</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-enable-threads</code></dt>
-  <dd>Threading support</dd>
-  <dt><a class="permalink" href="#V"><code class="Fl" id="V">-V</code></a>,
-    <code class="Fl">-</code><code class="Fl">-value-stack-size=SIZE</code></dt>
+  <dt id="version"><a class="permalink" href="#version"><code class="Fl">--version</code></a></dt>
+  <dd>Print version information</dd>
+  <dt id="v"><a class="permalink" href="#v"><code class="Fl">-v</code></a>,
+    <code class="Fl">--verbose</code></dt>
+  <dd>Use multiple times for more info</dd>
+  <dt id="enable-exceptions"><a class="permalink" href="#enable-exceptions"><code class="Fl">--enable-exceptions</code></a></dt>
+  <dd>Enable Experimental exception handling</dd>
+  <dt id="disable-mutable-globals"><a class="permalink" href="#disable-mutable-globals"><code class="Fl">--disable-mutable-globals</code></a></dt>
+  <dd>Disable Import/export mutable globals</dd>
+  <dt id="disable-saturating-float-to-int"><a class="permalink" href="#disable-saturating-float-to-int"><code class="Fl">--disable-saturating-float-to-int</code></a></dt>
+  <dd>Disable Saturating float-to-int operators</dd>
+  <dt id="disable-sign-extension"><a class="permalink" href="#disable-sign-extension"><code class="Fl">--disable-sign-extension</code></a></dt>
+  <dd>Disable Sign-extension operators</dd>
+  <dt id="disable-simd"><a class="permalink" href="#disable-simd"><code class="Fl">--disable-simd</code></a></dt>
+  <dd>Disable SIMD support</dd>
+  <dt id="enable-threads"><a class="permalink" href="#enable-threads"><code class="Fl">--enable-threads</code></a></dt>
+  <dd>Enable Threading support</dd>
+  <dt id="enable-function-references"><a class="permalink" href="#enable-function-references"><code class="Fl">--enable-function-references</code></a></dt>
+  <dd>Enable Typed function references</dd>
+  <dt id="disable-multi-value"><a class="permalink" href="#disable-multi-value"><code class="Fl">--disable-multi-value</code></a></dt>
+  <dd>Disable Multi-value</dd>
+  <dt id="enable-tail-call"><a class="permalink" href="#enable-tail-call"><code class="Fl">--enable-tail-call</code></a></dt>
+  <dd>Enable Tail-call support</dd>
+  <dt id="disable-bulk-memory"><a class="permalink" href="#disable-bulk-memory"><code class="Fl">--disable-bulk-memory</code></a></dt>
+  <dd>Disable Bulk-memory operations</dd>
+  <dt id="disable-reference-types"><a class="permalink" href="#disable-reference-types"><code class="Fl">--disable-reference-types</code></a></dt>
+  <dd>Disable Reference types (externref)</dd>
+  <dt id="enable-annotations"><a class="permalink" href="#enable-annotations"><code class="Fl">--enable-annotations</code></a></dt>
+  <dd>Enable Custom annotation syntax</dd>
+  <dt id="enable-code-metadata"><a class="permalink" href="#enable-code-metadata"><code class="Fl">--enable-code-metadata</code></a></dt>
+  <dd>Enable Code metadata</dd>
+  <dt id="enable-gc"><a class="permalink" href="#enable-gc"><code class="Fl">--enable-gc</code></a></dt>
+  <dd>Enable Garbage collection</dd>
+  <dt id="enable-memory64"><a class="permalink" href="#enable-memory64"><code class="Fl">--enable-memory64</code></a></dt>
+  <dd>Enable 64-bit memory</dd>
+  <dt id="enable-multi-memory"><a class="permalink" href="#enable-multi-memory"><code class="Fl">--enable-multi-memory</code></a></dt>
+  <dd>Enable Multi-memory</dd>
+  <dt id="enable-extended-const"><a class="permalink" href="#enable-extended-const"><code class="Fl">--enable-extended-const</code></a></dt>
+  <dd>Enable Extended constant expressions</dd>
+  <dt id="enable-all"><a class="permalink" href="#enable-all"><code class="Fl">--enable-all</code></a></dt>
+  <dd>Enable all features</dd>
+  <dt id="V"><a class="permalink" href="#V"><code class="Fl">-V</code></a>,
+    <code class="Fl">--value-stack-size=SIZE</code></dt>
   <dd>Size in elements of the value stack</dd>
-  <dt><a class="permalink" href="#C"><code class="Fl" id="C">-C</code></a>,
-    <code class="Fl">-</code><code class="Fl">-call-stack-size=SIZE</code></dt>
+  <dt id="C"><a class="permalink" href="#C"><code class="Fl">-C</code></a>,
+    <code class="Fl">--call-stack-size=SIZE</code></dt>
   <dd>Size in elements of the call stack</dd>
-  <dt><a class="permalink" href="#t"><code class="Fl" id="t">-t</code></a>,
-    <code class="Fl">-</code><code class="Fl">-trace</code></dt>
+  <dt id="t"><a class="permalink" href="#t"><code class="Fl">-t</code></a>,
+    <code class="Fl">--trace</code></dt>
   <dd>Trace execution</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-run-all-exports</code></dt>
+  <dt id="wasi"><a class="permalink" href="#wasi"><code class="Fl">--wasi</code></a></dt>
+  <dd>Assume input module is WASI compliant (Export WASI API the the module and
+      invoke _start function)</dd>
+  <dt id="e"><a class="permalink" href="#e"><code class="Fl">-e</code></a>,
+    <code class="Fl">--env=ENV</code></dt>
+  <dd>Pass the given environment string in the WASI runtime</dd>
+  <dt id="d"><a class="permalink" href="#d"><code class="Fl">-d</code></a>,
+    <code class="Fl">--dir=DIR</code></dt>
+  <dd>Pass the given directory the the WASI runtime</dd>
+  <dt id="run-all-exports"><a class="permalink" href="#run-all-exports"><code class="Fl">--run-all-exports</code></a></dt>
   <dd>Run all the exported functions, in order. Useful for testing</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-host-print</code></dt>
+  <dt id="host-print"><a class="permalink" href="#host-print"><code class="Fl">--host-print</code></a></dt>
   <dd>Include an importable function named &quot;host.print&quot; for printing
       to stdout</dd>
+  <dt id="dummy-import-func"><a class="permalink" href="#dummy-import-func"><code class="Fl">--dummy-import-func</code></a></dt>
+  <dd>Provide a dummy implementation of all imported functions. The function
+      will log the call and return an appropriate zero value.</dd>
 </dl>
 </section>
 <section class="Sh">
 <h1 class="Sh" id="EXAMPLES"><a class="permalink" href="#EXAMPLES">EXAMPLES</a></h1>
-Parse binary file test.wasm, and type-check it
+<p class="Pp">Parse binary file test.wasm, and type-check it</p>
 <p class="Pp"></p>
 <div class="Bd Bd-indent"><code class="Li">$ wasm-interp test.wasm</code></div>
 <p class="Pp">Parse test.wasm and run all its exported functions</p>
@@ -101,27 +139,28 @@ Parse binary file test.wasm, and type-check it
 <section class="Sh">
 <h1 class="Sh" id="SEE_ALSO"><a class="permalink" href="#SEE_ALSO">SEE
   ALSO</a></h1>
-<a class="Xr" href="wasm-objdump.1.html">wasm-objdump(1)</a>,
-  <a class="Xr" href="wasm-stats.1.html">wasm-stats(1)</a>,
-  <a class="Xr" href="wasm-strip.1.html">wasm-strip(1)</a>,
-  <a class="Xr" href="wasm-validate.1.html">wasm-validate(1)</a>,
-  <a class="Xr" href="wasm2c.1.html">wasm2c(1)</a>,
-  <a class="Xr" href="wasm2wat.1.html">wasm2wat(1)</a>,
-  <a class="Xr" href="wast2json.1.html">wast2json(1)</a>,
-  <a class="Xr" href="wat-desugar.1.html">wat-desugar(1)</a>,
-  <a class="Xr" href="wat2wasm.1.html">wat2wasm(1)</a>,
-  <a class="Xr" href="spectest-interp.1.html">spectest-interp(1)</a>
+<p class="Pp"><a class="Xr" href="wasm-decompile.1.html">wasm-decompile(1)</a>,
+    <a class="Xr" href="wasm-objdump.1.html">wasm-objdump(1)</a>,
+    <a class="Xr" href="wasm-stats.1.html">wasm-stats(1)</a>,
+    <a class="Xr" href="wasm-strip.1.html">wasm-strip(1)</a>,
+    <a class="Xr" href="wasm-validate.1.html">wasm-validate(1)</a>,
+    <a class="Xr" href="wasm2c.1.html">wasm2c(1)</a>,
+    <a class="Xr" href="wasm2wat.1.html">wasm2wat(1)</a>,
+    <a class="Xr" href="wast2json.1.html">wast2json(1)</a>,
+    <a class="Xr" href="wat-desugar.1.html">wat-desugar(1)</a>,
+    <a class="Xr" href="wat2wasm.1.html">wat2wasm(1)</a>,
+    <a class="Xr" href="spectest-interp.1.html">spectest-interp(1)</a></p>
 </section>
 <section class="Sh">
 <h1 class="Sh" id="BUGS"><a class="permalink" href="#BUGS">BUGS</a></h1>
-If you find a bug, please report it at
-<br/>
-<a class="Lk" href="https://github.com/WebAssembly/wabt/issues">https://github.com/WebAssembly/wabt/issues</a>.
+<p class="Pp">If you find a bug, please report it at
+  <br/>
+  <a class="Lk" href="https://github.com/WebAssembly/wabt/issues">https://github.com/WebAssembly/wabt/issues</a>.</p>
 </section>
 </div>
 <table class="foot">
   <tr>
-    <td class="foot-date">October 7, 2021</td>
+    <td class="foot-date">September 23, 2025</td>
     <td class="foot-os">Debian</td>
   </tr>
 </table>

--- a/docs/doc/wasm-objdump.1.html
+++ b/docs/doc/wasm-objdump.1.html
@@ -2,17 +2,17 @@
 <html>
 <head>
   <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <style>
     table.head, table.foot { width: 100%; }
     td.head-rtitle, td.foot-os { text-align: right; }
     td.head-vol { text-align: center; }
-    div.Pp { margin: 1ex 0ex; }
-    div.Nd, div.Bf, div.Op { display: inline; }
-    span.Pa, span.Ad { font-style: italic; }
-    span.Ms { font-weight: bold; }
-    dl.Bl-diag > dt { font-weight: bold; }
-    code.Nm, code.Fl, code.Cm, code.Ic, code.In, code.Fd, code.Fn,
-    code.Cd { font-weight: bold; font-family: inherit; }
+    .Nd, .Bf, .Op { display: inline; }
+    .Pa, .Ad { font-style: italic; }
+    .Ms { font-weight: bold; }
+    .Bl-diag > dt { font-weight: bold; }
+    code.Nm, .Fl, .Cm, .Ic, code.In, .Fd, .Fn, .Cd { font-weight: bold;
+      font-family: inherit; }
   </style>
   <title>WABT(1)</title>
 </head>
@@ -27,8 +27,8 @@
 <div class="manual-text">
 <section class="Sh">
 <h1 class="Sh" id="NAME"><a class="permalink" href="#NAME">NAME</a></h1>
-<code class="Nm">wasm-objdump</code> &#x2014;
-<div class="Nd">print information about a wasm binary</div>
+<p class="Pp"><code class="Nm">wasm-objdump</code> &#x2014;
+    <span class="Nd">print information about a wasm binary</span></p>
 </section>
 <section class="Sh">
 <h1 class="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h1>
@@ -41,32 +41,36 @@
 </section>
 <section class="Sh">
 <h1 class="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h1>
-<code class="Nm">wasm-objdump</code> prints information about a wasm binary,
-  similar to objdump.
+<p class="Pp"><code class="Nm">wasm-objdump</code> Print information about the
+    contents of wasm binaries.</p>
 <p class="Pp">The options are as follows:</p>
 <dl class="Bl-tag">
-  <dt><a class="permalink" href="#h"><code class="Fl" id="h">-h</code></a>,
-    <code class="Fl">-</code><code class="Fl">-headers</code></dt>
-  <dd>Print headers</dd>
-  <dt><a class="permalink" href="#j"><code class="Fl" id="j">-j</code></a>,
-    <code class="Fl">-</code><code class="Fl">-section=SECTION</code></dt>
-  <dd>Select just one section</dd>
-  <dt><a class="permalink" href="#s"><code class="Fl" id="s">-s</code></a>,
-    <code class="Fl">-</code><code class="Fl">-full-contents</code></dt>
-  <dd>Print raw section contents</dd>
-  <dt><a class="permalink" href="#d"><code class="Fl" id="d">-d</code></a>,
-    <code class="Fl">-</code><code class="Fl">-disassemble</code></dt>
-  <dd>Disassemble function bodies</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-debug</code></dt>
-  <dd>Print extra debug information</dd>
-  <dt><a class="permalink" href="#x"><code class="Fl" id="x">-x</code></a>,
-    <code class="Fl">-</code><code class="Fl">-details</code></dt>
-  <dd>Show section details</dd>
-  <dt><a class="permalink" href="#r"><code class="Fl" id="r">-r</code></a>,
-    <code class="Fl">-</code><code class="Fl">-reloc</code></dt>
-  <dd>Show relocations inline with disassembly</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-help</code></dt>
+  <dt id="help"><a class="permalink" href="#help"><code class="Fl">--help</code></a></dt>
   <dd>Print a help message</dd>
+  <dt id="version"><a class="permalink" href="#version"><code class="Fl">--version</code></a></dt>
+  <dd>Print version information</dd>
+  <dt id="h"><a class="permalink" href="#h"><code class="Fl">-h</code></a>,
+    <code class="Fl">--headers</code></dt>
+  <dd>Print headers</dd>
+  <dt id="j"><a class="permalink" href="#j"><code class="Fl">-j</code></a>,
+    <code class="Fl">--section=SECTION</code></dt>
+  <dd>Select just one section</dd>
+  <dt id="s"><a class="permalink" href="#s"><code class="Fl">-s</code></a>,
+    <code class="Fl">--full-contents</code></dt>
+  <dd>Print raw section contents</dd>
+  <dt id="d"><a class="permalink" href="#d"><code class="Fl">-d</code></a>,
+    <code class="Fl">--disassemble</code></dt>
+  <dd>Disassemble function bodies</dd>
+  <dt id="debug"><a class="permalink" href="#debug"><code class="Fl">--debug</code></a></dt>
+  <dd>Print extra debug information</dd>
+  <dt id="x"><a class="permalink" href="#x"><code class="Fl">-x</code></a>,
+    <code class="Fl">--details</code></dt>
+  <dd>Show section details</dd>
+  <dt id="r"><a class="permalink" href="#r"><code class="Fl">-r</code></a>,
+    <code class="Fl">--reloc</code></dt>
+  <dd>Show relocations inline with disassembly</dd>
+  <dt id="section-offsets"><a class="permalink" href="#section-offsets"><code class="Fl">--section-offsets</code></a></dt>
+  <dd>Print section offsets instead of file offsets in code disassembly</dd>
 </dl>
 </section>
 <section class="Sh">
@@ -76,27 +80,28 @@
 <section class="Sh">
 <h1 class="Sh" id="SEE_ALSO"><a class="permalink" href="#SEE_ALSO">SEE
   ALSO</a></h1>
-<a class="Xr" href="wasm-interp.1.html">wasm-interp(1)</a>,
-  <a class="Xr" href="wasm-stats.1.html">wasm-stats(1)</a>,
-  <a class="Xr" href="wasm-strip.1.html">wasm-strip(1)</a>,
-  <a class="Xr" href="wasm-validate.1.html">wasm-validate(1)</a>,
-  <a class="Xr" href="wasm2c.1.html">wasm2c(1)</a>,
-  <a class="Xr" href="wasm2wat.1.html">wasm2wat(1)</a>,
-  <a class="Xr" href="wast2json.1.html">wast2json(1)</a>,
-  <a class="Xr" href="wat-desugar.1.html">wat-desugar(1)</a>,
-  <a class="Xr" href="wat2wasm.1.html">wat2wasm(1)</a>,
-  <a class="Xr" href="spectest-interp.1.html">spectest-interp(1)</a>
+<p class="Pp"><a class="Xr" href="wasm-decompile.1.html">wasm-decompile(1)</a>,
+    <a class="Xr" href="wasm-interp.1.html">wasm-interp(1)</a>,
+    <a class="Xr" href="wasm-stats.1.html">wasm-stats(1)</a>,
+    <a class="Xr" href="wasm-strip.1.html">wasm-strip(1)</a>,
+    <a class="Xr" href="wasm-validate.1.html">wasm-validate(1)</a>,
+    <a class="Xr" href="wasm2c.1.html">wasm2c(1)</a>,
+    <a class="Xr" href="wasm2wat.1.html">wasm2wat(1)</a>,
+    <a class="Xr" href="wast2json.1.html">wast2json(1)</a>,
+    <a class="Xr" href="wat-desugar.1.html">wat-desugar(1)</a>,
+    <a class="Xr" href="wat2wasm.1.html">wat2wasm(1)</a>,
+    <a class="Xr" href="spectest-interp.1.html">spectest-interp(1)</a></p>
 </section>
 <section class="Sh">
 <h1 class="Sh" id="BUGS"><a class="permalink" href="#BUGS">BUGS</a></h1>
-If you find a bug, please report it at
-<br/>
-<a class="Lk" href="https://github.com/WebAssembly/wabt/issues">https://github.com/WebAssembly/wabt/issues</a>.
+<p class="Pp">If you find a bug, please report it at
+  <br/>
+  <a class="Lk" href="https://github.com/WebAssembly/wabt/issues">https://github.com/WebAssembly/wabt/issues</a>.</p>
 </section>
 </div>
 <table class="foot">
   <tr>
-    <td class="foot-date">October 7, 2021</td>
+    <td class="foot-date">September 23, 2025</td>
     <td class="foot-os">Debian</td>
   </tr>
 </table>

--- a/docs/doc/wasm-stats.1.html
+++ b/docs/doc/wasm-stats.1.html
@@ -2,17 +2,17 @@
 <html>
 <head>
   <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <style>
     table.head, table.foot { width: 100%; }
     td.head-rtitle, td.foot-os { text-align: right; }
     td.head-vol { text-align: center; }
-    div.Pp { margin: 1ex 0ex; }
-    div.Nd, div.Bf, div.Op { display: inline; }
-    span.Pa, span.Ad { font-style: italic; }
-    span.Ms { font-weight: bold; }
-    dl.Bl-diag > dt { font-weight: bold; }
-    code.Nm, code.Fl, code.Cm, code.Ic, code.In, code.Fd, code.Fn,
-    code.Cd { font-weight: bold; font-family: inherit; }
+    .Nd, .Bf, .Op { display: inline; }
+    .Pa, .Ad { font-style: italic; }
+    .Ms { font-weight: bold; }
+    .Bl-diag > dt { font-weight: bold; }
+    code.Nm, .Fl, .Cm, .Ic, code.In, .Fd, .Fn, .Cd { font-weight: bold;
+      font-family: inherit; }
   </style>
   <title>WABT(1)</title>
 </head>
@@ -27,8 +27,8 @@
 <div class="manual-text">
 <section class="Sh">
 <h1 class="Sh" id="NAME"><a class="permalink" href="#NAME">NAME</a></h1>
-<code class="Nm">wasm-stats</code> &#x2014;
-<div class="Nd">show stats for a module</div>
+<p class="Pp"><code class="Nm">wasm-stats</code> &#x2014; <span class="Nd">show
+    stats for a module</span></p>
 </section>
 <section class="Sh">
 <h1 class="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h1>
@@ -41,30 +41,68 @@
 </section>
 <section class="Sh">
 <h1 class="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h1>
-<code class="Nm">wasm-stats</code> reads a file in the wasm binary format,
-  and shows stats.
+<p class="Pp"><code class="Nm">wasm-stats</code> Read a file in the wasm binary
+    format, and show stats.</p>
 <p class="Pp">The options are as follows:</p>
 <dl class="Bl-tag">
-  <dt><a class="permalink" href="#v"><code class="Fl" id="v">-v</code></a>,
-    <code class="Fl">-</code><code class="Fl">-verbose</code></dt>
-  <dd>Use multiple times for more info</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-help</code></dt>
+  <dt id="help"><a class="permalink" href="#help"><code class="Fl">--help</code></a></dt>
   <dd>Print a help message</dd>
-  <dt><a class="permalink" href="#o"><code class="Fl" id="o">-o</code></a>,
-    <code class="Fl">-</code><code class="Fl">-output=FILENAME</code></dt>
+  <dt id="version"><a class="permalink" href="#version"><code class="Fl">--version</code></a></dt>
+  <dd>Print version information</dd>
+  <dt id="v"><a class="permalink" href="#v"><code class="Fl">-v</code></a>,
+    <code class="Fl">--verbose</code></dt>
+  <dd>Use multiple times for more info</dd>
+  <dt id="enable-exceptions"><a class="permalink" href="#enable-exceptions"><code class="Fl">--enable-exceptions</code></a></dt>
+  <dd>Enable Experimental exception handling</dd>
+  <dt id="disable-mutable-globals"><a class="permalink" href="#disable-mutable-globals"><code class="Fl">--disable-mutable-globals</code></a></dt>
+  <dd>Disable Import/export mutable globals</dd>
+  <dt id="disable-saturating-float-to-int"><a class="permalink" href="#disable-saturating-float-to-int"><code class="Fl">--disable-saturating-float-to-int</code></a></dt>
+  <dd>Disable Saturating float-to-int operators</dd>
+  <dt id="disable-sign-extension"><a class="permalink" href="#disable-sign-extension"><code class="Fl">--disable-sign-extension</code></a></dt>
+  <dd>Disable Sign-extension operators</dd>
+  <dt id="disable-simd"><a class="permalink" href="#disable-simd"><code class="Fl">--disable-simd</code></a></dt>
+  <dd>Disable SIMD support</dd>
+  <dt id="enable-threads"><a class="permalink" href="#enable-threads"><code class="Fl">--enable-threads</code></a></dt>
+  <dd>Enable Threading support</dd>
+  <dt id="enable-function-references"><a class="permalink" href="#enable-function-references"><code class="Fl">--enable-function-references</code></a></dt>
+  <dd>Enable Typed function references</dd>
+  <dt id="disable-multi-value"><a class="permalink" href="#disable-multi-value"><code class="Fl">--disable-multi-value</code></a></dt>
+  <dd>Disable Multi-value</dd>
+  <dt id="enable-tail-call"><a class="permalink" href="#enable-tail-call"><code class="Fl">--enable-tail-call</code></a></dt>
+  <dd>Enable Tail-call support</dd>
+  <dt id="disable-bulk-memory"><a class="permalink" href="#disable-bulk-memory"><code class="Fl">--disable-bulk-memory</code></a></dt>
+  <dd>Disable Bulk-memory operations</dd>
+  <dt id="disable-reference-types"><a class="permalink" href="#disable-reference-types"><code class="Fl">--disable-reference-types</code></a></dt>
+  <dd>Disable Reference types (externref)</dd>
+  <dt id="enable-annotations"><a class="permalink" href="#enable-annotations"><code class="Fl">--enable-annotations</code></a></dt>
+  <dd>Enable Custom annotation syntax</dd>
+  <dt id="enable-code-metadata"><a class="permalink" href="#enable-code-metadata"><code class="Fl">--enable-code-metadata</code></a></dt>
+  <dd>Enable Code metadata</dd>
+  <dt id="enable-gc"><a class="permalink" href="#enable-gc"><code class="Fl">--enable-gc</code></a></dt>
+  <dd>Enable Garbage collection</dd>
+  <dt id="enable-memory64"><a class="permalink" href="#enable-memory64"><code class="Fl">--enable-memory64</code></a></dt>
+  <dd>Enable 64-bit memory</dd>
+  <dt id="enable-multi-memory"><a class="permalink" href="#enable-multi-memory"><code class="Fl">--enable-multi-memory</code></a></dt>
+  <dd>Enable Multi-memory</dd>
+  <dt id="enable-extended-const"><a class="permalink" href="#enable-extended-const"><code class="Fl">--enable-extended-const</code></a></dt>
+  <dd>Enable Extended constant expressions</dd>
+  <dt id="enable-all"><a class="permalink" href="#enable-all"><code class="Fl">--enable-all</code></a></dt>
+  <dd>Enable all features</dd>
+  <dt id="o"><a class="permalink" href="#o"><code class="Fl">-o</code></a>,
+    <code class="Fl">--output=FILENAME</code></dt>
   <dd>Output file for the opcode counts, by default use stdout</dd>
-  <dt><a class="permalink" href="#c"><code class="Fl" id="c">-c</code></a>,
-    <code class="Fl">-</code><code class="Fl">-cutoff=N</code></dt>
+  <dt id="c"><a class="permalink" href="#c"><code class="Fl">-c</code></a>,
+    <code class="Fl">--cutoff=N</code></dt>
   <dd>Cutoff for reporting counts less than N</dd>
-  <dt><a class="permalink" href="#s"><code class="Fl" id="s">-s</code></a>,
-    <code class="Fl">-</code><code class="Fl">-separator=SEPARATOR</code></dt>
-  <dd>Separator text between element and count when reporting counts expected
-      filename argument</dd>
+  <dt id="s"><a class="permalink" href="#s"><code class="Fl">-s</code></a>,
+    <code class="Fl">--separator=SEPARATOR</code></dt>
+  <dd>Separator text between element and count when reporting counts</dd>
 </dl>
 </section>
 <section class="Sh">
 <h1 class="Sh" id="EXAMPLES"><a class="permalink" href="#EXAMPLES">EXAMPLES</a></h1>
-Parse binary file test.wasm and write opcode dist file test.dist
+<p class="Pp">Parse binary file test.wasm and write opcode dist file
+  test.dist</p>
 <p class="Pp"></p>
 <div class="Bd Bd-indent"><code class="Li">$ wasm-stats test.wasm -o
   test.dist</code></div>
@@ -72,27 +110,28 @@ Parse binary file test.wasm and write opcode dist file test.dist
 <section class="Sh">
 <h1 class="Sh" id="SEE_ALSO"><a class="permalink" href="#SEE_ALSO">SEE
   ALSO</a></h1>
-<a class="Xr" href="wasm-interp.1.html">wasm-interp(1)</a>,
-  <a class="Xr" href="wasm-objdump.1.html">wasm-objdump(1)</a>,
-  <a class="Xr" href="wasm-strip.1.html">wasm-strip(1)</a>,
-  <a class="Xr" href="wasm-validate.1.html">wasm-validate(1)</a>,
-  <a class="Xr" href="wasm2c.1.html">wasm2c(1)</a>,
-  <a class="Xr" href="wasm2wat.1.html">wasm2wat(1)</a>,
-  <a class="Xr" href="wast2json.1.html">wast2json(1)</a>,
-  <a class="Xr" href="wat-desugar.1.html">wat-desugar(1)</a>,
-  <a class="Xr" href="wat2wasm.1.html">wat2wasm(1)</a>,
-  <a class="Xr" href="spectest-interp.1.html">spectest-interp(1)</a>
+<p class="Pp"><a class="Xr" href="wasm-decompile.1.html">wasm-decompile(1)</a>,
+    <a class="Xr" href="wasm-interp.1.html">wasm-interp(1)</a>,
+    <a class="Xr" href="wasm-objdump.1.html">wasm-objdump(1)</a>,
+    <a class="Xr" href="wasm-strip.1.html">wasm-strip(1)</a>,
+    <a class="Xr" href="wasm-validate.1.html">wasm-validate(1)</a>,
+    <a class="Xr" href="wasm2c.1.html">wasm2c(1)</a>,
+    <a class="Xr" href="wasm2wat.1.html">wasm2wat(1)</a>,
+    <a class="Xr" href="wast2json.1.html">wast2json(1)</a>,
+    <a class="Xr" href="wat-desugar.1.html">wat-desugar(1)</a>,
+    <a class="Xr" href="wat2wasm.1.html">wat2wasm(1)</a>,
+    <a class="Xr" href="spectest-interp.1.html">spectest-interp(1)</a></p>
 </section>
 <section class="Sh">
 <h1 class="Sh" id="BUGS"><a class="permalink" href="#BUGS">BUGS</a></h1>
-If you find a bug, please report it at
-<br/>
-<a class="Lk" href="https://github.com/WebAssembly/wabt/issues">https://github.com/WebAssembly/wabt/issues</a>.
+<p class="Pp">If you find a bug, please report it at
+  <br/>
+  <a class="Lk" href="https://github.com/WebAssembly/wabt/issues">https://github.com/WebAssembly/wabt/issues</a>.</p>
 </section>
 </div>
 <table class="foot">
   <tr>
-    <td class="foot-date">October 7, 2021</td>
+    <td class="foot-date">September 23, 2025</td>
     <td class="foot-os">Debian</td>
   </tr>
 </table>

--- a/docs/doc/wasm-strip.1.html
+++ b/docs/doc/wasm-strip.1.html
@@ -2,17 +2,17 @@
 <html>
 <head>
   <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <style>
     table.head, table.foot { width: 100%; }
     td.head-rtitle, td.foot-os { text-align: right; }
     td.head-vol { text-align: center; }
-    div.Pp { margin: 1ex 0ex; }
-    div.Nd, div.Bf, div.Op { display: inline; }
-    span.Pa, span.Ad { font-style: italic; }
-    span.Ms { font-weight: bold; }
-    dl.Bl-diag > dt { font-weight: bold; }
-    code.Nm, code.Fl, code.Cm, code.Ic, code.In, code.Fd, code.Fn,
-    code.Cd { font-weight: bold; font-family: inherit; }
+    .Nd, .Bf, .Op { display: inline; }
+    .Pa, .Ad { font-style: italic; }
+    .Ms { font-weight: bold; }
+    .Bl-diag > dt { font-weight: bold; }
+    code.Nm, .Fl, .Cm, .Ic, code.In, .Fd, .Fn, .Cd { font-weight: bold;
+      font-family: inherit; }
   </style>
   <title>WABT(1)</title>
 </head>
@@ -27,8 +27,8 @@
 <div class="manual-text">
 <section class="Sh">
 <h1 class="Sh" id="NAME"><a class="permalink" href="#NAME">NAME</a></h1>
-<code class="Nm">wasm-strip</code> &#x2014;
-<div class="Nd">remove sections of a WebAssembly binary file</div>
+<p class="Pp"><code class="Nm">wasm-strip</code> &#x2014;
+    <span class="Nd">remove sections of a WebAssembly binary file</span></p>
 </section>
 <section class="Sh">
 <h1 class="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h1>
@@ -41,44 +41,51 @@
 </section>
 <section class="Sh">
 <h1 class="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h1>
-<code class="Nm">wasm-strip</code> removes sections of a WebAssembly binary
-  file.
+<p class="Pp"><code class="Nm">wasm-strip</code> Remove sections of a
+    WebAssembly binary file.</p>
 <p class="Pp">The options are as follows:</p>
 <dl class="Bl-tag">
-  <dt><code class="Fl">-</code><code class="Fl">-help</code></dt>
+  <dt id="help"><a class="permalink" href="#help"><code class="Fl">--help</code></a></dt>
   <dd>Print a help message</dd>
+  <dt id="version"><a class="permalink" href="#version"><code class="Fl">--version</code></a></dt>
+  <dd>Print version information</dd>
+  <dt id="o"><a class="permalink" href="#o"><code class="Fl">-o</code></a>,
+    <code class="Fl">--output=FILE</code></dt>
+  <dd>output wasm binary file</dd>
 </dl>
 </section>
 <section class="Sh">
 <h1 class="Sh" id="EXAMPLES"><a class="permalink" href="#EXAMPLES">EXAMPLES</a></h1>
-Remove all custom sections from test.wasm
+<p class="Pp">Remove all custom sections from test.wasm</p>
 <p class="Pp"></p>
 <div class="Bd Bd-indent"><code class="Li">$ wasm-strip test.wasm</code></div>
 </section>
 <section class="Sh">
 <h1 class="Sh" id="SEE_ALSO"><a class="permalink" href="#SEE_ALSO">SEE
   ALSO</a></h1>
-<a class="Xr" href="wasm-interp.1.html">wasm-interp(1)</a>,
-  <a class="Xr" href="wasm-objdump.1.html">wasm-objdump(1)</a>,
-  <a class="Xr" href="wasm-stats.1.html">wasm-stats(1)</a>,
-  <a class="Xr" href="wasm-validate.1.html">wasm-validate(1)</a>,
-  <a class="Xr" href="wasm2c.1.html">wasm2c(1)</a>,
-  <a class="Xr" href="wasm2wat.1.html">wasm2wat(1)</a>,
-  <a class="Xr" href="wast2json.1.html">wast2json(1)</a>,
-  <a class="Xr" href="wat-desugar.1.html">wat-desugar(1)</a>,
-  <a class="Xr" href="wat2wasm.1.html">wat2wasm(1)</a>,
-  <a class="Xr" href="spectest-interp.1.html">spectest-interp(1)</a>
+<p class="Pp"><a class="Xr" href="wasm-decompile.1.html">wasm-decompile(1)</a>,
+    <a class="Xr" href="wasm-interp.1.html">wasm-interp(1)</a>,
+    <a class="Xr" href="wasm-objdump.1.html">wasm-objdump(1)</a>,
+    <a class="Xr" href="wasm-stats.1.html">wasm-stats(1)</a>,
+    <a class="Xr" href="wasm-strip.1.html">wasm-strip(1)</a>,
+    <a class="Xr" href="wasm-validate.1.html">wasm-validate(1)</a>,
+    <a class="Xr" href="wasm2c.1.html">wasm2c(1)</a>,
+    <a class="Xr" href="wasm2wat.1.html">wasm2wat(1)</a>,
+    <a class="Xr" href="wast2json.1.html">wast2json(1)</a>,
+    <a class="Xr" href="wat-desugar.1.html">wat-desugar(1)</a>,
+    <a class="Xr" href="wat2wasm.1.html">wat2wasm(1)</a>,
+    <a class="Xr" href="spectest-interp.1.html">spectest-interp(1)</a></p>
 </section>
 <section class="Sh">
 <h1 class="Sh" id="BUGS"><a class="permalink" href="#BUGS">BUGS</a></h1>
-If you find a bug, please report it at
-<br/>
-<a class="Lk" href="https://github.com/WebAssembly/wabt/issues">https://github.com/WebAssembly/wabt/issues</a>.
+<p class="Pp">If you find a bug, please report it at
+  <br/>
+  <a class="Lk" href="https://github.com/WebAssembly/wabt/issues">https://github.com/WebAssembly/wabt/issues</a>.</p>
 </section>
 </div>
 <table class="foot">
   <tr>
-    <td class="foot-date">October 7, 2021</td>
+    <td class="foot-date">September 23, 2025</td>
     <td class="foot-os">Debian</td>
   </tr>
 </table>

--- a/docs/doc/wasm-validate.1.html
+++ b/docs/doc/wasm-validate.1.html
@@ -2,17 +2,17 @@
 <html>
 <head>
   <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <style>
     table.head, table.foot { width: 100%; }
     td.head-rtitle, td.foot-os { text-align: right; }
     td.head-vol { text-align: center; }
-    div.Pp { margin: 1ex 0ex; }
-    div.Nd, div.Bf, div.Op { display: inline; }
-    span.Pa, span.Ad { font-style: italic; }
-    span.Ms { font-weight: bold; }
-    dl.Bl-diag > dt { font-weight: bold; }
-    code.Nm, code.Fl, code.Cm, code.Ic, code.In, code.Fd, code.Fn,
-    code.Cd { font-weight: bold; font-family: inherit; }
+    .Nd, .Bf, .Op { display: inline; }
+    .Pa, .Ad { font-style: italic; }
+    .Ms { font-weight: bold; }
+    .Bl-diag > dt { font-weight: bold; }
+    code.Nm, .Fl, .Cm, .Ic, code.In, .Fd, .Fn, .Cd { font-weight: bold;
+      font-family: inherit; }
   </style>
   <title>WABT(1)</title>
 </head>
@@ -27,8 +27,8 @@
 <div class="manual-text">
 <section class="Sh">
 <h1 class="Sh" id="NAME"><a class="permalink" href="#NAME">NAME</a></h1>
-<code class="Nm">wasm-validate</code> &#x2014;
-<div class="Nd">validate a file in the WebAssembly binary format</div>
+<p class="Pp"><code class="Nm">wasm-validate</code> &#x2014;
+    <span class="Nd">validate a file in the WebAssembly binary format</span></p>
 </section>
 <section class="Sh">
 <h1 class="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h1>
@@ -41,40 +41,62 @@
 </section>
 <section class="Sh">
 <h1 class="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h1>
-<code class="Nm">wasm-validate</code> reads a file in the WebAssembly binary
-  format and validates it.
+<p class="Pp"><code class="Nm">wasm-validate</code> Read a file in the
+    WebAssembly binary format, and validate it.</p>
 <p class="Pp">The options are as follows:</p>
 <dl class="Bl-tag">
-  <dt><a class="permalink" href="#v"><code class="Fl" id="v">-v</code></a>,
-    <code class="Fl">-</code><code class="Fl">-verbose</code></dt>
-  <dd>Use multiple times for more info</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-help</code></dt>
+  <dt id="help"><a class="permalink" href="#help"><code class="Fl">--help</code></a></dt>
   <dd>Print this help message</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-enable-exceptions</code></dt>
+  <dt id="version"><a class="permalink" href="#version"><code class="Fl">--version</code></a></dt>
+  <dd>Print version information</dd>
+  <dt id="v"><a class="permalink" href="#v"><code class="Fl">-v</code></a>,
+    <code class="Fl">--verbose</code></dt>
+  <dd>Use multiple times for more info</dd>
+  <dt id="enable-exceptions"><a class="permalink" href="#enable-exceptions"><code class="Fl">--enable-exceptions</code></a></dt>
   <dd>Enable Experimental exception handling</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-disable-mutable-globals</code></dt>
+  <dt id="disable-mutable-globals"><a class="permalink" href="#disable-mutable-globals"><code class="Fl">--disable-mutable-globals</code></a></dt>
   <dd>Disable Import/export mutable globals</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-enable-saturating-float-to-int</code></dt>
-  <dd>Enable Saturating float-to-int operators</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-enable-sign-extension</code></dt>
-  <dd>Enable Sign-extension operators</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-disable-simd</code></dt>
+  <dt id="disable-saturating-float-to-int"><a class="permalink" href="#disable-saturating-float-to-int"><code class="Fl">--disable-saturating-float-to-int</code></a></dt>
+  <dd>Disable Saturating float-to-int operators</dd>
+  <dt id="disable-sign-extension"><a class="permalink" href="#disable-sign-extension"><code class="Fl">--disable-sign-extension</code></a></dt>
+  <dd>Disable Sign-extension operators</dd>
+  <dt id="disable-simd"><a class="permalink" href="#disable-simd"><code class="Fl">--disable-simd</code></a></dt>
   <dd>Disable SIMD support</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-enable-threads</code></dt>
+  <dt id="enable-threads"><a class="permalink" href="#enable-threads"><code class="Fl">--enable-threads</code></a></dt>
   <dd>Enable Threading support</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-enable-multi-value</code></dt>
-  <dd>Enable Multi-value</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-enable-tail-call</code></dt>
+  <dt id="enable-function-references"><a class="permalink" href="#enable-function-references"><code class="Fl">--enable-function-references</code></a></dt>
+  <dd>Enable Typed function references</dd>
+  <dt id="disable-multi-value"><a class="permalink" href="#disable-multi-value"><code class="Fl">--disable-multi-value</code></a></dt>
+  <dd>Disable Multi-value</dd>
+  <dt id="enable-tail-call"><a class="permalink" href="#enable-tail-call"><code class="Fl">--enable-tail-call</code></a></dt>
   <dd>Enable Tail-call support</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-no-debug-names</code></dt>
+  <dt id="disable-bulk-memory"><a class="permalink" href="#disable-bulk-memory"><code class="Fl">--disable-bulk-memory</code></a></dt>
+  <dd>Disable Bulk-memory operations</dd>
+  <dt id="disable-reference-types"><a class="permalink" href="#disable-reference-types"><code class="Fl">--disable-reference-types</code></a></dt>
+  <dd>Disable Reference types (externref)</dd>
+  <dt id="enable-annotations"><a class="permalink" href="#enable-annotations"><code class="Fl">--enable-annotations</code></a></dt>
+  <dd>Enable Custom annotation syntax</dd>
+  <dt id="enable-code-metadata"><a class="permalink" href="#enable-code-metadata"><code class="Fl">--enable-code-metadata</code></a></dt>
+  <dd>Enable Code metadata</dd>
+  <dt id="enable-gc"><a class="permalink" href="#enable-gc"><code class="Fl">--enable-gc</code></a></dt>
+  <dd>Enable Garbage collection</dd>
+  <dt id="enable-memory64"><a class="permalink" href="#enable-memory64"><code class="Fl">--enable-memory64</code></a></dt>
+  <dd>Enable 64-bit memory</dd>
+  <dt id="enable-multi-memory"><a class="permalink" href="#enable-multi-memory"><code class="Fl">--enable-multi-memory</code></a></dt>
+  <dd>Enable Multi-memory</dd>
+  <dt id="enable-extended-const"><a class="permalink" href="#enable-extended-const"><code class="Fl">--enable-extended-const</code></a></dt>
+  <dd>Enable Extended constant expressions</dd>
+  <dt id="enable-all"><a class="permalink" href="#enable-all"><code class="Fl">--enable-all</code></a></dt>
+  <dd>Enable all features</dd>
+  <dt id="no-debug-names"><a class="permalink" href="#no-debug-names"><code class="Fl">--no-debug-names</code></a></dt>
   <dd>Ignore debug names in the binary file</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-ignore-custom-section-errors</code></dt>
+  <dt id="ignore-custom-section-errors"><a class="permalink" href="#ignore-custom-section-errors"><code class="Fl">--ignore-custom-section-errors</code></a></dt>
   <dd>Ignore errors in custom sections</dd>
 </dl>
 </section>
 <section class="Sh">
 <h1 class="Sh" id="EXAMPLES"><a class="permalink" href="#EXAMPLES">EXAMPLES</a></h1>
-Validate binary file test.wasm
+<p class="Pp">Validate binary file test.wasm</p>
 <p class="Pp"></p>
 <div class="Bd Bd-indent"><code class="Li">$ wasm-validate
   test.wasm</code></div>
@@ -82,27 +104,28 @@ Validate binary file test.wasm
 <section class="Sh">
 <h1 class="Sh" id="SEE_ALSO"><a class="permalink" href="#SEE_ALSO">SEE
   ALSO</a></h1>
-<a class="Xr" href="wasm-interp.1.html">wasm-interp(1)</a>,
-  <a class="Xr" href="wasm-objdump.1.html">wasm-objdump(1)</a>,
-  <a class="Xr" href="wasm-stats.1.html">wasm-stats(1)</a>,
-  <a class="Xr" href="wasm-strip.1.html">wasm-strip(1)</a>,
-  <a class="Xr" href="wasm2c.1.html">wasm2c(1)</a>,
-  <a class="Xr" href="wasm2wat.1.html">wasm2wat(1)</a>,
-  <a class="Xr" href="wast2json.1.html">wast2json(1)</a>,
-  <a class="Xr" href="wat-desugar.1.html">wat-desugar(1)</a>,
-  <a class="Xr" href="wat2wasm.1.html">wat2wasm(1)</a>,
-  <a class="Xr" href="spectest-interp.1.html">spectest-interp(1)</a>
+<p class="Pp"><a class="Xr" href="wasm-decompile.1.html">wasm-decompile(1)</a>,
+    <a class="Xr" href="wasm-interp.1.html">wasm-interp(1)</a>,
+    <a class="Xr" href="wasm-objdump.1.html">wasm-objdump(1)</a>,
+    <a class="Xr" href="wasm-stats.1.html">wasm-stats(1)</a>,
+    <a class="Xr" href="wasm-strip.1.html">wasm-strip(1)</a>,
+    <a class="Xr" href="wasm2c.1.html">wasm2c(1)</a>,
+    <a class="Xr" href="wasm2wat.1.html">wasm2wat(1)</a>,
+    <a class="Xr" href="wast2json.1.html">wast2json(1)</a>,
+    <a class="Xr" href="wat-desugar.1.html">wat-desugar(1)</a>,
+    <a class="Xr" href="wat2wasm.1.html">wat2wasm(1)</a>,
+    <a class="Xr" href="spectest-interp.1.html">spectest-interp(1)</a></p>
 </section>
 <section class="Sh">
 <h1 class="Sh" id="BUGS"><a class="permalink" href="#BUGS">BUGS</a></h1>
-If you find a bug, please report it at
-<br/>
-<a class="Lk" href="https://github.com/WebAssembly/wabt/issues">https://github.com/WebAssembly/wabt/issues</a>.
+<p class="Pp">If you find a bug, please report it at
+  <br/>
+  <a class="Lk" href="https://github.com/WebAssembly/wabt/issues">https://github.com/WebAssembly/wabt/issues</a>.</p>
 </section>
 </div>
 <table class="foot">
   <tr>
-    <td class="foot-date">October 7, 2021</td>
+    <td class="foot-date">September 23, 2025</td>
     <td class="foot-os">Debian</td>
   </tr>
 </table>

--- a/docs/doc/wasm2c.1.html
+++ b/docs/doc/wasm2c.1.html
@@ -2,17 +2,17 @@
 <html>
 <head>
   <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <style>
     table.head, table.foot { width: 100%; }
     td.head-rtitle, td.foot-os { text-align: right; }
     td.head-vol { text-align: center; }
-    div.Pp { margin: 1ex 0ex; }
-    div.Nd, div.Bf, div.Op { display: inline; }
-    span.Pa, span.Ad { font-style: italic; }
-    span.Ms { font-weight: bold; }
-    dl.Bl-diag > dt { font-weight: bold; }
-    code.Nm, code.Fl, code.Cm, code.Ic, code.In, code.Fd, code.Fn,
-    code.Cd { font-weight: bold; font-family: inherit; }
+    .Nd, .Bf, .Op { display: inline; }
+    .Pa, .Ad { font-style: italic; }
+    .Ms { font-weight: bold; }
+    .Bl-diag > dt { font-weight: bold; }
+    code.Nm, .Fl, .Cm, .Ic, code.In, .Fd, .Fn, .Cd { font-weight: bold;
+      font-family: inherit; }
   </style>
   <title>WABT(1)</title>
 </head>
@@ -27,8 +27,8 @@
 <div class="manual-text">
 <section class="Sh">
 <h1 class="Sh" id="NAME"><a class="permalink" href="#NAME">NAME</a></h1>
-<code class="Nm">wasm2c</code> &#x2014;
-<div class="Nd">convert a WebAssembly binary file to a C source and header</div>
+<p class="Pp"><code class="Nm">wasm2c</code> &#x2014; <span class="Nd">convert a
+    WebAssembly binary file to a C source and header</span></p>
 </section>
 <section class="Sh">
 <h1 class="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h1>
@@ -41,37 +41,69 @@
 </section>
 <section class="Sh">
 <h1 class="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h1>
-<code class="Nm">wasm2c</code> takes a WebAssembly module and produces an
-  equivalent C source and header.
+<p class="Pp"><code class="Nm">wasm2c</code> takes a WebAssembly module and
+    produces an equivalent C source and header.</p>
 <p class="Pp">The options are as follows:</p>
 <dl class="Bl-tag">
-  <dt><a class="permalink" href="#v"><code class="Fl" id="v">-v</code></a>,
-    <code class="Fl">-</code><code class="Fl">-verbose</code></dt>
-  <dd>Use multiple times for more info</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-help</code></dt>
+  <dt id="help"><a class="permalink" href="#help"><code class="Fl">--help</code></a></dt>
   <dd>Print a help message</dd>
-  <dt><a class="permalink" href="#o"><code class="Fl" id="o">-o</code></a>,
-    <code class="Fl">-</code><code class="Fl">-output=FILENAME</code></dt>
+  <dt id="version"><a class="permalink" href="#version"><code class="Fl">--version</code></a></dt>
+  <dd>Print version information</dd>
+  <dt id="v"><a class="permalink" href="#v"><code class="Fl">-v</code></a>,
+    <code class="Fl">--verbose</code></dt>
+  <dd>Use multiple times for more info</dd>
+  <dt id="o"><a class="permalink" href="#o"><code class="Fl">-o</code></a>,
+    <code class="Fl">--output=FILENAME</code></dt>
   <dd>Output file for the generated C source file, by default use stdout</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-enable-exceptions</code></dt>
-  <dd>Experimental exception handling</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-disable-mutable-globals</code></dt>
-  <dd>Import/export mutable globals</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-enable-saturating-float-to-int</code></dt>
-  <dd>Saturating float-to-int operators</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-enable-sign-extension</code></dt>
-  <dd>Sign-extension operators</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-disable-simd</code></dt>
-  <dd>SIMD support</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-enable-threads</code></dt>
-  <dd>Threading support</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-no-debug-names</code></dt>
+  <dt id="n"><a class="permalink" href="#n"><code class="Fl">-n</code></a>,
+    <code class="Fl">--module-name=MODNAME</code></dt>
+  <dd>Unique name for the module being generated. This name is prefixed to each
+      of the generaed C symbols. By default, the module name from the names
+      section is used. If that is not present the name of the input file is used
+      as the default.</dd>
+  <dt id="enable-exceptions"><a class="permalink" href="#enable-exceptions"><code class="Fl">--enable-exceptions</code></a></dt>
+  <dd>Enable Experimental exception handling</dd>
+  <dt id="disable-mutable-globals"><a class="permalink" href="#disable-mutable-globals"><code class="Fl">--disable-mutable-globals</code></a></dt>
+  <dd>Disable Import/export mutable globals</dd>
+  <dt id="disable-saturating-float-to-int"><a class="permalink" href="#disable-saturating-float-to-int"><code class="Fl">--disable-saturating-float-to-int</code></a></dt>
+  <dd>Disable Saturating float-to-int operators</dd>
+  <dt id="disable-sign-extension"><a class="permalink" href="#disable-sign-extension"><code class="Fl">--disable-sign-extension</code></a></dt>
+  <dd>Disable Sign-extension operators</dd>
+  <dt id="disable-simd"><a class="permalink" href="#disable-simd"><code class="Fl">--disable-simd</code></a></dt>
+  <dd>Disable SIMD support</dd>
+  <dt id="enable-threads"><a class="permalink" href="#enable-threads"><code class="Fl">--enable-threads</code></a></dt>
+  <dd>Enable Threading support</dd>
+  <dt id="enable-function-references"><a class="permalink" href="#enable-function-references"><code class="Fl">--enable-function-references</code></a></dt>
+  <dd>Enable Typed function references</dd>
+  <dt id="disable-multi-value"><a class="permalink" href="#disable-multi-value"><code class="Fl">--disable-multi-value</code></a></dt>
+  <dd>Disable Multi-value</dd>
+  <dt id="enable-tail-call"><a class="permalink" href="#enable-tail-call"><code class="Fl">--enable-tail-call</code></a></dt>
+  <dd>Enable Tail-call support</dd>
+  <dt id="disable-bulk-memory"><a class="permalink" href="#disable-bulk-memory"><code class="Fl">--disable-bulk-memory</code></a></dt>
+  <dd>Disable Bulk-memory operations</dd>
+  <dt id="disable-reference-types"><a class="permalink" href="#disable-reference-types"><code class="Fl">--disable-reference-types</code></a></dt>
+  <dd>Disable Reference types (externref)</dd>
+  <dt id="enable-annotations"><a class="permalink" href="#enable-annotations"><code class="Fl">--enable-annotations</code></a></dt>
+  <dd>Enable Custom annotation syntax</dd>
+  <dt id="enable-code-metadata"><a class="permalink" href="#enable-code-metadata"><code class="Fl">--enable-code-metadata</code></a></dt>
+  <dd>Enable Code metadata</dd>
+  <dt id="enable-gc"><a class="permalink" href="#enable-gc"><code class="Fl">--enable-gc</code></a></dt>
+  <dd>Enable Garbage collection</dd>
+  <dt id="enable-memory64"><a class="permalink" href="#enable-memory64"><code class="Fl">--enable-memory64</code></a></dt>
+  <dd>Enable 64-bit memory</dd>
+  <dt id="enable-multi-memory"><a class="permalink" href="#enable-multi-memory"><code class="Fl">--enable-multi-memory</code></a></dt>
+  <dd>Enable Multi-memory</dd>
+  <dt id="enable-extended-const"><a class="permalink" href="#enable-extended-const"><code class="Fl">--enable-extended-const</code></a></dt>
+  <dd>Enable Extended constant expressions</dd>
+  <dt id="enable-all"><a class="permalink" href="#enable-all"><code class="Fl">--enable-all</code></a></dt>
+  <dd>Enable all features</dd>
+  <dt id="no-debug-names"><a class="permalink" href="#no-debug-names"><code class="Fl">--no-debug-names</code></a></dt>
   <dd>Ignore debug names in the binary file</dd>
 </dl>
 </section>
 <section class="Sh">
 <h1 class="Sh" id="EXAMPLES"><a class="permalink" href="#EXAMPLES">EXAMPLES</a></h1>
-Parse binary file test.wasm and write test.c and test.h
+<p class="Pp">Parse binary file test.wasm and write test.c and test.h</p>
 <p class="Pp"></p>
 <div class="Bd Bd-indent"><code class="Li">$ wasm2c test.wasm -o
   test.c</code></div>
@@ -84,27 +116,28 @@ Parse binary file test.wasm and write test.c and test.h
 <section class="Sh">
 <h1 class="Sh" id="SEE_ALSO"><a class="permalink" href="#SEE_ALSO">SEE
   ALSO</a></h1>
-<a class="Xr" href="wasm-interp.1.html">wasm-interp(1)</a>,
-  <a class="Xr" href="wasm-objdump.1.html">wasm-objdump(1)</a>,
-  <a class="Xr" href="wasm-stats.1.html">wasm-stats(1)</a>,
-  <a class="Xr" href="wasm-strip.1.html">wasm-strip(1)</a>,
-  <a class="Xr" href="wasm-validate.1.html">wasm-validate(1)</a>,
-  <a class="Xr" href="wasm2wat.1.html">wasm2wat(1)</a>,
-  <a class="Xr" href="wast2json.1.html">wast2json(1)</a>,
-  <a class="Xr" href="wat-desugar.1.html">wat-desugar(1)</a>,
-  <a class="Xr" href="wat2wasm.1.html">wat2wasm(1)</a>,
-  <a class="Xr" href="spectest-interp.1.html">spectest-interp(1)</a>
+<p class="Pp"><a class="Xr" href="wasm-decompile.1.html">wasm-decompile(1)</a>,
+    <a class="Xr" href="wasm-interp.1.html">wasm-interp(1)</a>,
+    <a class="Xr" href="wasm-objdump.1.html">wasm-objdump(1)</a>,
+    <a class="Xr" href="wasm-stats.1.html">wasm-stats(1)</a>,
+    <a class="Xr" href="wasm-strip.1.html">wasm-strip(1)</a>,
+    <a class="Xr" href="wasm-validate.1.html">wasm-validate(1)</a>,
+    <a class="Xr" href="wasm2wat.1.html">wasm2wat(1)</a>,
+    <a class="Xr" href="wast2json.1.html">wast2json(1)</a>,
+    <a class="Xr" href="wat-desugar.1.html">wat-desugar(1)</a>,
+    <a class="Xr" href="wat2wasm.1.html">wat2wasm(1)</a>,
+    <a class="Xr" href="spectest-interp.1.html">spectest-interp(1)</a></p>
 </section>
 <section class="Sh">
 <h1 class="Sh" id="BUGS"><a class="permalink" href="#BUGS">BUGS</a></h1>
-If you find a bug, please report it at
-<br/>
-<a class="Lk" href="https://github.com/WebAssembly/wabt/issues">https://github.com/WebAssembly/wabt/issues</a>.
+<p class="Pp">If you find a bug, please report it at
+  <br/>
+  <a class="Lk" href="https://github.com/WebAssembly/wabt/issues">https://github.com/WebAssembly/wabt/issues</a>.</p>
 </section>
 </div>
 <table class="foot">
   <tr>
-    <td class="foot-date">October 7, 2021</td>
+    <td class="foot-date">September 23, 2025</td>
     <td class="foot-os">Debian</td>
   </tr>
 </table>

--- a/docs/doc/wasm2wat.1.html
+++ b/docs/doc/wasm2wat.1.html
@@ -2,17 +2,17 @@
 <html>
 <head>
   <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <style>
     table.head, table.foot { width: 100%; }
     td.head-rtitle, td.foot-os { text-align: right; }
     td.head-vol { text-align: center; }
-    div.Pp { margin: 1ex 0ex; }
-    div.Nd, div.Bf, div.Op { display: inline; }
-    span.Pa, span.Ad { font-style: italic; }
-    span.Ms { font-weight: bold; }
-    dl.Bl-diag > dt { font-weight: bold; }
-    code.Nm, code.Fl, code.Cm, code.Ic, code.In, code.Fd, code.Fn,
-    code.Cd { font-weight: bold; font-family: inherit; }
+    .Nd, .Bf, .Op { display: inline; }
+    .Pa, .Ad { font-style: italic; }
+    .Ms { font-weight: bold; }
+    .Bl-diag > dt { font-weight: bold; }
+    code.Nm, .Fl, .Cm, .Ic, code.In, .Fd, .Fn, .Cd { font-weight: bold;
+      font-family: inherit; }
   </style>
   <title>WABT(1)</title>
 </head>
@@ -27,8 +27,9 @@
 <div class="manual-text">
 <section class="Sh">
 <h1 class="Sh" id="NAME"><a class="permalink" href="#NAME">NAME</a></h1>
-<code class="Nm">wasm2wat</code> &#x2014;
-<div class="Nd">translate from the binary format to the text format</div>
+<p class="Pp"><code class="Nm">wasm2wat</code> &#x2014;
+    <span class="Nd">translate from the binary format to the text
+  format</span></p>
 </section>
 <section class="Sh">
 <h1 class="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h1>
@@ -41,48 +42,76 @@
 </section>
 <section class="Sh">
 <h1 class="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h1>
-<code class="Nm">wasm2wat</code> does the inverse of wat2wasm, translate from
-  the binary format back to the text format (also known as a .wat).
+<p class="Pp"><code class="Nm">wasm2wat</code> Read a file in the WebAssembly
+    binary format, and convert it to the WebAssembly text format.</p>
 <p class="Pp">The options are as follows:</p>
 <dl class="Bl-tag">
-  <dt><a class="permalink" href="#v"><code class="Fl" id="v">-v</code></a>,
-    <code class="Fl">-</code><code class="Fl">-verbose</code></dt>
-  <dd>Use multiple times for more info</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-help</code></dt>
+  <dt id="help"><a class="permalink" href="#help"><code class="Fl">--help</code></a></dt>
   <dd>Print a help message</dd>
-  <dt><a class="permalink" href="#o"><code class="Fl" id="o">-o</code></a>,
-    <code class="Fl">-</code><code class="Fl">-output=FILENAME</code></dt>
+  <dt id="version"><a class="permalink" href="#version"><code class="Fl">--version</code></a></dt>
+  <dd>Print version information</dd>
+  <dt id="v"><a class="permalink" href="#v"><code class="Fl">-v</code></a>,
+    <code class="Fl">--verbose</code></dt>
+  <dd>Use multiple times for more info</dd>
+  <dt id="o"><a class="permalink" href="#o"><code class="Fl">-o</code></a>,
+    <code class="Fl">--output=FILENAME</code></dt>
   <dd>Output file for the generated wast file, by default use stdout</dd>
-  <dt><a class="permalink" href="#f"><code class="Fl" id="f">-f</code></a>,
-    <code class="Fl">-</code><code class="Fl">-fold-exprs</code></dt>
+  <dt id="f"><a class="permalink" href="#f"><code class="Fl">-f</code></a>,
+    <code class="Fl">--fold-exprs</code></dt>
   <dd>Write folded expressions where possible</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-enable-exceptions</code></dt>
-  <dd>Experimental exception handling</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-disable-mutable-globals</code></dt>
-  <dd>Import/export mutable globals</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-enable-saturating-float-to-int</code></dt>
-  <dd>Saturating float-to-int operators</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-enable-sign-extension</code></dt>
-  <dd>Sign-extension operators</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-disable-simd</code></dt>
-  <dd>SIMD support</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-enable-threads</code></dt>
-  <dd>Threading support</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-inline-exports</code></dt>
+  <dt id="enable-exceptions"><a class="permalink" href="#enable-exceptions"><code class="Fl">--enable-exceptions</code></a></dt>
+  <dd>Enable Experimental exception handling</dd>
+  <dt id="disable-mutable-globals"><a class="permalink" href="#disable-mutable-globals"><code class="Fl">--disable-mutable-globals</code></a></dt>
+  <dd>Disable Import/export mutable globals</dd>
+  <dt id="disable-saturating-float-to-int"><a class="permalink" href="#disable-saturating-float-to-int"><code class="Fl">--disable-saturating-float-to-int</code></a></dt>
+  <dd>Disable Saturating float-to-int operators</dd>
+  <dt id="disable-sign-extension"><a class="permalink" href="#disable-sign-extension"><code class="Fl">--disable-sign-extension</code></a></dt>
+  <dd>Disable Sign-extension operators</dd>
+  <dt id="disable-simd"><a class="permalink" href="#disable-simd"><code class="Fl">--disable-simd</code></a></dt>
+  <dd>Disable SIMD support</dd>
+  <dt id="enable-threads"><a class="permalink" href="#enable-threads"><code class="Fl">--enable-threads</code></a></dt>
+  <dd>Enable Threading support</dd>
+  <dt id="enable-function-references"><a class="permalink" href="#enable-function-references"><code class="Fl">--enable-function-references</code></a></dt>
+  <dd>Enable Typed function references</dd>
+  <dt id="disable-multi-value"><a class="permalink" href="#disable-multi-value"><code class="Fl">--disable-multi-value</code></a></dt>
+  <dd>Disable Multi-value</dd>
+  <dt id="enable-tail-call"><a class="permalink" href="#enable-tail-call"><code class="Fl">--enable-tail-call</code></a></dt>
+  <dd>Enable Tail-call support</dd>
+  <dt id="disable-bulk-memory"><a class="permalink" href="#disable-bulk-memory"><code class="Fl">--disable-bulk-memory</code></a></dt>
+  <dd>Disable Bulk-memory operations</dd>
+  <dt id="disable-reference-types"><a class="permalink" href="#disable-reference-types"><code class="Fl">--disable-reference-types</code></a></dt>
+  <dd>Disable Reference types (externref)</dd>
+  <dt id="enable-annotations"><a class="permalink" href="#enable-annotations"><code class="Fl">--enable-annotations</code></a></dt>
+  <dd>Enable Custom annotation syntax</dd>
+  <dt id="enable-code-metadata"><a class="permalink" href="#enable-code-metadata"><code class="Fl">--enable-code-metadata</code></a></dt>
+  <dd>Enable Code metadata</dd>
+  <dt id="enable-gc"><a class="permalink" href="#enable-gc"><code class="Fl">--enable-gc</code></a></dt>
+  <dd>Enable Garbage collection</dd>
+  <dt id="enable-memory64"><a class="permalink" href="#enable-memory64"><code class="Fl">--enable-memory64</code></a></dt>
+  <dd>Enable 64-bit memory</dd>
+  <dt id="enable-multi-memory"><a class="permalink" href="#enable-multi-memory"><code class="Fl">--enable-multi-memory</code></a></dt>
+  <dd>Enable Multi-memory</dd>
+  <dt id="enable-extended-const"><a class="permalink" href="#enable-extended-const"><code class="Fl">--enable-extended-const</code></a></dt>
+  <dd>Enable Extended constant expressions</dd>
+  <dt id="enable-all"><a class="permalink" href="#enable-all"><code class="Fl">--enable-all</code></a></dt>
+  <dd>Enable all features</dd>
+  <dt id="inline-exports"><a class="permalink" href="#inline-exports"><code class="Fl">--inline-exports</code></a></dt>
   <dd>Write all exports inline</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-inline-imports</code></dt>
+  <dt id="inline-imports"><a class="permalink" href="#inline-imports"><code class="Fl">--inline-imports</code></a></dt>
   <dd>Write all imports inline</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-no-debug-names</code></dt>
+  <dt id="no-debug-names"><a class="permalink" href="#no-debug-names"><code class="Fl">--no-debug-names</code></a></dt>
   <dd>Ignore debug names in the binary file</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-generate-names</code></dt>
+  <dt id="ignore-custom-section-errors"><a class="permalink" href="#ignore-custom-section-errors"><code class="Fl">--ignore-custom-section-errors</code></a></dt>
+  <dd>Ignore errors in custom sections</dd>
+  <dt id="generate-names"><a class="permalink" href="#generate-names"><code class="Fl">--generate-names</code></a></dt>
   <dd>Give auto-generated names to non-named functions, types, etc.</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-no-check</code></dt>
+  <dt id="no-check"><a class="permalink" href="#no-check"><code class="Fl">--no-check</code></a></dt>
   <dd>Don't check for invalid modules</dd>
 </dl>
 </section>
 <section class="Sh">
 <h1 class="Sh" id="EXAMPLES"><a class="permalink" href="#EXAMPLES">EXAMPLES</a></h1>
-Parse binary file test.wasm and write text file test.wast
+<p class="Pp">Parse binary file test.wasm and write text file test.wast</p>
 <p class="Pp"></p>
 <div class="Bd Bd-indent"><code class="Li">$ wasm2wat test.wasm -o
   test.wat</code></div>
@@ -95,27 +124,28 @@ Parse binary file test.wasm and write text file test.wast
 <section class="Sh">
 <h1 class="Sh" id="SEE_ALSO"><a class="permalink" href="#SEE_ALSO">SEE
   ALSO</a></h1>
-<a class="Xr" href="wasm-interp.1.html">wasm-interp(1)</a>,
-  <a class="Xr" href="wasm-objdump.1.html">wasm-objdump(1)</a>,
-  <a class="Xr" href="wasm-stats.1.html">wasm-stats(1)</a>,
-  <a class="Xr" href="wasm-strip.1.html">wasm-strip(1)</a>,
-  <a class="Xr" href="wasm-validate.1.html">wasm-validate(1)</a>,
-  <a class="Xr" href="wasm2c.1.html">wasm2c(1)</a>,
-  <a class="Xr" href="wast2json.1.html">wast2json(1)</a>,
-  <a class="Xr" href="wat-desugar.1.html">wat-desugar(1)</a>,
-  <a class="Xr" href="wat2wasm.1.html">wat2wasm(1)</a>,
-  <a class="Xr" href="spectest-interp.1.html">spectest-interp(1)</a>
+<p class="Pp"><a class="Xr" href="wasm-decompile.1.html">wasm-decompile(1)</a>,
+    <a class="Xr" href="wasm-interp.1.html">wasm-interp(1)</a>,
+    <a class="Xr" href="wasm-objdump.1.html">wasm-objdump(1)</a>,
+    <a class="Xr" href="wasm-stats.1.html">wasm-stats(1)</a>,
+    <a class="Xr" href="wasm-strip.1.html">wasm-strip(1)</a>,
+    <a class="Xr" href="wasm-validate.1.html">wasm-validate(1)</a>,
+    <a class="Xr" href="wasm2c.1.html">wasm2c(1)</a>,
+    <a class="Xr" href="wast2json.1.html">wast2json(1)</a>,
+    <a class="Xr" href="wat-desugar.1.html">wat-desugar(1)</a>,
+    <a class="Xr" href="wat2wasm.1.html">wat2wasm(1)</a>,
+    <a class="Xr" href="spectest-interp.1.html">spectest-interp(1)</a></p>
 </section>
 <section class="Sh">
 <h1 class="Sh" id="BUGS"><a class="permalink" href="#BUGS">BUGS</a></h1>
-If you find a bug, please report it at
-<br/>
-<a class="Lk" href="https://github.com/WebAssembly/wabt/issues">https://github.com/WebAssembly/wabt/issues</a>.
+<p class="Pp">If you find a bug, please report it at
+  <br/>
+  <a class="Lk" href="https://github.com/WebAssembly/wabt/issues">https://github.com/WebAssembly/wabt/issues</a>.</p>
 </section>
 </div>
 <table class="foot">
   <tr>
-    <td class="foot-date">October 7, 2021</td>
+    <td class="foot-date">September 23, 2025</td>
     <td class="foot-os">Debian</td>
   </tr>
 </table>

--- a/docs/doc/wast2json.1.html
+++ b/docs/doc/wast2json.1.html
@@ -2,17 +2,17 @@
 <html>
 <head>
   <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <style>
     table.head, table.foot { width: 100%; }
     td.head-rtitle, td.foot-os { text-align: right; }
     td.head-vol { text-align: center; }
-    div.Pp { margin: 1ex 0ex; }
-    div.Nd, div.Bf, div.Op { display: inline; }
-    span.Pa, span.Ad { font-style: italic; }
-    span.Ms { font-weight: bold; }
-    dl.Bl-diag > dt { font-weight: bold; }
-    code.Nm, code.Fl, code.Cm, code.Ic, code.In, code.Fd, code.Fn,
-    code.Cd { font-weight: bold; font-family: inherit; }
+    .Nd, .Bf, .Op { display: inline; }
+    .Pa, .Ad { font-style: italic; }
+    .Ms { font-weight: bold; }
+    .Bl-diag > dt { font-weight: bold; }
+    code.Nm, .Fl, .Cm, .Ic, code.In, .Fd, .Fn, .Cd { font-weight: bold;
+      font-family: inherit; }
   </style>
   <title>WABT(1)</title>
 </head>
@@ -27,9 +27,9 @@
 <div class="manual-text">
 <section class="Sh">
 <h1 class="Sh" id="NAME"><a class="permalink" href="#NAME">NAME</a></h1>
-<code class="Nm">wast2json</code> &#x2014;
-<div class="Nd">convert a file in the wasm spec test format to a JSON file and
-  associated wasm binary files</div>
+<p class="Pp"><code class="Nm">wast2json</code> &#x2014;
+    <span class="Nd">convert a file in the wasm spec test format to a JSON file
+    and associated wasm binary files</span></p>
 </section>
 <section class="Sh">
 <h1 class="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h1>
@@ -42,52 +42,74 @@
 </section>
 <section class="Sh">
 <h1 class="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h1>
-<code class="Nm">wast2json</code> reads a file in the wasm spec test format,
-  checks it for errors, and converts it to a JSON file and associated wasm
-  binary files.
+<p class="Pp"><code class="Nm">wast2json</code> Read a file in the wasm spec
+    test format, check it for errors, and convert it to a JSON file and
+    associated wasm binary files.</p>
 <p class="Pp">The options are as follows:</p>
 <dl class="Bl-tag">
-  <dt><a class="permalink" href="#v"><code class="Fl" id="v">-v</code></a>,
-    <code class="Fl">-</code><code class="Fl">-verbose</code></dt>
-  <dd>Use multiple times for more info</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-help</code></dt>
+  <dt id="help"><a class="permalink" href="#help"><code class="Fl">--help</code></a></dt>
   <dd>Print this help message</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-debug-parser</code></dt>
+  <dt id="version"><a class="permalink" href="#version"><code class="Fl">--version</code></a></dt>
+  <dd>Print version information</dd>
+  <dt id="v"><a class="permalink" href="#v"><code class="Fl">-v</code></a>,
+    <code class="Fl">--verbose</code></dt>
+  <dd>Use multiple times for more info</dd>
+  <dt id="debug-parser"><a class="permalink" href="#debug-parser"><code class="Fl">--debug-parser</code></a></dt>
   <dd>Turn on debugging the parser of wast files</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-enable-exceptions</code></dt>
+  <dt id="enable-exceptions"><a class="permalink" href="#enable-exceptions"><code class="Fl">--enable-exceptions</code></a></dt>
   <dd>Enable Experimental exception handling</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-disable-mutable-globals</code></dt>
+  <dt id="disable-mutable-globals"><a class="permalink" href="#disable-mutable-globals"><code class="Fl">--disable-mutable-globals</code></a></dt>
   <dd>Disable Import/export mutable globals</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-enable-saturating-float-to-int</code></dt>
-  <dd>Enable Saturating float-to-int operators</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-enable-sign-extension</code></dt>
-  <dd>Enable Sign-extension operators</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-disable-simd</code></dt>
+  <dt id="disable-saturating-float-to-int"><a class="permalink" href="#disable-saturating-float-to-int"><code class="Fl">--disable-saturating-float-to-int</code></a></dt>
+  <dd>Disable Saturating float-to-int operators</dd>
+  <dt id="disable-sign-extension"><a class="permalink" href="#disable-sign-extension"><code class="Fl">--disable-sign-extension</code></a></dt>
+  <dd>Disable Sign-extension operators</dd>
+  <dt id="disable-simd"><a class="permalink" href="#disable-simd"><code class="Fl">--disable-simd</code></a></dt>
   <dd>Disable SIMD support</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-enable-threads</code></dt>
+  <dt id="enable-threads"><a class="permalink" href="#enable-threads"><code class="Fl">--enable-threads</code></a></dt>
   <dd>Enable Threading support</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-enable-multi-value</code></dt>
-  <dd>Enable Multi-value</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-enable-tail-call</code></dt>
+  <dt id="enable-function-references"><a class="permalink" href="#enable-function-references"><code class="Fl">--enable-function-references</code></a></dt>
+  <dd>Enable Typed function references</dd>
+  <dt id="disable-multi-value"><a class="permalink" href="#disable-multi-value"><code class="Fl">--disable-multi-value</code></a></dt>
+  <dd>Disable Multi-value</dd>
+  <dt id="enable-tail-call"><a class="permalink" href="#enable-tail-call"><code class="Fl">--enable-tail-call</code></a></dt>
   <dd>Enable Tail-call support</dd>
-  <dt><a class="permalink" href="#o"><code class="Fl" id="o">-o</code></a>,
-    <code class="Fl">-</code><code class="Fl">-output=FILE</code></dt>
-  <dd>output wasm binary file</dd>
-  <dt><a class="permalink" href="#r"><code class="Fl" id="r">-r</code></a>,
-    <code class="Fl">-</code><code class="Fl">-relocatable</code></dt>
+  <dt id="disable-bulk-memory"><a class="permalink" href="#disable-bulk-memory"><code class="Fl">--disable-bulk-memory</code></a></dt>
+  <dd>Disable Bulk-memory operations</dd>
+  <dt id="disable-reference-types"><a class="permalink" href="#disable-reference-types"><code class="Fl">--disable-reference-types</code></a></dt>
+  <dd>Disable Reference types (externref)</dd>
+  <dt id="enable-annotations"><a class="permalink" href="#enable-annotations"><code class="Fl">--enable-annotations</code></a></dt>
+  <dd>Enable Custom annotation syntax</dd>
+  <dt id="enable-code-metadata"><a class="permalink" href="#enable-code-metadata"><code class="Fl">--enable-code-metadata</code></a></dt>
+  <dd>Enable Code metadata</dd>
+  <dt id="enable-gc"><a class="permalink" href="#enable-gc"><code class="Fl">--enable-gc</code></a></dt>
+  <dd>Enable Garbage collection</dd>
+  <dt id="enable-memory64"><a class="permalink" href="#enable-memory64"><code class="Fl">--enable-memory64</code></a></dt>
+  <dd>Enable 64-bit memory</dd>
+  <dt id="enable-multi-memory"><a class="permalink" href="#enable-multi-memory"><code class="Fl">--enable-multi-memory</code></a></dt>
+  <dd>Enable Multi-memory</dd>
+  <dt id="enable-extended-const"><a class="permalink" href="#enable-extended-const"><code class="Fl">--enable-extended-const</code></a></dt>
+  <dd>Enable Extended constant expressions</dd>
+  <dt id="enable-all"><a class="permalink" href="#enable-all"><code class="Fl">--enable-all</code></a></dt>
+  <dd>Enable all features</dd>
+  <dt id="o"><a class="permalink" href="#o"><code class="Fl">-o</code></a>,
+    <code class="Fl">--output=FILE</code></dt>
+  <dd>output JSON file</dd>
+  <dt id="r"><a class="permalink" href="#r"><code class="Fl">-r</code></a>,
+    <code class="Fl">--relocatable</code></dt>
   <dd>Create a relocatable wasm binary (suitable for linking with e.g. lld)</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-no-canonicalize-leb128s</code></dt>
+  <dt id="no-canonicalize-leb128s"><a class="permalink" href="#no-canonicalize-leb128s"><code class="Fl">--no-canonicalize-leb128s</code></a></dt>
   <dd>Write all LEB128 sizes as 5-bytes instead of their minimal size</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-debug-names</code></dt>
+  <dt id="debug-names"><a class="permalink" href="#debug-names"><code class="Fl">--debug-names</code></a></dt>
   <dd>Write debug names to the generated binary file</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-no-check</code></dt>
+  <dt id="no-check"><a class="permalink" href="#no-check"><code class="Fl">--no-check</code></a></dt>
   <dd>Don't check for invalid modules</dd>
 </dl>
 </section>
 <section class="Sh">
 <h1 class="Sh" id="EXAMPLES"><a class="permalink" href="#EXAMPLES">EXAMPLES</a></h1>
-Parse spec-test.wast, and write files to spec-test.json. Modules are written to
-  spec-test.0.wasm, spec-test.1.wasm, etc.
+<p class="Pp">Parse spec-test.wast, and write files to spec-test.json. Modules
+    are written to spec-test.0.wasm, spec-test.1.wasm, etc.</p>
 <p class="Pp"></p>
 <div class="Bd Bd-indent"><code class="Li">$ wast2json spec-test.wast -o
   spec-test.json</code></div>
@@ -95,27 +117,28 @@ Parse spec-test.wast, and write files to spec-test.json. Modules are written to
 <section class="Sh">
 <h1 class="Sh" id="SEE_ALSO"><a class="permalink" href="#SEE_ALSO">SEE
   ALSO</a></h1>
-<a class="Xr" href="wasm-interp.1.html">wasm-interp(1)</a>,
-  <a class="Xr" href="wasm-objdump.1.html">wasm-objdump(1)</a>,
-  <a class="Xr" href="wasm-stats.1.html">wasm-stats(1)</a>,
-  <a class="Xr" href="wasm-strip.1.html">wasm-strip(1)</a>,
-  <a class="Xr" href="wasm-validate.1.html">wasm-validate(1)</a>,
-  <a class="Xr" href="wasm2c.1.html">wasm2c(1)</a>,
-  <a class="Xr" href="wasm2wat.1.html">wasm2wat(1)</a>,
-  <a class="Xr" href="wat-desugar.1.html">wat-desugar(1)</a>,
-  <a class="Xr" href="wat2wasm.1.html">wat2wasm(1)</a>,
-  <a class="Xr" href="spectest-interp.1.html">spectest-interp(1)</a>
+<p class="Pp"><a class="Xr" href="wasm-decompile.1.html">wasm-decompile(1)</a>,
+    <a class="Xr" href="wasm-interp.1.html">wasm-interp(1)</a>,
+    <a class="Xr" href="wasm-objdump.1.html">wasm-objdump(1)</a>,
+    <a class="Xr" href="wasm-stats.1.html">wasm-stats(1)</a>,
+    <a class="Xr" href="wasm-strip.1.html">wasm-strip(1)</a>,
+    <a class="Xr" href="wasm-validate.1.html">wasm-validate(1)</a>,
+    <a class="Xr" href="wasm2c.1.html">wasm2c(1)</a>,
+    <a class="Xr" href="wasm2wat.1.html">wasm2wat(1)</a>,
+    <a class="Xr" href="wat-desugar.1.html">wat-desugar(1)</a>,
+    <a class="Xr" href="wat2wasm.1.html">wat2wasm(1)</a>,
+    <a class="Xr" href="spectest-interp.1.html">spectest-interp(1)</a></p>
 </section>
 <section class="Sh">
 <h1 class="Sh" id="BUGS"><a class="permalink" href="#BUGS">BUGS</a></h1>
-If you find a bug, please report it at
-<br/>
-<a class="Lk" href="https://github.com/WebAssembly/wabt/issues">https://github.com/WebAssembly/wabt/issues</a>.
+<p class="Pp">If you find a bug, please report it at
+  <br/>
+  <a class="Lk" href="https://github.com/WebAssembly/wabt/issues">https://github.com/WebAssembly/wabt/issues</a>.</p>
 </section>
 </div>
 <table class="foot">
   <tr>
-    <td class="foot-date">October 7, 2021</td>
+    <td class="foot-date">September 23, 2025</td>
     <td class="foot-os">Debian</td>
   </tr>
 </table>

--- a/docs/doc/wat-desugar.1.html
+++ b/docs/doc/wat-desugar.1.html
@@ -2,17 +2,17 @@
 <html>
 <head>
   <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <style>
     table.head, table.foot { width: 100%; }
     td.head-rtitle, td.foot-os { text-align: right; }
     td.head-vol { text-align: center; }
-    div.Pp { margin: 1ex 0ex; }
-    div.Nd, div.Bf, div.Op { display: inline; }
-    span.Pa, span.Ad { font-style: italic; }
-    span.Ms { font-weight: bold; }
-    dl.Bl-diag > dt { font-weight: bold; }
-    code.Nm, code.Fl, code.Cm, code.Ic, code.In, code.Fd, code.Fn,
-    code.Cd { font-weight: bold; font-family: inherit; }
+    .Nd, .Bf, .Op { display: inline; }
+    .Pa, .Ad { font-style: italic; }
+    .Ms { font-weight: bold; }
+    .Bl-diag > dt { font-weight: bold; }
+    code.Nm, .Fl, .Cm, .Ic, code.In, .Fd, .Fn, .Cd { font-weight: bold;
+      font-family: inherit; }
   </style>
   <title>WABT(1)</title>
 </head>
@@ -27,8 +27,9 @@
 <div class="manual-text">
 <section class="Sh">
 <h1 class="Sh" id="NAME"><a class="permalink" href="#NAME">NAME</a></h1>
-<code class="Nm">wat-desugar</code> &#x2014;
-<div class="Nd">parse .wat text form and print canonical flat format</div>
+<p class="Pp"><code class="Nm">wat-desugar</code> &#x2014;
+    <span class="Nd">parse .wat text form and print canonical flat
+  format</span></p>
 </section>
 <section class="Sh">
 <h1 class="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h1>
@@ -41,44 +42,70 @@
 </section>
 <section class="Sh">
 <h1 class="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h1>
-<code class="Nm">wat-desugar</code> parses .wat text form as supported by the
-  spec interpreter (s-expressions, flat syntax, or mixed) and prints
-  &quot;canonical&quot; flat format.
+<p class="Pp"><code class="Nm">wat-desugar</code> Parses .wat text form as
+    supported by the spec interpreter (s-expressions, flat syntax, or mixed) and
+    prints &quot;canonical&quot; flat format.</p>
 <p class="Pp">The options are as follows:</p>
 <dl class="Bl-tag">
-  <dt><code class="Fl">-</code><code class="Fl">-help</code></dt>
-  <dd>Print a help message</dd>
-  <dt><a class="permalink" href="#o"><code class="Fl" id="o">-o</code></a>,
-    <code class="Fl">-</code><code class="Fl">-output=FILE</code></dt>
+  <dt id="help"><a class="permalink" href="#help"><code class="Fl">--help</code></a></dt>
+  <dd>Print this help message</dd>
+  <dt id="version"><a class="permalink" href="#version"><code class="Fl">--version</code></a></dt>
+  <dd>Print version information</dd>
+  <dt id="o"><a class="permalink" href="#o"><code class="Fl">-o</code></a>,
+    <code class="Fl">--output=FILE</code></dt>
   <dd>Output file for the formatted file</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-debug-parser</code></dt>
+  <dt id="debug-parser"><a class="permalink" href="#debug-parser"><code class="Fl">--debug-parser</code></a></dt>
   <dd>Turn on debugging the parser of wat files</dd>
-  <dt><a class="permalink" href="#f"><code class="Fl" id="f">-f</code></a>,
-    <code class="Fl">-</code><code class="Fl">-fold-exprs</code></dt>
+  <dt id="f"><a class="permalink" href="#f"><code class="Fl">-f</code></a>,
+    <code class="Fl">--fold-exprs</code></dt>
   <dd>Write folded expressions where possible</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-enable-exceptions</code></dt>
-  <dd>Experimental exception handling</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-disable-mutable-globals</code></dt>
-  <dd>Import/export mutable globals</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-enable-saturating-float-to-int</code></dt>
-  <dd>Saturating float-to-int operators</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-enable-sign-extension</code></dt>
-  <dd>Sign-extension operators</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-disable-simd</code></dt>
-  <dd>SIMD support</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-enable-threads</code></dt>
-  <dd>Threading support</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-inline-exports</code></dt>
+  <dt id="inline-exports"><a class="permalink" href="#inline-exports"><code class="Fl">--inline-exports</code></a></dt>
   <dd>Write all exports inline</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-inline-imports</code></dt>
+  <dt id="inline-imports"><a class="permalink" href="#inline-imports"><code class="Fl">--inline-imports</code></a></dt>
   <dd>Write all imports inline</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-generate-names</code></dt>
+  <dt id="enable-exceptions"><a class="permalink" href="#enable-exceptions"><code class="Fl">--enable-exceptions</code></a></dt>
+  <dd>Enable Experimental exception handling</dd>
+  <dt id="disable-mutable-globals"><a class="permalink" href="#disable-mutable-globals"><code class="Fl">--disable-mutable-globals</code></a></dt>
+  <dd>Disable Import/export mutable globals</dd>
+  <dt id="disable-saturating-float-to-int"><a class="permalink" href="#disable-saturating-float-to-int"><code class="Fl">--disable-saturating-float-to-int</code></a></dt>
+  <dd>Disable Saturating float-to-int operators</dd>
+  <dt id="disable-sign-extension"><a class="permalink" href="#disable-sign-extension"><code class="Fl">--disable-sign-extension</code></a></dt>
+  <dd>Disable Sign-extension operators</dd>
+  <dt id="disable-simd"><a class="permalink" href="#disable-simd"><code class="Fl">--disable-simd</code></a></dt>
+  <dd>Disable SIMD support</dd>
+  <dt id="enable-threads"><a class="permalink" href="#enable-threads"><code class="Fl">--enable-threads</code></a></dt>
+  <dd>Enable Threading support</dd>
+  <dt id="enable-function-references"><a class="permalink" href="#enable-function-references"><code class="Fl">--enable-function-references</code></a></dt>
+  <dd>Enable Typed function references</dd>
+  <dt id="disable-multi-value"><a class="permalink" href="#disable-multi-value"><code class="Fl">--disable-multi-value</code></a></dt>
+  <dd>Disable Multi-value</dd>
+  <dt id="enable-tail-call"><a class="permalink" href="#enable-tail-call"><code class="Fl">--enable-tail-call</code></a></dt>
+  <dd>Enable Tail-call support</dd>
+  <dt id="disable-bulk-memory"><a class="permalink" href="#disable-bulk-memory"><code class="Fl">--disable-bulk-memory</code></a></dt>
+  <dd>Disable Bulk-memory operations</dd>
+  <dt id="disable-reference-types"><a class="permalink" href="#disable-reference-types"><code class="Fl">--disable-reference-types</code></a></dt>
+  <dd>Disable Reference types (externref)</dd>
+  <dt id="enable-annotations"><a class="permalink" href="#enable-annotations"><code class="Fl">--enable-annotations</code></a></dt>
+  <dd>Enable Custom annotation syntax</dd>
+  <dt id="enable-code-metadata"><a class="permalink" href="#enable-code-metadata"><code class="Fl">--enable-code-metadata</code></a></dt>
+  <dd>Enable Code metadata</dd>
+  <dt id="enable-gc"><a class="permalink" href="#enable-gc"><code class="Fl">--enable-gc</code></a></dt>
+  <dd>Enable Garbage collection</dd>
+  <dt id="enable-memory64"><a class="permalink" href="#enable-memory64"><code class="Fl">--enable-memory64</code></a></dt>
+  <dd>Enable 64-bit memory</dd>
+  <dt id="enable-multi-memory"><a class="permalink" href="#enable-multi-memory"><code class="Fl">--enable-multi-memory</code></a></dt>
+  <dd>Enable Multi-memory</dd>
+  <dt id="enable-extended-const"><a class="permalink" href="#enable-extended-const"><code class="Fl">--enable-extended-const</code></a></dt>
+  <dd>Enable Extended constant expressions</dd>
+  <dt id="enable-all"><a class="permalink" href="#enable-all"><code class="Fl">--enable-all</code></a></dt>
+  <dd>Enable all features</dd>
+  <dt id="generate-names"><a class="permalink" href="#generate-names"><code class="Fl">--generate-names</code></a></dt>
   <dd>Give auto-generated names to non-named functions, types, etc.</dd>
 </dl>
 </section>
 <section class="Sh">
 <h1 class="Sh" id="EXAMPLES"><a class="permalink" href="#EXAMPLES">EXAMPLES</a></h1>
-Write output to stdout
+<p class="Pp">Write output to stdout</p>
 <p class="Pp"></p>
 <div class="Bd Bd-indent"><code class="Li">$ wat-desugar test.wat</code></div>
 <p class="Pp">Write output to test2.wat</p>
@@ -93,27 +120,28 @@ Write output to stdout
 <section class="Sh">
 <h1 class="Sh" id="SEE_ALSO"><a class="permalink" href="#SEE_ALSO">SEE
   ALSO</a></h1>
-<a class="Xr" href="wasm-interp.1.html">wasm-interp(1)</a>,
-  <a class="Xr" href="wasm-objdump.1.html">wasm-objdump(1)</a>,
-  <a class="Xr" href="wasm-stats.1.html">wasm-stats(1)</a>,
-  <a class="Xr" href="wasm-strip.1.html">wasm-strip(1)</a>,
-  <a class="Xr" href="wasm-validate.1.html">wasm-validate(1)</a>,
-  <a class="Xr" href="wasm2c.1.html">wasm2c(1)</a>,
-  <a class="Xr" href="wasm2wat.1.html">wasm2wat(1)</a>,
-  <a class="Xr" href="wast2json.1.html">wast2json(1)</a>,
-  <a class="Xr" href="wat2wasm.1,.html">wat2wasm(1,)</a>
-  <a class="Xr" href="spectest-interp.1.html">spectest-interp(1)</a>
+<p class="Pp"><a class="Xr" href="wasm-decompile.1.html">wasm-decompile(1)</a>,
+    <a class="Xr" href="wasm-interp.1.html">wasm-interp(1)</a>,
+    <a class="Xr" href="wasm-objdump.1.html">wasm-objdump(1)</a>,
+    <a class="Xr" href="wasm-stats.1.html">wasm-stats(1)</a>,
+    <a class="Xr" href="wasm-strip.1.html">wasm-strip(1)</a>,
+    <a class="Xr" href="wasm-validate.1.html">wasm-validate(1)</a>,
+    <a class="Xr" href="wasm2c.1.html">wasm2c(1)</a>,
+    <a class="Xr" href="wasm2wat.1.html">wasm2wat(1)</a>,
+    <a class="Xr" href="wast2json.1.html">wast2json(1)</a>,
+    <a class="Xr" href="wat2wasm.1.html">wat2wasm(1)</a>,
+    <a class="Xr" href="spectest-interp.1.html">spectest-interp(1)</a></p>
 </section>
 <section class="Sh">
 <h1 class="Sh" id="BUGS"><a class="permalink" href="#BUGS">BUGS</a></h1>
-If you find a bug, please report it at
-<br/>
-<a class="Lk" href="https://github.com/WebAssembly/wabt/issues">https://github.com/WebAssembly/wabt/issues</a>.
+<p class="Pp">If you find a bug, please report it at
+  <br/>
+  <a class="Lk" href="https://github.com/WebAssembly/wabt/issues">https://github.com/WebAssembly/wabt/issues</a>.</p>
 </section>
 </div>
 <table class="foot">
   <tr>
-    <td class="foot-date">October 7, 2021</td>
+    <td class="foot-date">September 23, 2025</td>
     <td class="foot-os">Debian</td>
   </tr>
 </table>

--- a/docs/doc/wat2wasm.1.html
+++ b/docs/doc/wat2wasm.1.html
@@ -2,17 +2,17 @@
 <html>
 <head>
   <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <style>
     table.head, table.foot { width: 100%; }
     td.head-rtitle, td.foot-os { text-align: right; }
     td.head-vol { text-align: center; }
-    div.Pp { margin: 1ex 0ex; }
-    div.Nd, div.Bf, div.Op { display: inline; }
-    span.Pa, span.Ad { font-style: italic; }
-    span.Ms { font-weight: bold; }
-    dl.Bl-diag > dt { font-weight: bold; }
-    code.Nm, code.Fl, code.Cm, code.Ic, code.In, code.Fd, code.Fn,
-    code.Cd { font-weight: bold; font-family: inherit; }
+    .Nd, .Bf, .Op { display: inline; }
+    .Pa, .Ad { font-style: italic; }
+    .Ms { font-weight: bold; }
+    .Bl-diag > dt { font-weight: bold; }
+    code.Nm, .Fl, .Cm, .Ic, code.In, .Fd, .Fn, .Cd { font-weight: bold;
+      font-family: inherit; }
   </style>
   <title>WABT(1)</title>
 </head>
@@ -27,9 +27,9 @@
 <div class="manual-text">
 <section class="Sh">
 <h1 class="Sh" id="NAME"><a class="permalink" href="#NAME">NAME</a></h1>
-<code class="Nm">wat2wasm</code> &#x2014;
-<div class="Nd">translate from WebAssembly text format to the WebAssembly binary
-  format</div>
+<p class="Pp"><code class="Nm">wat2wasm</code> &#x2014;
+    <span class="Nd">translate from WebAssembly text format to the WebAssembly
+    binary format</span></p>
 </section>
 <section class="Sh">
 <h1 class="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h1>
@@ -42,49 +42,76 @@
 </section>
 <section class="Sh">
 <h1 class="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h1>
-<code class="Nm">wat2wasm</code> translates from WebAssembly text format to the
-  WebAssembly binary format.
+<p class="Pp"><code class="Nm">wat2wasm</code> Read a file in the wasm text
+    format, check it for errors, and convert it to the wasm binary format.</p>
 <p class="Pp">The options are as follows:</p>
 <dl class="Bl-tag">
-  <dt><a class="permalink" href="#v"><code class="Fl" id="v">-v</code></a>,
-    <code class="Fl">-</code><code class="Fl">-verbose</code></dt>
+  <dt id="help"><a class="permalink" href="#help"><code class="Fl">--help</code></a></dt>
+  <dd>Print this help message</dd>
+  <dt id="version"><a class="permalink" href="#version"><code class="Fl">--version</code></a></dt>
+  <dd>Print version information</dd>
+  <dt id="v"><a class="permalink" href="#v"><code class="Fl">-v</code></a>,
+    <code class="Fl">--verbose</code></dt>
   <dd>Use multiple times for more info</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-help</code></dt>
-  <dd>Print a help message</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-debug-parser</code></dt>
+  <dt id="debug-parser"><a class="permalink" href="#debug-parser"><code class="Fl">--debug-parser</code></a></dt>
   <dd>Turn on debugging the parser of wat files</dd>
-  <dt><a class="permalink" href="#d"><code class="Fl" id="d">-d</code></a>,
-    <code class="Fl">-</code><code class="Fl">-dump-module</code></dt>
+  <dt id="d"><a class="permalink" href="#d"><code class="Fl">-d</code></a>,
+    <code class="Fl">--dump-module</code></dt>
   <dd>Print a hexdump of the module to stdout</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-enable-exceptions</code></dt>
-  <dd>Experimental exception handling</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-disable-mutable-globals</code></dt>
-  <dd>Import/export mutable globals</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-enable-saturating-float-to-int</code></dt>
-  <dd>Saturating float-to-int operators</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-enable-sign-extension</code></dt>
-  <dd>Sign-extension operators</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-disable-simd</code></dt>
-  <dd>SIMD support</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-enable-threads</code></dt>
-  <dd>Threading support</dd>
-  <dt><a class="permalink" href="#o"><code class="Fl" id="o">-o</code></a>,
-    <code class="Fl">-</code><code class="Fl">-output=FILE</code></dt>
-  <dd>output wasm binary file</dd>
-  <dt><a class="permalink" href="#r"><code class="Fl" id="r">-r</code></a>,
-    <code class="Fl">-</code><code class="Fl">-relocatable</code></dt>
+  <dt id="enable-exceptions"><a class="permalink" href="#enable-exceptions"><code class="Fl">--enable-exceptions</code></a></dt>
+  <dd>Enable Experimental exception handling</dd>
+  <dt id="disable-mutable-globals"><a class="permalink" href="#disable-mutable-globals"><code class="Fl">--disable-mutable-globals</code></a></dt>
+  <dd>Disable Import/export mutable globals</dd>
+  <dt id="disable-saturating-float-to-int"><a class="permalink" href="#disable-saturating-float-to-int"><code class="Fl">--disable-saturating-float-to-int</code></a></dt>
+  <dd>Disable Saturating float-to-int operators</dd>
+  <dt id="disable-sign-extension"><a class="permalink" href="#disable-sign-extension"><code class="Fl">--disable-sign-extension</code></a></dt>
+  <dd>Disable Sign-extension operators</dd>
+  <dt id="disable-simd"><a class="permalink" href="#disable-simd"><code class="Fl">--disable-simd</code></a></dt>
+  <dd>Disable SIMD support</dd>
+  <dt id="enable-threads"><a class="permalink" href="#enable-threads"><code class="Fl">--enable-threads</code></a></dt>
+  <dd>Enable Threading support</dd>
+  <dt id="enable-function-references"><a class="permalink" href="#enable-function-references"><code class="Fl">--enable-function-references</code></a></dt>
+  <dd>Enable Typed function references</dd>
+  <dt id="disable-multi-value"><a class="permalink" href="#disable-multi-value"><code class="Fl">--disable-multi-value</code></a></dt>
+  <dd>Disable Multi-value</dd>
+  <dt id="enable-tail-call"><a class="permalink" href="#enable-tail-call"><code class="Fl">--enable-tail-call</code></a></dt>
+  <dd>Enable Tail-call support</dd>
+  <dt id="disable-bulk-memory"><a class="permalink" href="#disable-bulk-memory"><code class="Fl">--disable-bulk-memory</code></a></dt>
+  <dd>Disable Bulk-memory operations</dd>
+  <dt id="disable-reference-types"><a class="permalink" href="#disable-reference-types"><code class="Fl">--disable-reference-types</code></a></dt>
+  <dd>Disable Reference types (externref)</dd>
+  <dt id="enable-annotations"><a class="permalink" href="#enable-annotations"><code class="Fl">--enable-annotations</code></a></dt>
+  <dd>Enable Custom annotation syntax</dd>
+  <dt id="enable-code-metadata"><a class="permalink" href="#enable-code-metadata"><code class="Fl">--enable-code-metadata</code></a></dt>
+  <dd>Enable Code metadata</dd>
+  <dt id="enable-gc"><a class="permalink" href="#enable-gc"><code class="Fl">--enable-gc</code></a></dt>
+  <dd>Enable Garbage collection</dd>
+  <dt id="enable-memory64"><a class="permalink" href="#enable-memory64"><code class="Fl">--enable-memory64</code></a></dt>
+  <dd>Enable 64-bit memory</dd>
+  <dt id="enable-multi-memory"><a class="permalink" href="#enable-multi-memory"><code class="Fl">--enable-multi-memory</code></a></dt>
+  <dd>Enable Multi-memory</dd>
+  <dt id="enable-extended-const"><a class="permalink" href="#enable-extended-const"><code class="Fl">--enable-extended-const</code></a></dt>
+  <dd>Enable Extended constant expressions</dd>
+  <dt id="enable-all"><a class="permalink" href="#enable-all"><code class="Fl">--enable-all</code></a></dt>
+  <dd>Enable all features</dd>
+  <dt id="o"><a class="permalink" href="#o"><code class="Fl">-o</code></a>,
+    <code class="Fl">--output=FILE</code></dt>
+  <dd>Output wasm binary file. Use &quot;-&quot; to write to stdout.</dd>
+  <dt id="r"><a class="permalink" href="#r"><code class="Fl">-r</code></a>,
+    <code class="Fl">--relocatable</code></dt>
   <dd>Create a relocatable wasm binary (suitable for linking with e.g. lld)</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-no-canonicalize-leb128s</code></dt>
+  <dt id="no-canonicalize-leb128s"><a class="permalink" href="#no-canonicalize-leb128s"><code class="Fl">--no-canonicalize-leb128s</code></a></dt>
   <dd>Write all LEB128 sizes as 5-bytes instead of their minimal size</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-debug-names</code></dt>
+  <dt id="debug-names"><a class="permalink" href="#debug-names"><code class="Fl">--debug-names</code></a></dt>
   <dd>Write debug names to the generated binary file</dd>
-  <dt><code class="Fl">-</code><code class="Fl">-no-check</code></dt>
+  <dt id="no-check"><a class="permalink" href="#no-check"><code class="Fl">--no-check</code></a></dt>
   <dd>Don't check for invalid modules</dd>
 </dl>
 </section>
 <section class="Sh">
 <h1 class="Sh" id="EXAMPLES"><a class="permalink" href="#EXAMPLES">EXAMPLES</a></h1>
-Parse test.wat and write to .wasm binary file with the same name
+<p class="Pp">Parse test.wat and write to .wasm binary file with the same
+  name</p>
 <p class="Pp"></p>
 <div class="Bd Bd-indent"><code class="Li">$ wat2wasm test.wat</code></div>
 <p class="Pp">Parse test.wat and write to binary file test.wasm</p>
@@ -100,27 +127,28 @@ Parse test.wat and write to .wasm binary file with the same name
 <section class="Sh">
 <h1 class="Sh" id="SEE_ALSO"><a class="permalink" href="#SEE_ALSO">SEE
   ALSO</a></h1>
-<a class="Xr" href="wasm-interp.1.html">wasm-interp(1)</a>,
-  <a class="Xr" href="wasm-objdump.1.html">wasm-objdump(1)</a>,
-  <a class="Xr" href="wasm-stats.1.html">wasm-stats(1)</a>,
-  <a class="Xr" href="wasm-strip.1.html">wasm-strip(1)</a>,
-  <a class="Xr" href="wasm-validate.1.html">wasm-validate(1)</a>,
-  <a class="Xr" href="wasm2c.1.html">wasm2c(1)</a>,
-  <a class="Xr" href="wasm2wat.1.html">wasm2wat(1)</a>,
-  <a class="Xr" href="wast2json.1.html">wast2json(1)</a>,
-  <a class="Xr" href="wat-desugar.1.html">wat-desugar(1)</a>,
-  <a class="Xr" href="spectest-interp.1.html">spectest-interp(1)</a>
+<p class="Pp"><a class="Xr" href="wasm-decompile.1.html">wasm-decompile(1)</a>,
+    <a class="Xr" href="wasm-interp.1.html">wasm-interp(1)</a>,
+    <a class="Xr" href="wasm-objdump.1.html">wasm-objdump(1)</a>,
+    <a class="Xr" href="wasm-stats.1.html">wasm-stats(1)</a>,
+    <a class="Xr" href="wasm-strip.1.html">wasm-strip(1)</a>,
+    <a class="Xr" href="wasm-validate.1.html">wasm-validate(1)</a>,
+    <a class="Xr" href="wasm2c.1.html">wasm2c(1)</a>,
+    <a class="Xr" href="wasm2wat.1.html">wasm2wat(1)</a>,
+    <a class="Xr" href="wast2json.1.html">wast2json(1)</a>,
+    <a class="Xr" href="wat-desugar.1.html">wat-desugar(1)</a>,
+    <a class="Xr" href="spectest-interp.1.html">spectest-interp(1)</a></p>
 </section>
 <section class="Sh">
 <h1 class="Sh" id="BUGS"><a class="permalink" href="#BUGS">BUGS</a></h1>
-If you find a bug, please report it at
-<br/>
-<a class="Lk" href="https://github.com/WebAssembly/wabt/issues">https://github.com/WebAssembly/wabt/issues</a>.
+<p class="Pp">If you find a bug, please report it at
+  <br/>
+  <a class="Lk" href="https://github.com/WebAssembly/wabt/issues">https://github.com/WebAssembly/wabt/issues</a>.</p>
 </section>
 </div>
 <table class="foot">
   <tr>
-    <td class="foot-date">October 7, 2021</td>
+    <td class="foot-date">September 23, 2025</td>
     <td class="foot-os">Debian</td>
   </tr>
 </table>


### PR DESCRIPTION
Previously I found that the web doc of wasm2wat doesn't mention `--enable-annotations`. Previous PR https://github.com/WebAssembly/wabt/pull/2642

After knowing that the HTML docs are auto-generated, I run `generate-html-docs.sh`. Now it includes `--enable-annotations` option because `wasm2wat.1` already includes it. 

That also caused many other changes, probably caused by HTML doc not updated for long time. I opened these html and they looks fine.