### PR TITLE
Fix CanonNaN template to use correct type for f64 NaN canonicalization

### DIFF
--- a/include/wabt/interp/interp-math.h
+++ b/include/wabt/interp/interp-math.h
@@ -59,7 +59,7 @@ template <
     typename std::enable_if<std::is_floating_point<T>::value, int>::type = 0>
 T WABT_VECTORCALL CanonNaN(T val) {
   if (WABT_UNLIKELY(std::isnan(val))) {
-    return std::numeric_limits<f32>::quiet_NaN();
+    return std::numeric_limits<T>::quiet_NaN();
   }
   return val;
 }


### PR DESCRIPTION
## Summary

- The `CanonNaN<T>` template function in `interp-math.h` hardcodes `std::numeric_limits<f32>::quiet_NaN()` instead of using the template parameter `T`.
- When `T` is `f64`, this returns an `f32` quiet NaN implicitly promoted to `f64`, which has a different bit pattern than the correct `f64` canonical NaN.
- This patch replaces `f32` with `T` so that `std::numeric_limits<T>::quiet_NaN()` produces the correct canonical NaN for both `f32` and `f64`.

## Test plan

- [x] `cmake --build build --target wabt-unittests` builds successfully
- Verified the fix matches the pattern already used elsewhere in the same file (e.g., `FloatDiv`, `FloatMin`, `FloatMax` all correctly use `std::numeric_limits<T>::quiet_NaN()`)