### PR TITLE
[wasi-interp] fix integer overflow in wasi getMemPtr size calculation

### DIFF
--- a/src/interp/interp-wasi.cc
+++ b/src/interp/interp-wasi.cc
@@ -605,12 +605,12 @@ class WasiInstance {
                    uint32_t num_elems,
                    T** result,
                    Trap::Ptr* trap) {
-    if (!memory->IsValidAccess(address, 0, num_elems * sizeof(T))) {
+    if (!memory->IsValidAccess(address, 0, u64{num_elems} * sizeof(T))) {
       *trap =
           Trap::New(*instance.store(),
                     StringPrintf("out of bounds memory access: "
                                  "[%u, %" PRIu64 ") >= max value %" PRIu64,
-                                 address, u64{address} + num_elems * sizeof(T),
+                                 address, u64{address} + u64{num_elems} * sizeof(T),
                                  memory->ByteSize()));
       return Result::Error;
     }


### PR DESCRIPTION
`getMemPtr` computes the access size as `num_elems * sizeof(T)` in `size_t` (interp-wasi.cc:608), which truncates on 32-bit targets so an oversized guest iovec count passes `IsValidAccess` and the caller then reads out of bounds. Widen the multiplication to 64 bits to match the `IsValidAccess` signature.