### PR TITLE
[wasm2c] Avoid size_t overflow in wasm_rt_grow table reallocation

### DIFF
--- a/wasm2c/wasm-rt-impl-tableops.inc
+++ b/wasm2c/wasm-rt-impl-tableops.inc
@@ -69,6 +69,9 @@ uint32_t WASM_RT_TABLE_APINAME(wasm_rt_grow)(WASM_RT_TABLE_TYPE* table,
   if ((new_elems < old_elems) || (new_elems > table->max_size)) {
     return (uint32_t)-1;
   }
+  if (new_elems > SIZE_MAX / sizeof(WASM_RT_TABLE_ELEMENT_TYPE)) {
+    return (uint32_t)-1;
+  }
   void* new_data =
       realloc(table->data, new_elems * sizeof(WASM_RT_TABLE_ELEMENT_TYPE));
   if (!new_data) {


### PR DESCRIPTION
On a 32-bit (ILP32) build, growing a funcref table in `wasm_rt_grow`:

    new_elems            = 230000000          (<= table->max_size)
    new_elems * sizeof   = 4600000000 bytes   (computed as uint64_t)
    realloc() size_t arg = 305032704 bytes    (truncated to 32-bit)

`new_elems` is a `uint64_t` but only bounded by `table->max_size`, which can be `UINT32_MAX`. The element is a multi-pointer struct, so the byte count crosses 2^32 long before `new_elems` does. The product is then narrowed to `realloc`'s `size_t` parameter, so the reallocation is far too small. The loop right after writes `new_elems` elements into it. A guest `table.grow` with a large delta on a table with a large max reaches this.

Found while reading the table path looking for the realloc-side equivalent of the recent wasi size fix. `calloc` in `wasm_rt_allocate` is safe because it overflows-checks its two operands; the grow path does the multiply itself and hands the result straight to `realloc`, which does not.

Reject the grow when the byte size would not fit in `size_t`, before the realloc. No effect on 64-bit. The shared include covers the funcref, externref and exnref variants.