### PR TITLE
Temporarily disable macos-latest testing.  NFC

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-13, macos-latest, windows-latest]
+        # Temporarily replaced macos-latest with macos-14.
+        # See https://github.com/WebAssembly/wabt/issues/2654
+        os: [ubuntu-latest, macos-13, macos-14, windows-latest]
     steps:
     - uses: actions/setup-python@v5
       with:
@@ -43,7 +45,7 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
     - name: install ninja (osx)
       run: brew install ninja
-      if: matrix.os == 'macos-13' || matrix.os == 'macos-latest'
+      if: startsWith(matrix.os, 'macos-')
     - name: install ninja (win)
       run: choco install ninja
       if: matrix.os == 'windows-latest'


### PR DESCRIPTION
Switch to macos-14 rather then macos-latest until we can figure out why
some wasm2c tests are failing there #2654.
