### PR TITLE
Remove debug-parser option and other unused variables

### DIFF
--- a/include/wabt/wast-parser.h
+++ b/include/wabt/wast-parser.h
@@ -34,7 +34,6 @@ struct WastParseOptions {
   WastParseOptions(const Features& features) : features(features) {}
 
   Features features;
-  bool debug_parsing = false;
   bool parse_binary_modules = true;
 };
 

--- a/src/tools/wasm-stats.cc
+++ b/src/tools/wasm-stats.cc
@@ -34,7 +34,6 @@
 
 using namespace wabt;
 
-static int s_verbose;
 static const char* s_infile;
 static const char* s_outfile;
 static size_t s_cutoff = 0;
@@ -56,7 +55,6 @@ static void ParseOptions(int argc, char** argv) {
   OptionParser parser("wasm-stats", s_description);
 
   parser.AddOption('v', "verbose", "Use multiple times for more info", []() {
-    s_verbose++;
     s_log_stream = FileStream::CreateStderr();
     s_read_binary_options.log_stream = s_log_stream.get();
   });

--- a/src/tools/wasm-validate.cc
+++ b/src/tools/wasm-validate.cc
@@ -30,7 +30,6 @@
 
 using namespace wabt;
 
-static int s_verbose;
 static std::string s_infile;
 static Features s_features;
 static bool s_read_debug_names = true;
@@ -48,10 +47,8 @@ examples:
 static void ParseOptions(int argc, char** argv) {
   OptionParser parser("wasm-validate", s_description);
 
-  parser.AddOption('v', "verbose", "Use multiple times for more info", []() {
-    s_verbose++;
-    s_log_stream = FileStream::CreateStderr();
-  });
+  parser.AddOption('v', "verbose", "Use multiple times for more info",
+                   []() { s_log_stream = FileStream::CreateStderr(); });
   s_features.AddOptions(&parser);
   parser.AddOption("no-debug-names", "Ignore debug names in the binary file",
                    []() { s_read_debug_names = false; });

--- a/src/tools/wasm2c.cc
+++ b/src/tools/wasm2c.cc
@@ -37,7 +37,6 @@
 
 using namespace wabt;
 
-static int s_verbose;
 static std::string s_infile;
 static std::string s_outfile;
 static unsigned int s_num_outputs = 1;
@@ -73,10 +72,8 @@ static bool IsFeatureSupported(const std::string& feature) {
 static void ParseOptions(int argc, char** argv) {
   OptionParser parser("wasm2c", s_description);
 
-  parser.AddOption('v', "verbose", "Use multiple times for more info", []() {
-    s_verbose++;
-    s_log_stream = FileStream::CreateStderr();
-  });
+  parser.AddOption('v', "verbose", "Use multiple times for more info",
+                   []() { s_log_stream = FileStream::CreateStderr(); });
   parser.AddOption(
       'o', "output", "FILENAME",
       "Output file for the generated C source file, by default use stdout",

--- a/src/tools/wasm2wat.cc
+++ b/src/tools/wasm2wat.cc
@@ -34,7 +34,6 @@
 
 using namespace wabt;
 
-static int s_verbose;
 static std::string s_infile;
 static std::string s_outfile;
 static Features s_features;
@@ -62,10 +61,8 @@ examples:
 static void ParseOptions(int argc, char** argv) {
   OptionParser parser("wasm2wat", s_description);
 
-  parser.AddOption('v', "verbose", "Use multiple times for more info", []() {
-    s_verbose++;
-    s_log_stream = FileStream::CreateStderr();
-  });
+  parser.AddOption('v', "verbose", "Use multiple times for more info",
+                   []() { s_log_stream = FileStream::CreateStderr(); });
   parser.AddOption(
       'o', "output", "FILENAME",
       "Output file for the generated wast file, by default use stdout",

--- a/src/tools/wast2json.cc
+++ b/src/tools/wast2json.cc
@@ -40,10 +40,8 @@ using namespace wabt;
 
 static const char* s_infile;
 static std::string s_outfile;
-static int s_verbose;
 static WriteBinaryOptions s_write_binary_options;
 static bool s_validate = true;
-static bool s_debug_parsing;
 static Features s_features;
 
 static std::unique_ptr<FileStream> s_log_stream;
@@ -61,12 +59,8 @@ examples:
 static void ParseOptions(int argc, char* argv[]) {
   OptionParser parser("wast2json", s_description);
 
-  parser.AddOption('v', "verbose", "Use multiple times for more info", []() {
-    s_verbose++;
-    s_log_stream = FileStream::CreateStderr();
-  });
-  parser.AddOption("debug-parser", "Turn on debugging the parser of wast files",
-                   []() { s_debug_parsing = true; });
+  parser.AddOption('v', "verbose", "Use multiple times for more info",
+                   []() { s_log_stream = FileStream::CreateStderr(); });
   s_features.AddOptions(&parser);
   parser.AddOption('o', "output", "FILE", "output JSON file",
                    [](const char* argument) { s_outfile = argument; });

--- a/src/tools/wat-desugar.cc
+++ b/src/tools/wat-desugar.cc
@@ -37,7 +37,6 @@ using namespace wabt;
 
 static const char* s_infile;
 static const char* s_outfile;
-static bool s_debug_parsing;
 static bool s_fold_exprs;
 static bool s_generate_names;
 static bool s_inline_import;
@@ -63,8 +62,6 @@ static void ParseOptions(int argc, char** argv) {
 
   parser.AddOption('o', "output", "FILE", "Output file for the formatted file",
                    [](const char* argument) { s_outfile = argument; });
-  parser.AddOption("debug-parser", "Turn on debugging the parser of wat files",
-                   []() { s_debug_parsing = true; });
   parser.AddOption('f', "fold-exprs", "Write folded expressions where possible",
                    []() { s_fold_exprs = true; });
   parser.AddOption("inline-exports", "Write all exports inline",

--- a/src/tools/wat2wasm.cc
+++ b/src/tools/wat2wasm.cc
@@ -43,7 +43,6 @@ static bool s_dump_module;
 static int s_verbose;
 static WriteBinaryOptions s_write_binary_options;
 static bool s_validate = true;
-static bool s_debug_parsing;
 static Features s_features;
 
 static std::unique_ptr<FileStream> s_log_stream;
@@ -71,8 +70,6 @@ static void ParseOptions(int argc, char* argv[]) {
     s_verbose++;
     s_log_stream = FileStream::CreateStderr();
   });
-  parser.AddOption("debug-parser", "Turn on debugging the parser of wat files",
-                   []() { s_debug_parsing = true; });
   parser.AddOption('d', "dump-module",
                    "Print a hexdump of the module to stdout",
                    []() { s_dump_module = true; });

--- a/test/help/wast2json.txt
+++ b/test/help/wast2json.txt
@@ -15,7 +15,6 @@ options:
       --help                                   Print this help message
       --version                                Print version information
   -v, --verbose                                Use multiple times for more info
-      --debug-parser                           Turn on debugging the parser of wast files
       --enable-exceptions                      Enable Experimental exception handling
       --disable-mutable-globals                Disable Import/export mutable globals
       --disable-saturating-float-to-int        Disable Saturating float-to-int operators

--- a/test/help/wat-desugar.txt
+++ b/test/help/wat-desugar.txt
@@ -19,7 +19,6 @@ options:
       --help                                   Print this help message
       --version                                Print version information
   -o, --output=FILE                            Output file for the formatted file
-      --debug-parser                           Turn on debugging the parser of wat files
   -f, --fold-exprs                             Write folded expressions where possible
       --inline-exports                         Write all exports inline
       --inline-imports                         Write all imports inline

--- a/test/help/wat2wasm.txt
+++ b/test/help/wat2wasm.txt
@@ -21,7 +21,6 @@ options:
       --help                                   Print this help message
       --version                                Print version information
   -v, --verbose                                Use multiple times for more info
-      --debug-parser                           Turn on debugging the parser of wat files
   -d, --dump-module                            Print a hexdump of the module to stdout
       --enable-exceptions                      Enable Experimental exception handling
       --disable-mutable-globals                Disable Import/export mutable globals


### PR DESCRIPTION
The support for --debug-parser is removed from the project after the parser has been reworked. This patch removes the    command line option as well.

Would not be bad to change the `"Use multiple times for more info"` to something else.