### PR TITLE
CMakeLists.txt: Update version to 1.0.38

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@
 #
 
 cmake_minimum_required(VERSION 3.16)
-project(WABT LANGUAGES C CXX VERSION 1.0.37)
+project(WABT LANGUAGES C CXX VERSION 1.0.38)
 
 include(GNUInstallDirs)
 


### PR DESCRIPTION
I should have done this before tagging he release but forgot.

We are also lacking some binaries for 1.0.38 so I think we should tag 1.0.39 soon a call 1.0.38 a failures.

See #2658