### PR TITLE
[CI] Disable `fail-fast` for release builder

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -14,6 +14,7 @@ jobs:
     name: build
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-20.04, macos-14, windows-latest]
     defaults:


### PR DESCRIPTION
Without this, the failure of one release builder will cancel any other outstanding ones.  This setting defaults to `true`.