### PR TITLE
[binary-reader] Re-use ReadExternalKind for import as well as exports. NFC

### DIFF
--- a/test/binary/bad-import-kind.txt
+++ b/test/binary/bad-import-kind.txt
@@ -3,6 +3,6 @@ magic
 version
 section(IMPORT) { count[1] str("module") str("func") dummy[5] }
 (;; STDERR ;;;
-0000018: error: malformed import kind: 5
-0000018: error: malformed import kind: 5
+0000018: error: invalid import external kind: 5
+0000018: error: invalid import external kind: 5
 ;;; STDERR ;;)

--- a/test/parse/branch-hints.txt
+++ b/test/parse/branch-hints.txt
@@ -53,8 +53,11 @@
 )
 
 (;; STDOUT ;;;
+
 branch-hints.wasm:	file format wasm 0x1
+
 Section Details:
+
 Custom:
  - name: "metadata.code.branch_hint"
    - func[0]:
@@ -75,7 +78,9 @@ Custom:
      - 0000000: 01                                       .
     - meta[7]:
      - 0000000: 00                                       .
+
 Code Disassembly:
+
 000057 func[0]:
  000058: 04 7f                      | local[0..3] type=i32
  00005a: 41 00                      | i32.const 0

--- a/test/spec/binary.txt
+++ b/test/spec/binary.txt
@@ -134,13 +134,13 @@ out/test/spec/binary.wast:680: assert_malformed passed:
 out/test/spec/binary.wast:690: assert_malformed passed:
   000000e: error: invalid import tag kind: exceptions not allowed
 out/test/spec/binary.wast:701: assert_malformed passed:
-  000000e: error: malformed import kind: 5
+  000000e: error: invalid import external kind: 5
 out/test/spec/binary.wast:711: assert_malformed passed:
-  000000e: error: malformed import kind: 5
+  000000e: error: invalid import external kind: 5
 out/test/spec/binary.wast:722: assert_malformed passed:
-  000000e: error: malformed import kind: 128
+  000000e: error: invalid import external kind: 128
 out/test/spec/binary.wast:732: assert_malformed passed:
-  000000e: error: malformed import kind: 128
+  000000e: error: invalid import external kind: 128
 out/test/spec/binary.wast:745: assert_malformed passed:
   0000027: error: unable to read u32 leb128: string length
 out/test/spec/binary.wast:764: assert_malformed passed:

--- a/test/spec/exception-handling/binary.txt
+++ b/test/spec/exception-handling/binary.txt
@@ -131,17 +131,17 @@ out/test/spec/exception-handling/binary.wast:650: assert_malformed passed:
 out/test/spec/exception-handling/binary.wast:661: assert_malformed passed:
   000000e: error: unfinished section (expected end: 0x11)
 out/test/spec/exception-handling/binary.wast:680: assert_malformed passed:
-  000000e: error: malformed import kind: 5
+  000000e: error: invalid import external kind: 5
 out/test/spec/exception-handling/binary.wast:690: assert_malformed passed:
-  000000e: error: malformed import kind: 5
+  000000e: error: invalid import external kind: 5
 out/test/spec/exception-handling/binary.wast:701: assert_malformed passed:
-  000000e: error: malformed import kind: 5
+  000000e: error: invalid import external kind: 5
 out/test/spec/exception-handling/binary.wast:711: assert_malformed passed:
-  000000e: error: malformed import kind: 5
+  000000e: error: invalid import external kind: 5
 out/test/spec/exception-handling/binary.wast:722: assert_malformed passed:
-  000000e: error: malformed import kind: 128
+  000000e: error: invalid import external kind: 128
 out/test/spec/exception-handling/binary.wast:732: assert_malformed passed:
-  000000e: error: malformed import kind: 128
+  000000e: error: invalid import external kind: 128
 out/test/spec/exception-handling/binary.wast:745: assert_malformed passed:
   0000027: error: unable to read u32 leb128: string length
 out/test/spec/exception-handling/binary.wast:764: assert_malformed passed:

--- a/test/spec/function-references/binary.txt
+++ b/test/spec/function-references/binary.txt
@@ -135,13 +135,13 @@ out/test/spec/function-references/binary.wast:680: assert_malformed passed:
 out/test/spec/function-references/binary.wast:690: assert_malformed passed:
   000000e: error: invalid import tag kind: exceptions not allowed
 out/test/spec/function-references/binary.wast:701: assert_malformed passed:
-  000000e: error: malformed import kind: 5
+  000000e: error: invalid import external kind: 5
 out/test/spec/function-references/binary.wast:711: assert_malformed passed:
-  000000e: error: malformed import kind: 5
+  000000e: error: invalid import external kind: 5
 out/test/spec/function-references/binary.wast:722: assert_malformed passed:
-  000000e: error: malformed import kind: 128
+  000000e: error: invalid import external kind: 128
 out/test/spec/function-references/binary.wast:732: assert_malformed passed:
-  000000e: error: malformed import kind: 128
+  000000e: error: invalid import external kind: 128
 out/test/spec/function-references/binary.wast:745: assert_malformed passed:
   0000027: error: unable to read u32 leb128: string length
 out/test/spec/function-references/binary.wast:764: assert_malformed passed:

--- a/test/spec/memory64/binary.txt
+++ b/test/spec/memory64/binary.txt
@@ -111,17 +111,17 @@ out/test/spec/memory64/binary.wast:459: assert_malformed passed:
 out/test/spec/memory64/binary.wast:470: assert_malformed passed:
   000000e: error: unfinished section (expected end: 0x11)
 out/test/spec/memory64/binary.wast:489: assert_malformed passed:
-  000000e: error: malformed import kind: 5
+  000000e: error: invalid import external kind: 5
 out/test/spec/memory64/binary.wast:499: assert_malformed passed:
-  000000e: error: malformed import kind: 5
+  000000e: error: invalid import external kind: 5
 out/test/spec/memory64/binary.wast:510: assert_malformed passed:
-  000000e: error: malformed import kind: 5
+  000000e: error: invalid import external kind: 5
 out/test/spec/memory64/binary.wast:520: assert_malformed passed:
-  000000e: error: malformed import kind: 5
+  000000e: error: invalid import external kind: 5
 out/test/spec/memory64/binary.wast:531: assert_malformed passed:
-  000000e: error: malformed import kind: 128
+  000000e: error: invalid import external kind: 128
 out/test/spec/memory64/binary.wast:541: assert_malformed passed:
-  000000e: error: malformed import kind: 128
+  000000e: error: invalid import external kind: 128
 out/test/spec/memory64/binary.wast:554: assert_malformed passed:
   0000027: error: unable to read u32 leb128: string length
 out/test/spec/memory64/binary.wast:573: assert_malformed passed:

--- a/test/spec/multi-memory/binary.txt
+++ b/test/spec/multi-memory/binary.txt
@@ -115,13 +115,13 @@ out/test/spec/multi-memory/binary.wast:489: assert_malformed passed:
 out/test/spec/multi-memory/binary.wast:499: assert_malformed passed:
   000000e: error: invalid import tag kind: exceptions not allowed
 out/test/spec/multi-memory/binary.wast:510: assert_malformed passed:
-  000000e: error: malformed import kind: 5
+  000000e: error: invalid import external kind: 5
 out/test/spec/multi-memory/binary.wast:520: assert_malformed passed:
-  000000e: error: malformed import kind: 5
+  000000e: error: invalid import external kind: 5
 out/test/spec/multi-memory/binary.wast:531: assert_malformed passed:
-  000000e: error: malformed import kind: 128
+  000000e: error: invalid import external kind: 128
 out/test/spec/multi-memory/binary.wast:541: assert_malformed passed:
-  000000e: error: malformed import kind: 128
+  000000e: error: invalid import external kind: 128
 out/test/spec/multi-memory/binary.wast:554: assert_malformed passed:
   0000027: error: unable to read u32 leb128: string length
 out/test/spec/multi-memory/binary.wast:573: assert_malformed passed:


### PR DESCRIPTION
Another refactor to prepare for compact imports.

I don't feel strongly about `malformed import kind` vs `invalid import external kind` but we should probably be consistent between imports and exports.