### PR TITLE
[wasm-objdump] Fix missing error on bad opcode

### DIFF
--- a/src/binary-reader-objdump.cc
+++ b/src/binary-reader-objdump.cc
@@ -74,6 +74,7 @@ class BinaryReaderObjdumpBase : public BinaryReaderNop {
   const uint8_t* data_;
   size_t size_;
   bool print_details_ = false;
+  bool in_function_body = false;
   BinarySection reloc_section_ = BinarySection::Invalid;
   Offset section_starts_[kBinarySectionCount];
   // Map of section index to section type
@@ -109,7 +110,7 @@ bool BinaryReaderObjdumpBase::OnError(const Error&) {
   // Tell the BinaryReader that this error is "handled" for all passes other
   // than the prepass. When the error is handled the default message will be
   // suppressed.
-  return options_->mode != ObjdumpMode::Prepass;
+  return options_->mode != ObjdumpMode::Prepass && !in_function_body;
 }
 
 Result BinaryReaderObjdumpBase::BeginModule(uint32_t version) {
@@ -565,7 +566,6 @@ class BinaryReaderObjdumpDisassemble : public BinaryReaderObjdumpBase {
   Index next_reloc = 0;
   Index current_function_index = 0;
   Index local_index_ = 0;
-  bool in_function_body = false;
   bool skip_next_opcode_ = false;
 };
 

--- a/test/binary/bad-opcode.txt
+++ b/test/binary/bad-opcode.txt
@@ -1,4 +1,6 @@
-;;; TOOL: run-gen-wasm-bad
+;;; TOOL: run-objdump-gen-wasm
+;;; ARGS: -x
+;;; ERROR: 1
 magic
 version
 section(TYPE) { count[1] function params[0] results[1] i32 }
@@ -12,5 +14,21 @@ section(CODE) {
 }
 (;; STDERR ;;;
 0000019: error: unexpected opcode: 0xff
-0000019: error: unexpected opcode: 0xff
 ;;; STDERR ;;)
+(;; STDOUT ;;;
+
+bad-opcode.wasm:	file format wasm 0x1
+
+Section Details:
+
+Type[1]:
+ - type[0] () -> i32
+Function[1]:
+ - func[0] sig=0
+Code[1]:
+ - func[0] size=3
+
+Code Disassembly:
+
+000017 func[0]:
+;;; STDOUT ;;)


### PR DESCRIPTION
In binary-reader-objdump were we suppressing all error except those in pre-pass, in order to avoid reporting them mulitple time.

However, the pre-pass is run with `skip_function_bodies` so opcode error are not shown in that pass.