### PR TITLE
Fix segmentation fault (SEGV) in wabt::Decompiler::VarName within wasm-decompile

### DIFF
--- a/src/decompiler.cc
+++ b/src/decompiler.cc
@@ -215,20 +215,28 @@ struct Decompiler {
     }
   }
 
-  std::string_view VarName(std::string_view name) {
-    assert(!name.empty());
-    return name[0] == '$' ? name.substr(1) : name;
+  std::string VarName(std::string_view name) {
+    if (name.empty()) {
+      return "unknown";
+    }
+    return std::string(name[0] == '$' ? name.substr(1) : name);
+  }
+
+  std::string GetName(const Var& var) {
+    if (var.is_name()) {
+      return VarName(var.name());
+    }
+    return std::to_string(var.index());
   }
 
   template <ExprType T>
   Value Get(const VarExpr<T>& ve) {
-    return Value{{std::string(VarName(ve.var.name()))}, Precedence::Atomic};
+    return Value{{GetName(ve.var)}, Precedence::Atomic};
   }
 
   template <ExprType T>
   Value Set(Value& child, const VarExpr<T>& ve) {
-    return WrapChild(child, VarName(ve.var.name()) + " = ", "",
-                     Precedence::Assign);
+    return WrapChild(child, GetName(ve.var) + " = ", "", Precedence::Assign);
   }
 
   std::string TempVarName(Index n) {
@@ -389,19 +397,19 @@ struct Decompiler {
       }
       case NodeType::Decl: {
         cur_ast->vars_defined[n.u.var->name()].defined = true;
-        return Value{{"var " + LocalDecl(std::string(n.u.var->name()),
+        return Value{{"var " + LocalDecl(GetName(*n.u.var),
                                          cur_func->GetLocalType(*n.u.var))},
                      Precedence::None};
       }
       case NodeType::DeclInit: {
         if (cur_ast->vars_defined[n.u.var->name()].defined) {
           // This has already been pre-declared, output as assign.
-          return WrapChild(args[0], cat(VarName(n.u.var->name()), " = "), "",
+          return WrapChild(args[0], cat(GetName(*n.u.var), " = "), "",
                            Precedence::None);
         } else {
           return WrapChild(args[0],
                            cat("var ",
-                               LocalDecl(std::string(n.u.var->name()),
+                               LocalDecl(GetName(*n.u.var),
                                          cur_func->GetLocalType(*n.u.var)),
                                " = "),
                            "", Precedence::None);
@@ -565,14 +573,14 @@ struct Decompiler {
       case ExprType::Br: {
         auto be = cast<BrExpr>(n.e);
         return Value{{(n.u.lt == LabelType::Loop ? "continue " : "goto ") +
-                      VarName(be->var.name())},
+                      GetName(be->var)},
                      Precedence::None};
       }
       case ExprType::BrIf: {
         auto bie = cast<BrIfExpr>(n.e);
         auto jmp = n.u.lt == LabelType::Loop ? "continue" : "goto";
         return WrapChild(args[0], "if (",
-                         cat(") ", jmp, " ", VarName(bie->var.name())),
+                         cat(") ", jmp, " ", GetName(bie->var)),
                          Precedence::None);
       }
       case ExprType::Return: {
@@ -599,11 +607,11 @@ struct Decompiler {
         auto bte = cast<BrTableExpr>(n.e);
         std::string ts = "br_table[";
         for (auto& v : bte->targets) {
-          ts += VarName(v.name());
+          ts += GetName(v);
           ts += ", ";
         }
         ts += "..";
-        ts += VarName(bte->default_target.name());
+        ts += GetName(bte->default_target);
         ts += "](";
         return WrapChild(args[0], ts, ")", Precedence::Atomic);
       }
@@ -619,10 +627,10 @@ struct Decompiler {
         auto precedence = Precedence::Atomic;
         switch (n.etype) {
           case ExprType::Call:
-            name = cast<CallExpr>(n.e)->var.name();
+            name = GetName(cast<CallExpr>(n.e)->var);
             break;
           case ExprType::ReturnCall:
-            name = "return_call " + cast<ReturnCallExpr>(n.e)->var.name();
+            name = "return_call " + GetName(cast<ReturnCallExpr>(n.e)->var);
             precedence = Precedence::None;
             break;
           case ExprType::Convert:


### PR DESCRIPTION
Fixes #2678

To fix the segmentation fault in `wasm-decompile`, we need to ensure that the decompiler handles `Var` objects that contain indices instead of names. The crash occurs because `VarName` assumes its input is a non-empty string, but when a `Var` is an index, calling `name()` in a Release build returns a reference to memory that is misinterpreted as a `std::string`, leading to a wild pointer dereference.

This PR updates `VarName` to handle empty strings gracefully (returning a placeholder) and adds a helper method `GetName` to safely retrieve a name or index string from a `Var` object.

## Verification Before Fix
Running the PoC `./wasm-decompile ./repro` triggers AddressSanitizer error:
```
AddressSanitizer:DEADLYSIGNAL
=================================================================
==720==ERROR: AddressSanitizer: SEGV on unknown address (pc 0x55f38dfddcf8 bp 0x7ffdac786ab0 sp 0x7ffdac7868d0 T0)
==720==The signal is caused by a READ memory access.
==720==Hint: this fault was caused by a dereference of a high value address (see register values below).  Disassemble the provided pc to learn which register was used.
    #0 0x55f38dfddcf8 in wabt::Decompiler::VarName(std::basic_string_view<char, std::char_traits<char>>) (/src/wabt/bin/wasm-decompile+0x1becf8)
    #1 0x55f38dfd0eb9 in wabt::Decompiler::DecompileExpr(wabt::Node const&, wabt::Node const*) (/src/wabt/bin/wasm-decompile+0x1b1eb9)
    #2 0x55f38dfceac6 in wabt::Decompiler::DecompileExpr(wabt::Node const&, wabt::Node const*) (/src/wabt/bin/wasm-decompile+0x1afac6)
    #3 0x55f38dfceac6 in wabt::Decompiler::DecompileExpr(wabt::Node const&, wabt::Node const*) (/src/wabt/bin/wasm-decompile+0x1afac6)
    #4 0x55f38dfc8b35 in wabt::Decompiler::Decompile[abi:cxx11]() (/src/wabt/bin/wasm-decompile+0x1a9b35)
    #5 0x55f38dfc6346 in wabt::Decompile[abi:cxx11](wabt::Module const&, wabt::DecompileOptions const&) (/src/wabt/bin/wasm-decompile+0x1a7346)
    #6 0x55f38df67801 in ProgramMain(int, char**) (/src/wabt/bin/wasm-decompile+0x148801)
    #7 0x7fc338d5f082 in __libc_start_main /build/glibc-B3wQXB/glibc-2.31/csu/../csu/libc-start.c:308:16
    #8 0x55f38de8e56d in _start (/src/wabt/bin/wasm-decompile+0x6f56d)

AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: SEGV (/src/wabt/bin/wasm-decompile+0x1becf8) in wabt::Decompiler::VarName(std::basic_string_view<char, std::char_traits<char>>)
==720==ABORTING
```

## Verification After Fix
Running the PoC `./wasm-decompile ./repro`:
```
export memory memory(initial: 256, max: 256);

global g_a:int = 5244416;

data d_a(offset: 1536) = "\c0\06P";

export function fib(a:int):int { // func0
  if (a >= 2) { return fib(a + -1) + fib(a + -2) }
  return a;
}

export function main(a:int, b:int):int { // func1
  let t0 = 0[32]:ubyte;
  nop;
  var d:int = t0[1]:int;
  var c:int = d[0];
  if (eqz(c)) { return fib(0) }
  b = 0;
  loop L_b {
    b = b * 10 + ((c << 24) >> 24) + -48;
    ((d + (a = a + 1))[0]:ubyte)[13@4]:float;
    unreachable;
  }
  return fib(b);
}

export function wasm_call_ctors() { // func2
  nop
}

export function stackAlloc(a:int):int { // func3
  g_a - a & -16;
  g_a = goto 0;
  return a;
}

export function start() { // func4
  main(0, 0)
}
```
