### PR TITLE
Fix fd_read using wrong parameter index for output pointer

### DIFF
--- a/src/interp/interp-wasi.cc
+++ b/src/interp/interp-wasi.cc
@@ -429,7 +429,7 @@ class WasiInstance {
     int32_t fd = params[0].Get<u32>();
     int32_t iovptr = params[1].Get<u32>();
     int32_t iovcnt = params[2].Get<u32>();
-    int32_t out_ptr = params[2].Get<u32>();
+    int32_t out_ptr = params[3].Get<u32>();
     if (trace_stream) {
       trace_stream->Writef("fd_read %d [%d]\n", fd, iovcnt);
     }


### PR DESCRIPTION
## Summary
- `fd_read` reads both `iovcnt` and `out_ptr` from `params[2]`, but `out_ptr` should come from `params[3]`.
- Fix changes the `out_ptr` parameter index from `[2]` to `[3]`.

## Details
The WASI `fd_read` function signature is `(fd: i32, iovs: i32, iovs_len: i32, nread: i32) -> errno`. The parameters map to:
- `params[0]` = fd
- `params[1]` = iovs (iov pointer)
- `params[2]` = iovs_len (iov count)
- `params[3]` = nread (output pointer for bytes read)

Both lines 431 and 432 were reading from `params[2]`, making `out_ptr` equal to `iovcnt`. This caused the bytes-read count to be written to the wrong memory address (the value of iovcnt interpreted as an address, rather than the actual output pointer).