### PR TITLE
Fix typed select to propagate result type instead of Any

### DIFF
--- a/src/type-checker.cc
+++ b/src/type-checker.cc
@@ -1015,6 +1015,7 @@ Result TypeChecker::OnSelect(const TypeVector& expected) {
     assert(expected.size() == 1);
     result |= CheckType(type1, expected[0]);
     result |= CheckType(type2, expected[0]);
+    result_type = expected[0];
   }
   PrintStackIfFailed(result, "select", result_type, result_type, Type::I32);
   result |= DropTypes(3);


### PR DESCRIPTION
## Summary

When processing a typed `select` instruction (one with an explicit type annotation), `TypeChecker::OnSelect()` validates both operand types against the expected type but never assigns the validated type to `result_type`. It stays as `Type::Any` from initialization, causing `PushType(Type::Any)` instead of pushing the declared result type.

This violates the WebAssembly spec, which requires a typed select to produce a value of the annotated type on the value stack. The untyped select path already correctly sets `result_type = type1`; this fix applies the analogous assignment for the typed path: `result_type = expected[0]`.

## The Fix

A single line addition after the type checks in the typed select branch:

```cpp
result_type = expected[0];
```

This ensures the annotated type flows through to `PushType(result_type)` and `PrintStackIfFailed()`.

## Test plan

- Verified the changed file compiles cleanly
- The fix is a minimal, obvious correction consistent with the existing untyped select logic