### PR TITLE
Use unsigned shift in GetAlignment to avoid signed overflow

### DIFF
--- a/src/interp/binary-reader-interp.cc
+++ b/src/interp/binary-reader-interp.cc
@@ -985,7 +985,7 @@ Result BinaryReaderInterp::OnSimdLaneOpExpr(Opcode opcode, uint64_t value) {
 }
 
 uint32_t GetAlignment(Address alignment_log2) {
-  return alignment_log2 < 32 ? 1 << alignment_log2 : ~0u;
+  return alignment_log2 < 32 ? 1u << alignment_log2 : ~0u;
 }
 
 Result BinaryReaderInterp::OnSimdLoadLaneExpr(Opcode opcode,


### PR DESCRIPTION
Reading the two binary readers side by side, the load/store alignment immediate gets widened differently:

    binary-reader-ir.cc:      1ull << alignment_log2
    binary-reader-interp.cc:  1 << alignment_log2

The interp form shifts a signed int. CheckAlignment only rejects alignment_log2 >= 32, so a load or store in an untrusted module can carry alignment_log2 == 31, and 1 << 31 on int is signed overflow. Switching the literal to 1u makes the shift unsigned; the returned value is unchanged.