### PR TITLE
Update minimum CMake version to 3.10 in wabt-config.cmake

### DIFF
--- a/scripts/wabt-config.cmake.in
+++ b/scripts/wabt-config.cmake.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.10)
 @PACKAGE_INIT@
 
 if ("@HAVE_OPENSSL_SHA_H@")


### PR DESCRIPTION
CMake versions 3.31 and newer have begun to warn that compatibility with CMake versions older than 3.10 will be removed. When that happens, this will stop working. For now, it issues annoying warnings.

See the 3.31 release notes: https://cmake.org/cmake/help/latest/release/3.31.html

I chose to bump to 3.10 out of extreme conservatism. But I don't know of any supported Linux systems that require anything that old. For context, Ubuntu 20.04 LTS shipped with 3.16. The oldest supported Debian release (bookworm) ships with 3.25.