### PR TITLE
Move filename out of Location

### DIFF
--- a/include/wabt/common.h
+++ b/include/wabt/common.h
@@ -209,17 +209,14 @@ struct Location {
   };
 
   Location() : line(0), first_column(0), last_column(0) {}
-  Location(std::string_view filename,
-           int line,
+  Location(int line,
            int first_column,
            int last_column)
-      : filename(filename),
-        line(line),
+      : line(line),
         first_column(first_column),
         last_column(last_column) {}
   explicit Location(size_t offset) : offset(offset) {}
 
-  std::string_view filename;
   union {
     // For text files.
     struct {

--- a/include/wabt/error.h
+++ b/include/wabt/error.h
@@ -43,11 +43,16 @@ static inline const char* GetErrorLevelName(ErrorLevel error_level) {
 class Error {
  public:
   Error() : error_level(ErrorLevel::Error) {}
-  Error(ErrorLevel error_level, Location loc, std::string_view message)
-      : error_level(error_level), loc(loc), message(message) {}
+  Error(ErrorLevel error_level,
+        Location loc,
+        std::string_view filename,
+        std::string_view message)
+      : error_level(error_level), loc(loc), filename(filename),
+        message(message) {}
 
   ErrorLevel error_level;
   Location loc;
+  std::string_view filename;
   std::string message;
 };
 

--- a/include/wabt/ir.h
+++ b/include/wabt/ir.h
@@ -1305,6 +1305,7 @@ struct Module {
 
   Location loc;
   std::string name;
+  std::string_view filename;
   ModuleFieldList fields;
 
   Index num_tag_imports = 0;
@@ -1578,6 +1579,7 @@ struct Script {
 
   CommandPtrVector commands;
   BindingHash module_bindings;
+  std::string_view filename;
 };
 
 void MakeTypeBindingReverseMapping(

--- a/include/wabt/shared-validator.h
+++ b/include/wabt/shared-validator.h
@@ -49,7 +49,9 @@ class SharedValidator {
  public:
   WABT_DISALLOW_COPY_AND_ASSIGN(SharedValidator);
   using FuncType = TypeChecker::FuncType;
-  SharedValidator(Errors*, const ValidateOptions& options);
+  SharedValidator(Errors*,
+                  std::string_view filename,
+                  const ValidateOptions& options);
 
   // TODO: Move into SharedValidator?
   using Label = TypeChecker::Label;
@@ -347,6 +349,7 @@ class SharedValidator {
 
   ValidateOptions options_;
   Errors* errors_;
+  std::string_view filename_;
   TypeChecker typechecker_;  // TODO: Move into SharedValidator.
   // Cached for access by OnTypecheckerError.
   Location expr_loc_ = Location(kInvalidOffset);

--- a/include/wabt/wast-lexer.h
+++ b/include/wabt/wast-lexer.h
@@ -49,6 +49,8 @@ class WastLexer {
 
   Token GetToken();
 
+  std::string_view Filename() const { return filename_; }
+
   // TODO(binji): Move this out of the lexer.
   std::unique_ptr<LexerSourceLineFinder> MakeLineFinder() {
     return std::make_unique<LexerSourceLineFinder>(source_->Clone());

--- a/src/binary-reader-ir.cc
+++ b/src/binary-reader-ir.cc
@@ -402,7 +402,6 @@ class BinaryReaderIR : public BinaryReaderNop {
 
   Func* current_func_ = nullptr;
   std::vector<LabelNode> label_stack_;
-  const char* filename_;
 
   CodeMetadataExprQueue code_metadata_queue_;
   std::string_view current_metadata_name_;
@@ -411,11 +410,12 @@ class BinaryReaderIR : public BinaryReaderNop {
 BinaryReaderIR::BinaryReaderIR(Module* out_module,
                                const char* filename,
                                Errors* errors)
-    : errors_(errors), module_(out_module), filename_(filename) {}
+    : errors_(errors), module_(out_module) {
+  out_module->filename = filename;
+}
 
 Location BinaryReaderIR::GetLocation() const {
   Location loc;
-  loc.filename = filename_;
   loc.offset = state->offset;
   return loc;
 }
@@ -423,7 +423,8 @@ Location BinaryReaderIR::GetLocation() const {
 void WABT_PRINTF_FORMAT(2, 3) BinaryReaderIR::PrintError(const char* format,
                                                          ...) {
   WABT_SNPRINTF_ALLOCA(buffer, length, format);
-  errors_->emplace_back(ErrorLevel::Error, Location(kInvalidOffset), buffer);
+  errors_->emplace_back(ErrorLevel::Error, Location(kInvalidOffset),
+                        std::string_view(), buffer);
 }
 
 Result BinaryReaderIR::PushLabel(LabelType label_type,

--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -244,7 +244,7 @@ void WABT_PRINTF_FORMAT(2, 3) BinaryReader::PrintError(const char* format,
           : ErrorLevel::Error;
 
   WABT_SNPRINTF_ALLOCA(buffer, length, format);
-  Error error(error_level, Location(state_.offset), buffer);
+  Error error(error_level, Location(state_.offset), std::string_view(), buffer);
   bool handled = delegate_->OnError(error);
 
   if (!handled) {

--- a/src/error-formatter.cc
+++ b/src/error-formatter.cc
@@ -32,8 +32,8 @@ std::string FormatError(const Error& error,
   result += color.MaybeBoldCode();
 
   const Location& loc = error.loc;
-  if (!loc.filename.empty()) {
-    result += loc.filename;
+  if (!error.filename.empty()) {
+    result += error.filename;
     result += ":";
   }
 

--- a/src/interp/binary-reader-interp.cc
+++ b/src/interp/binary-reader-interp.cc
@@ -366,7 +366,6 @@ class BinaryReaderInterp : public BinaryReaderNop {
 
 Location BinaryReaderInterp::GetLocation() const {
   Location loc;
-  loc.filename = filename_;
   loc.offset = state->offset;
   return loc;
 }
@@ -397,7 +396,7 @@ BinaryReaderInterp::BinaryReaderInterp(ModuleDesc* module,
     : errors_(errors),
       module_(*module),
       istream_(module->istream),
-      validator_(errors, ValidateOptions(features)),
+      validator_(errors, filename, ValidateOptions(features)),
       filename_(filename) {}
 
 Label* BinaryReaderInterp::GetLabel(Index depth) {
@@ -422,7 +421,8 @@ Label* BinaryReaderInterp::TopLabel() {
 void WABT_PRINTF_FORMAT(2, 3) BinaryReaderInterp::PrintError(const char* format,
                                                              ...) {
   WABT_SNPRINTF_ALLOCA(buffer, length, format);
-  errors_->emplace_back(ErrorLevel::Error, Location(kInvalidOffset), buffer);
+  errors_->emplace_back(ErrorLevel::Error, Location(kInvalidOffset), filename_,
+                        buffer);
 }
 
 Result BinaryReaderInterp::GetDropCount(Index keep_count,

--- a/src/resolve-names.cc
+++ b/src/resolve-names.cc
@@ -136,7 +136,8 @@ void WABT_PRINTF_FORMAT(3, 4) NameResolver::PrintError(const Location* loc,
                                                        ...) {
   result_ = Result::Error;
   WABT_SNPRINTF_ALLOCA(buffer, length, format);
-  errors_->emplace_back(ErrorLevel::Error, *loc, buffer);
+  errors_->emplace_back(ErrorLevel::Error, *loc, current_module_->filename,
+                        buffer);
 }
 
 void NameResolver::PushLabel(const std::string& label) {

--- a/src/shared-validator.cc
+++ b/src/shared-validator.cc
@@ -26,9 +26,12 @@ TypeVector SharedValidator::ToTypeVector(Index count, const Type* types) {
   return TypeVector(&types[0], &types[count]);
 }
 
-SharedValidator::SharedValidator(Errors* errors, const ValidateOptions& options)
+SharedValidator::SharedValidator(Errors* errors,
+                                 std::string_view filename,
+                                 const ValidateOptions& options)
     : options_(options),
       errors_(errors),
+      filename_(filename),
       typechecker_(options.features, func_types_) {
   typechecker_.set_error_callback(
       [this](const char* msg) { OnTypecheckerError(msg); });
@@ -38,7 +41,7 @@ Result WABT_PRINTF_FORMAT(3, 4) SharedValidator::PrintError(const Location& loc,
                                                             const char* format,
                                                             ...) {
   WABT_SNPRINTF_ALLOCA(buffer, length, format);
-  errors_->emplace_back(ErrorLevel::Error, loc, buffer);
+  errors_->emplace_back(ErrorLevel::Error, loc, filename_, buffer);
   return Result::Error;
 }
 

--- a/src/tools/spectest-interp.cc
+++ b/src/tools/spectest-interp.cc
@@ -417,6 +417,7 @@ class JSONParser {
   // Parsing info.
   std::vector<uint8_t> json_data_;
   size_t json_offset_ = 0;
+  std::string_view spec_json_filename_;
   Location loc_;
   Location prev_loc_;
   bool has_prev_loc_ = false;
@@ -428,7 +429,7 @@ class JSONParser {
   CHECK_RESULT(ParseKeyStringValue(key, value))
 
 wabt::Result JSONParser::ReadFile(std::string_view spec_json_filename) {
-  loc_.filename = spec_json_filename;
+  spec_json_filename_ = spec_json_filename;
   loc_.line = 1;
   loc_.first_column = 1;
 
@@ -437,7 +438,7 @@ wabt::Result JSONParser::ReadFile(std::string_view spec_json_filename) {
 
 void JSONParser::PrintError(const char* format, ...) {
   WABT_SNPRINTF_ALLOCA(buffer, length, format);
-  fprintf(stderr, "%s:%d:%d: %s\n", std::string(loc_.filename).c_str(),
+  fprintf(stderr, "%s:%d:%d: %s\n", std::string(spec_json_filename_).c_str(),
           loc_.line, loc_.first_column, buffer);
 }
 
@@ -1028,8 +1029,7 @@ static std::string_view GetDirname(std::string_view path) {
 }
 
 std::string JSONParser::CreateModulePath(std::string_view filename) {
-  std::string_view spec_json_filename = loc_.filename;
-  std::string_view dirname = GetDirname(spec_json_filename);
+  std::string_view dirname = GetDirname(spec_json_filename_);
   std::string path;
 
   if (dirname.size() == 0) {

--- a/src/validator.cc
+++ b/src/validator.cc
@@ -191,7 +191,7 @@ ScriptValidator::ScriptValidator(Errors* errors,
 void ScriptValidator::PrintError(const Location* loc, const char* format, ...) {
   result_ = Result::Error;
   WABT_SNPRINTF_ALLOCA(buffer, length, format);
-  errors_->emplace_back(ErrorLevel::Error, *loc, buffer);
+  errors_->emplace_back(ErrorLevel::Error, *loc, script_->filename, buffer);
 }
 
 static Result CheckType(Type actual, Type expected) {
@@ -757,7 +757,7 @@ Validator::Validator(Errors* errors,
                      const ValidateOptions& options)
     : options_(options),
       errors_(errors),
-      validator_(errors_, options_),
+      validator_(errors_, module->filename, options_),
       current_module_(module) {}
 
 Result Validator::CheckModule() {

--- a/src/wast-lexer.cc
+++ b/src/wast-lexer.cc
@@ -194,7 +194,7 @@ Location WastLexer::GetLocation() {
   auto column = [this](const char* p) {
     return std::max(1, static_cast<int>(p - line_start_ + 1));
   };
-  return Location(filename_, line_, column(token_start_), column(cursor_));
+  return Location(line_, column(token_start_), column(cursor_));
 }
 
 std::string_view WastLexer::GetText(size_t offset) {
@@ -638,7 +638,7 @@ Token WastLexer::GetReservedToken() {
 
 void WastLexer::Error(Location loc, const char* format, ...) {
   WABT_SNPRINTF_ALLOCA(buffer, length, format);
-  errors_->emplace_back(ErrorLevel::Error, loc, buffer);
+  errors_->emplace_back(ErrorLevel::Error, loc, filename_, buffer);
 }
 
 }  // namespace wabt

--- a/src/wast-parser.cc
+++ b/src/wast-parser.cc
@@ -348,6 +348,7 @@ void ResolveImplicitlyDefinedFunctionType(const Location& loc,
 }
 
 Result CheckTypeIndex(const Location& loc,
+                      std::string_view filename,
                       Type actual,
                       Type expected,
                       const char* desc,
@@ -357,7 +358,7 @@ Result CheckTypeIndex(const Location& loc,
   // Types must match exactly; no subtyping should be allowed.
   if (actual != expected) {
     errors->emplace_back(
-        ErrorLevel::Error, loc,
+        ErrorLevel::Error, loc, filename,
         StringPrintf("type mismatch for %s %" PRIindex
                      " of %s. got %s, expected %s",
                      index_kind, index, desc, actual.GetName().c_str(),
@@ -368,6 +369,7 @@ Result CheckTypeIndex(const Location& loc,
 }
 
 Result CheckTypes(const Location& loc,
+                  std::string_view filename,
                   const TypeVector& actual,
                   const TypeVector& expected,
                   const char* desc,
@@ -376,12 +378,12 @@ Result CheckTypes(const Location& loc,
   Result result = Result::Ok;
   if (actual.size() == expected.size()) {
     for (size_t i = 0; i < actual.size(); ++i) {
-      result |= CheckTypeIndex(loc, actual[i], expected[i], desc, i, index_kind,
-                               errors);
+      result |= CheckTypeIndex(loc, filename, actual[i], expected[i], desc, i,
+                               index_kind, errors);
     }
   } else {
     errors->emplace_back(
-        ErrorLevel::Error, loc,
+        ErrorLevel::Error, loc, filename,
         StringPrintf("expected %" PRIzd " %ss, got %" PRIzd, expected.size(),
                      index_kind, actual.size()));
     result = Result::Error;
@@ -398,11 +400,11 @@ Result CheckFuncTypeVarMatchesExplicit(const Location& loc,
     const FuncType* func_type = module.GetFuncType(decl.type_var);
     if (func_type) {
       result |=
-          CheckTypes(loc, decl.sig.result_types, func_type->sig.result_types,
-                     "function", "result", errors);
-      result |=
-          CheckTypes(loc, decl.sig.param_types, func_type->sig.param_types,
-                     "function", "argument", errors);
+          CheckTypes(loc, module.filename, decl.sig.result_types,
+                     func_type->sig.result_types, "function", "result", errors);
+      result |= CheckTypes(loc, module.filename, decl.sig.param_types,
+                           func_type->sig.param_types, "function", "argument",
+                           errors);
     } else if (!(decl.sig.param_types.empty() &&
                  decl.sig.result_types.empty())) {
       // We want to check whether the function type at the explicit index
@@ -412,11 +414,11 @@ Result CheckFuncTypeVarMatchesExplicit(const Location& loc,
       // have to check. If we get here then the type var is invalid, so we
       // can't check whether they match.
       if (decl.type_var.is_index()) {
-        errors->emplace_back(ErrorLevel::Error, loc,
+        errors->emplace_back(ErrorLevel::Error, loc, module.filename,
                              StringPrintf("invalid func type index %" PRIindex,
                                           decl.type_var.index()));
       } else {
-        errors->emplace_back(ErrorLevel::Error, loc,
+        errors->emplace_back(ErrorLevel::Error, loc, module.filename,
                              StringPrintf("expected func type identifier %s",
                                           decl.type_var.name().c_str()));
       }
@@ -563,7 +565,7 @@ WastParser::WastParser(WastLexer* lexer,
 
 void WastParser::Error(Location loc, const char* format, ...) {
   WABT_SNPRINTF_ALLOCA(buffer, length, format);
-  errors_->emplace_back(ErrorLevel::Error, loc, buffer);
+  errors_->emplace_back(ErrorLevel::Error, loc, lexer_->Filename(), buffer);
 }
 
 Token WastParser::GetToken() {
@@ -1264,6 +1266,7 @@ Result WastParser::ParseNat(uint64_t* out_nat, bool is_64) {
 Result WastParser::ParseModule(std::unique_ptr<Module>* out_module) {
   WABT_TRACE(ParseModule);
   auto module = std::make_unique<Module>();
+  module->filename = lexer_->Filename();
 
   if (PeekMatchLpar(TokenType::Module)) {
     // Starts with "(module". Allow text and binary modules, but no quoted
@@ -1282,7 +1285,8 @@ Result WastParser::ParseModule(std::unique_ptr<Module>* out_module) {
     // Parse an inline module (i.e. one with no surrounding (module)).
     CHECK_RESULT(ParseModuleFieldList(module.get()));
   } else if (PeekMatch(TokenType::Eof)) {
-    errors_->emplace_back(ErrorLevel::Warning, GetLocation(), "empty module");
+    errors_->emplace_back(ErrorLevel::Warning, GetLocation(),
+                          lexer_->Filename(), "empty module");
   } else {
     ConsumeIfLpar();
     ErrorExpected({"a module field", "a module"});
@@ -1300,6 +1304,7 @@ Result WastParser::ParseModule(std::unique_ptr<Module>* out_module) {
 Result WastParser::ParseScript(std::unique_ptr<Script>* out_script) {
   WABT_TRACE(ParseScript);
   auto script = std::make_unique<Script>();
+  script->filename = lexer_->Filename();
 
   // Don't consume the Lpar yet, even though it is required. This way the
   // sub-parser functions (e.g. ParseFuncModuleField) can consume it and keep
@@ -1313,7 +1318,8 @@ Result WastParser::ParseScript(std::unique_ptr<Script>* out_script) {
   } else if (IsCommand(PeekPair())) {
     CHECK_RESULT(ParseCommandList(script.get(), &script->commands));
   } else if (PeekMatch(TokenType::Eof)) {
-    errors_->emplace_back(ErrorLevel::Warning, GetLocation(), "empty script");
+    errors_->emplace_back(ErrorLevel::Warning, GetLocation(),
+                          lexer_->Filename(), "empty script");
   } else {
     ConsumeIfLpar();
     ErrorExpected({"a module field", "a command"});
@@ -1404,7 +1410,7 @@ Result WastParser::ResolveTargetRefType(const Module& module,
   }
 
   errors->emplace_back(
-      ErrorLevel::Error, var.loc,
+      ErrorLevel::Error, var.loc, module.filename,
       StringPrintf("undefined reference type name %s", var.name().c_str()));
   return Result::Ok;
 }
@@ -3960,6 +3966,7 @@ Result WastParser::ParseScriptModule(
       auto tsm = std::make_unique<TextScriptModule>();
       tsm->module.name = name;
       tsm->module.loc = loc;
+      tsm->module.filename = lexer_->Filename();
       if (IsModuleField(PeekPair()) || PeekIsCustom()) {
         CHECK_RESULT(ParseModuleFieldList(&tsm->module));
       } else if (!PeekMatch(TokenType::Rpar)) {

--- a/test/parse/module/bad-table-invalid-function.txt
+++ b/test/parse/module/bad-table-invalid-function.txt
@@ -8,5 +8,5 @@
 out/test/parse/module/bad-table-invalid-function.txt:6:26: error: function variable out of range: 1 (max 1)
   (elem (i32.const 0) $f 1))
                          ^
-0:0: error: type mismatch in initializer expression, expected [funcref] but got []
+out/test/parse/module/bad-table-invalid-function.txt:0:0: error: type mismatch in initializer expression, expected [funcref] but got []
 ;;; STDERR ;;)


### PR DESCRIPTION
Locations should only contain the line info / binary offset, since the filename is the same everywhere. This patch reduces the memory consumption of locations without loosing any information.