### PR TITLE
Fix GC root leak in RefPtr assignment operators

### DIFF
--- a/include/wabt/interp/interp-inl.h
+++ b/include/wabt/interp/interp-inl.h
@@ -273,6 +273,8 @@ RefPtr<T>::RefPtr(const RefPtr& other)
 
 template <typename T>
 RefPtr<T>& RefPtr<T>::operator=(const RefPtr& other) {
+  if (this == &other) return *this;
+  reset();
   obj_ = other.obj_;
   store_ = other.store_;
   root_index_ = store_ ? store_->CopyRoot(other.root_index_) : 0;
@@ -289,6 +291,7 @@ RefPtr<T>::RefPtr(RefPtr&& other)
 
 template <typename T>
 RefPtr<T>& RefPtr<T>::operator=(RefPtr&& other) {
+  reset();
   obj_ = other.obj_;
   store_ = other.store_;
   root_index_ = other.root_index_;
@@ -313,6 +316,7 @@ RefPtr<T>::RefPtr(const RefPtr<U>& other)
 template <typename T>
 template <typename U>
 RefPtr<T>& RefPtr<T>::operator=(const RefPtr<U>& other) {
+  reset();
   obj_ = other.obj_;
   store_ = other.store_;
   root_index_ = store_ ? store_->CopyRoot(other.root_index_) : 0;
@@ -331,6 +335,7 @@ RefPtr<T>::RefPtr(RefPtr&& other)
 template <typename T>
 template <typename U>
 RefPtr<T>& RefPtr<T>::operator=(RefPtr&& other) {
+  reset();
   obj_ = other.obj_;
   store_ = other.store_;
   root_index_ = other.root_index_;


### PR DESCRIPTION
## Summary
- All four RefPtr assignment operators overwrite `root_index_` without deleting the old GC root, leaking entries in the Store's root set.
- Fix adds `reset()` before overwriting in each operator and a self-assignment guard for copy assignment.

## Details
The RefPtr class correctly cleans up GC roots in its destructor via `reset()`, which calls `store_->DeleteRoot(root_index_)`. However, all four assignment operators (copy, move, templated copy, templated move) overwrite `root_index_` without first deleting the old root. This means every assignment leaks a root entry in the Store.

Leaked roots prevent the GC from collecting objects that are no longer referenced, causing unbounded memory growth in long-running interpreter sessions that reassign RefPtr values.

The fix:
1. Adds `reset()` at the start of each assignment operator to clean up the existing root before overwriting.
2. Adds `if (this == &other) return *this;` guard in the same-type copy assignment operator, since `reset()` sets `obj_ = nullptr` which would corrupt `other` if `this == &other`.
3. The templated copy assignment operators do not need a self-assignment guard since `RefPtr<T>` and `RefPtr<U>` are different types (self-assignment is not possible).
4. Move assignment does not need a self-assignment guard since self-move is undefined behavior per the standard.