### PR TITLE
Fix wrong iterator variable in InterpDropKeep ref tracking loop

### DIFF
--- a/src/interp/interp.cc
+++ b/src/interp/interp.cc
@@ -1684,7 +1684,7 @@ RunResult Thread::StepInternal(Trap::Ptr* out_trap) {
       // Find dropped refs.
       auto drop_iter = iter;
       for (; drop_iter != refs_.rend(); ++drop_iter) {
-        if (*iter < values_.size() - keep - drop) {
+        if (*drop_iter < values_.size() - keep - drop) {
           break;
         }
       }


### PR DESCRIPTION
## Summary
- The second loop in `InterpDropKeep`'s ref tracking code checks `*iter` instead of `*drop_iter`, causing incorrect ref erasure during stack manipulation.
- Fix changes the loop condition to use the correct iterator variable.

## Details
In `InterpDropKeep` (interp.cc), two loops iterate over `refs_` in reverse. The first loop advances `iter` past the kept refs. The second loop should advance `drop_iter` to find refs in the dropped range, but the loop condition incorrectly reads `*iter` (which is fixed at the boundary position) instead of `*drop_iter`. This causes the loop to either:
- Skip all dropped refs (if `*iter` is already below the threshold), leaking GC roots, or
- Never terminate early (if `*iter` is above the threshold), erasing refs that should be kept.

The fix is a one-variable-name change: `*iter` -> `*drop_iter` in the loop condition.