### PR TITLE
Fix wrong iterator variable in InterpDropKeep ref tracking

### DIFF
--- a/src/interp/interp.cc
+++ b/src/interp/interp.cc
@@ -1684,7 +1684,7 @@ RunResult Thread::StepInternal(Trap::Ptr* out_trap) {
       // Find dropped refs.
       auto drop_iter = iter;
       for (; drop_iter != refs_.rend(); ++drop_iter) {
-        if (*iter < values_.size() - keep - drop) {
+        if (*drop_iter < values_.size() - keep - drop) {
           break;
         }
       }


### PR DESCRIPTION
## Summary

- Fix a bug in the `InterpDropKeep` handler in `src/interp/interp.cc` where the "find dropped refs" loop checked `*iter` instead of `*drop_iter`

## Problem

In the `InterpDropKeep` opcode handler, after shifting kept refs down, a second loop scans for refs that fall in the dropped value range so they can be erased. However, the loop condition on line 1687 dereferenced `iter` (the end position of the *previous* loop) rather than `drop_iter` (the current loop's iterator).

Because `iter` is never advanced in the second loop, the condition is loop-invariant: it either breaks immediately on the first iteration or never breaks at all. This means refs pointing into the dropped range may not be properly identified and erased from `refs_`, leaving stale indices that can cause out-of-bounds access when `Thread::Mark()` walks `refs_` during garbage collection.

## Fix

Change `*iter` to `*drop_iter` on the condition line so the loop correctly inspects each candidate ref index.

## Test plan

- [x] Build passes (`cmake --build build --target wabt-unittests`)
- Verified by code inspection that `drop_iter` is the intended loop variable