### PR TITLE
bug fix for wat2wasm demo to remove call to module.resolveNames

### DIFF
--- a/docs/demo/wat2wasm/demo.js
+++ b/docs/demo/wat2wasm/demo.js
@@ -107,7 +107,6 @@ function compile() {
   try {
     module =
         wabt.parseWat('test.wast', watEditor.state.doc.toString(), features);
-    module.resolveNames();
     module.validate(features);
     const binaryOutput = module.toBinary({log: true, write_debug_names: true});
     outputLog = binaryOutput.log;


### PR DESCRIPTION
On the [wat2wasm demo website](https://webassembly.github.io/wabt/demo/wat2wasm/), when correct WAT is written (such as with any of the examples), the build log displays the following error: `TypeError: module.resolveNames is not a function`. This error seems to originate from the JavaScript file `demo.js`, which contains `module.resolveNames()` on line 110. This prevents WebAssembly from being generated.

At commit [d8e3fe6](https://github.com/WebAssembly/wabt/tree/d8e3fe601070ba99b8e68577b83036e4cdc105ff), the `resolveNames` function existed within [`libwabt.js`](https://github.com/WebAssembly/wabt/tree/d8e3fe601070ba99b8e68577b83036e4cdc105ff/docs/demo/libwabt.js) as an empty function. However, this reference seems to have been removed in the later commit [10dcc58](https://github.com/WebAssembly/wabt/tree/10dcc589d874cf47f1bc1bc0147824c4d252bb9f) and its version of [`libwabt.js`](https://github.com/WebAssembly/wabt/blob/10dcc589d874cf47f1bc1bc0147824c4d252bb9f/docs/demo/libwabt.js). This function seems to have been empty even in older commits (such as commit [6aac429](https://github.com/WebAssembly/wabt/tree/6aac429991b31f179ec948f1835c2a5eadc8404c) and its version of [`libwabt.js`](https://github.com/WebAssembly/wabt/blob/6aac429991b31f179ec948f1835c2a5eadc8404c/docs/demo/libwabt.js), where the file had not been edited for four years prior). As such, it appears that simply deleting the `module.resolveNames()` call in `demo.js` seems to fix the error - though it should be double-checked that there are no side effects of this deletion.

This is my first attempted contribution to any major open source project, so please let me know if there are any additional guidelines I may have missed or if there is any other information I should provide. Thanks!