### PR TITLE
Save local set data in EndTryTable

### DIFF
--- a/src/shared-validator.cc
+++ b/src/shared-validator.cc
@@ -1422,7 +1422,6 @@ Result SharedValidator::BeginTryTable(const Location& loc, Type sig_type) {
   result |= CheckBlockSignature(loc, Opcode::TryTable, sig_type, &param_types,
                                 &result_types);
   result |= typechecker_.BeginTryTable(param_types);
-  SaveLocalRefs();
   return result;
 }
 
@@ -1447,8 +1446,8 @@ Result SharedValidator::EndTryTable(const Location& loc, Type sig_type) {
   TypeVector param_types, result_types;
   result |= CheckBlockSignature(loc, Opcode::TryTable, sig_type, &param_types,
                                 &result_types);
-  RestoreLocalRefs(result);
   result |= typechecker_.EndTryTable(param_types, result_types);
+  SaveLocalRefs();
   return result;
 }
 

--- a/test/parse/bad-refs-in-trytable.txt
+++ b/test/parse/bad-refs-in-trytable.txt
@@ -1,0 +1,32 @@
+;;; TOOL: wat2wasm
+;;; ARGS: --enable-function-references --enable-exceptions
+;;; ERROR: 1
+(module
+  (func (param (ref func))
+    (local (ref func) (ref func))
+    local.get 0
+    local.set 1
+    try_table
+      try_table
+        local.get 0
+        local.set 2
+      end
+      local.get 1
+      local.set 0
+      local.get 2
+      local.set 0
+    end
+    local.get 1
+    local.set 0
+    local.get 2
+    local.set 0
+  )
+)
+(;; STDERR ;;;
+out/test/parse/bad-refs-in-trytable.txt:16:17: error: uninitialized local reference
+      local.get 2
+                ^
+out/test/parse/bad-refs-in-trytable.txt:21:15: error: uninitialized local reference
+    local.get 2
+              ^
+;;; STDERR ;;)

--- a/test/regress/regress-2670.txt
+++ b/test/regress/regress-2670.txt
@@ -6,7 +6,17 @@
 ;; save/restore operations was missing for try tables
 
 (module
-  (func (local (ref func)))
+  (tag $e0)
+
+  (func (local (ref func) (ref func) (ref func)))
+  (func
+    (local (ref func) (ref func))
+    try_table
+    end)
+  (func
+    (local (ref func))
+    try_table (catch $e0 0) (catch_all 0)
+    end)
   (func
     unreachable
     try_table
@@ -16,9 +26,19 @@
 (module
   (type $t0 (func))
   (func $f0 (type $t0)
-    (local $l0 (ref func)))
+    (local $l0 (ref func)) (local $l1 (ref func)) (local $l2 (ref func)))
   (func $f1 (type $t0)
+    (local $l0 (ref func)) (local $l1 (ref func))
+    (try_table $T0
+    ))
+  (func $f2 (type $t0)
+    (local $l0 (ref func))
+    (try_table $T0
+      (catch $e0 0 (;@0;))
+      (catch_all 0 (;@0;))))
+  (func $f3 (type $t0)
     (unreachable)
     (try_table $T0
-    )))
+    ))
+  (tag $e0 (type $t0)))
 ;;; STDOUT ;;)


### PR DESCRIPTION
I have checked with `gdb` that `OnEnd` is really called. I hope I don't make more mistakes. I have also added the test case without `unreachable`, since the `unreachable` should not affect the bug, although it might trigger future bugs, so both should be present.