### PR TITLE
Fix incorrect parameter index in WASI fd_read

### DIFF
--- a/src/interp/interp-wasi.cc
+++ b/src/interp/interp-wasi.cc
@@ -429,7 +429,7 @@ class WasiInstance {
     int32_t fd = params[0].Get<u32>();
     int32_t iovptr = params[1].Get<u32>();
     int32_t iovcnt = params[2].Get<u32>();
-    int32_t out_ptr = params[2].Get<u32>();
+    int32_t out_ptr = params[3].Get<u32>();
     if (trace_stream) {
       trace_stream->Writef("fd_read %d [%d]\n", fd, iovcnt);
     }


### PR DESCRIPTION
## Summary

Fix a copy-paste bug in the WASI `fd_read` implementation where `params[2]` was used for both `iovcnt` and `out_ptr`.

## Details

In `src/interp/interp-wasi.cc`, the `fd_read` function extracts its four parameters from the `params` array:

```
params[0] -> fd
params[1] -> iovptr
params[2] -> iovcnt
params[3] -> out_ptr (nread)
```

However, `out_ptr` was incorrectly reading from `params[2]` instead of `params[3]`, causing it to receive the same value as `iovcnt`. This meant the number of bytes read would be written to the wrong memory address.

The correct behavior can be seen in the adjacent `fd_write` implementation, which properly uses `params[3]` for its output pointer.

## Test plan

- Verified the fix compiles successfully (`cmake --build build --target wabt-unittests`)
- Compared with `fd_write` implementation which correctly uses `params[3]`