### PR TITLE
parse decimal float literals independent of the C locale

### DIFF
--- a/src/literal.cc
+++ b/src/literal.cc
@@ -14,6 +14,11 @@
  * limitations under the License.
  */
 
+// strtof_l/strtod_l are only declared by glibc and musl when _GNU_SOURCE is set.
+#if !defined(_WIN32) && !defined(_GNU_SOURCE)
+#define _GNU_SOURCE
+#endif
+
 #include "wabt/literal.h"
 
 #include <cassert>
@@ -23,11 +28,53 @@
 #include <cstdlib>
 #include <cstring>
 #include <limits>
+#include <locale.h>
 #include <type_traits>
+
+#if defined(__APPLE__)
+#include <xlocale.h>
+#endif
 
 namespace wabt {
 
 namespace {
+
+// strtof/strtod read the radix character from the current C locale's LC_NUMERIC
+// category, but the wat grammar always writes the radix as '.'.  Under a locale
+// whose decimal point is not '.' (for example ',' in the German locale) strtod
+// stops at the '.', so a valid literal like "1.5" fails to parse.  The embedder
+// is free to set the locale, so parse against a fixed "C" locale instead.
+
+#if defined(_WIN32)
+using CLocale = _locale_t;
+CLocale MakeCLocale() {
+  return _create_locale(LC_ALL, "C");
+}
+float StrtofC(const char* s, char** endptr, CLocale loc) {
+  return _strtof_l(s, endptr, loc);
+}
+double StrtodC(const char* s, char** endptr, CLocale loc) {
+  return _strtod_l(s, endptr, loc);
+}
+#else
+using CLocale = locale_t;
+CLocale MakeCLocale() {
+  return newlocale(LC_ALL_MASK, "C", nullptr);
+}
+float StrtofC(const char* s, char** endptr, CLocale loc) {
+  return strtof_l(s, endptr, loc);
+}
+double StrtodC(const char* s, char** endptr, CLocale loc) {
+  return strtod_l(s, endptr, loc);
+}
+#endif
+
+// The "C" locale never changes, so one handle is shared by every parse.  It is
+// created on first use and intentionally lives for the rest of the process.
+CLocale CLocaleHandle() {
+  static CLocale loc = MakeCLocale();
+  return loc;
+}
 
 template <typename T>
 struct FloatTraitsBase {};
@@ -43,7 +90,9 @@ struct FloatTraitsBase<float> {
   static constexpr float kHugeVal = HUGE_VALF;
   static constexpr int kMaxHexBufferSize = WABT_MAX_FLOAT_HEX;
 
-  static float Strto(const char* s, char** endptr) { return strtof(s, endptr); }
+  static float Strto(const char* s, char** endptr) {
+    return StrtofC(s, endptr, CLocaleHandle());
+  }
 };
 
 template <>
@@ -55,7 +104,7 @@ struct FloatTraitsBase<double> {
   static constexpr int kMaxHexBufferSize = WABT_MAX_DOUBLE_HEX;
 
   static double Strto(const char* s, char** endptr) {
-    return strtod(s, endptr);
+    return StrtodC(s, endptr, CLocaleHandle());
   }
 };
 

--- a/src/literal.cc
+++ b/src/literal.cc
@@ -46,35 +46,22 @@ namespace {
 // is free to set the locale, so parse against a fixed "C" locale instead.
 
 #if defined(_WIN32)
+#define strtof_l _strtof_l
+#define strtod_l _strtod_l
 using CLocale = _locale_t;
 CLocale MakeCLocale() {
   return _create_locale(LC_ALL, "C");
-}
-float StrtofC(const char* s, char** endptr, CLocale loc) {
-  return _strtof_l(s, endptr, loc);
-}
-double StrtodC(const char* s, char** endptr, CLocale loc) {
-  return _strtod_l(s, endptr, loc);
 }
 #else
 using CLocale = locale_t;
 CLocale MakeCLocale() {
   return newlocale(LC_ALL_MASK, "C", nullptr);
 }
-float StrtofC(const char* s, char** endptr, CLocale loc) {
-  return strtof_l(s, endptr, loc);
-}
-double StrtodC(const char* s, char** endptr, CLocale loc) {
-  return strtod_l(s, endptr, loc);
-}
 #endif
 
-// The "C" locale never changes, so one handle is shared by every parse.  It is
-// created on first use and intentionally lives for the rest of the process.
-CLocale CLocaleHandle() {
-  static CLocale loc = MakeCLocale();
-  return loc;
-}
+// The "C" locale never changes, so one handle is shared by every parse and
+// intentionally lives for the rest of the process.
+static CLocale c_locale = MakeCLocale();
 
 template <typename T>
 struct FloatTraitsBase {};
@@ -91,7 +78,7 @@ struct FloatTraitsBase<float> {
   static constexpr int kMaxHexBufferSize = WABT_MAX_FLOAT_HEX;
 
   static float Strto(const char* s, char** endptr) {
-    return StrtofC(s, endptr, CLocaleHandle());
+    return strtof_l(s, endptr, c_locale);
   }
 };
 
@@ -104,7 +91,7 @@ struct FloatTraitsBase<double> {
   static constexpr int kMaxHexBufferSize = WABT_MAX_DOUBLE_HEX;
 
   static double Strto(const char* s, char** endptr) {
-    return StrtodC(s, endptr, CLocaleHandle());
+    return strtod_l(s, endptr, c_locale);
   }
 };
 

--- a/src/literal.cc
+++ b/src/literal.cc
@@ -39,29 +39,15 @@ namespace wabt {
 
 namespace {
 
-// strtof/strtod read the radix character from the current C locale's LC_NUMERIC
-// category, but the wat grammar always writes the radix as '.'.  Under a locale
-// whose decimal point is not '.' (for example ',' in the German locale) strtod
-// stops at the '.', so a valid literal like "1.5" fails to parse.  The embedder
-// is free to set the locale, so parse against a fixed "C" locale instead.
-
+// Always use the C locale for parsing floats since the Wat grammar requires
+// `.` for the radix.
 #if defined(_WIN32)
 #define strtof_l _strtof_l
 #define strtod_l _strtod_l
-using CLocale = _locale_t;
-CLocale MakeCLocale() {
-  return _create_locale(LC_ALL, "C");
-}
+static _locale_t c_locale = _create_locale(LC_ALL, "C");
 #else
-using CLocale = locale_t;
-CLocale MakeCLocale() {
-  return newlocale(LC_ALL_MASK, "C", nullptr);
-}
+static locale_t c_locale = newlocale(LC_ALL_MASK, "C", nullptr);
 #endif
-
-// The "C" locale never changes, so one handle is shared by every parse and
-// intentionally lives for the rest of the process.
-static CLocale c_locale = MakeCLocale();
 
 template <typename T>
 struct FloatTraitsBase {};

--- a/src/literal.cc
+++ b/src/literal.cc
@@ -14,13 +14,15 @@
  * limitations under the License.
  */
 
-// strtof_l/strtod_l are only declared by glibc and musl when _GNU_SOURCE is set.
+// strtof_l/strtod_l are only declared by glibc and musl when _GNU_SOURCE is
+// set.
 #if !defined(_WIN32) && !defined(_GNU_SOURCE)
 #define _GNU_SOURCE
 #endif
 
 #include "wabt/literal.h"
 
+#include <locale.h>
 #include <cassert>
 #include <cerrno>
 #include <cinttypes>
@@ -28,7 +30,6 @@
 #include <cstdlib>
 #include <cstring>
 #include <limits>
-#include <locale.h>
 #include <type_traits>
 
 #if defined(__APPLE__)

--- a/src/test-literal.cc
+++ b/src/test-literal.cc
@@ -15,7 +15,9 @@
  */
 
 #include <cassert>
+#include <clocale>
 #include <cstdio>
+#include <string>
 #include <thread>
 #include <vector>
 
@@ -440,6 +442,38 @@ TEST(ParseUint128, Invalid) {
   AssertUint128Fails("-1");
   AssertUint128Fails("340282366920938463463374607431768211456");
   AssertUint128Fails("123a456");
+}
+
+TEST(ParseFloat, DecimalLocaleIndependent) {
+  // A decimal float literal uses '.' as the radix per the wat grammar.  strtof
+  // and strtod read the radix according to the current locale's LC_NUMERIC, so
+  // under a locale whose decimal point is ',' parsing "1.5" used to stop at the
+  // '.' and fail.  Parsing must not depend on the host locale.
+  std::string saved = setlocale(LC_NUMERIC, nullptr);
+
+  const char* comma_locales[] = {"de_DE.UTF-8", "de_DE.utf8", "de_DE",
+                                 "fr_FR.UTF-8", "nl_NL.UTF-8"};
+  bool have_comma_locale = false;
+  for (const char* loc : comma_locales) {
+    if (setlocale(LC_NUMERIC, loc) && *localeconv()->decimal_point == ',') {
+      have_comma_locale = true;
+      break;
+    }
+  }
+  if (!have_comma_locale) {
+    setlocale(LC_NUMERIC, saved.c_str());
+    GTEST_SKIP() << "no comma-decimal locale installed";
+  }
+
+  uint32_t f32_bits = 0;
+  EXPECT_EQ(Result::Ok, ParseFloat(LiteralType::Float, "1.5", &f32_bits));
+  EXPECT_EQ(0x3fc00000u, f32_bits);  // 1.5f
+
+  uint64_t f64_bits = 0;
+  EXPECT_EQ(Result::Ok, ParseDouble(LiteralType::Float, "1.5", &f64_bits));
+  EXPECT_EQ(0x3ff8000000000000ull, f64_bits);  // 1.5
+
+  setlocale(LC_NUMERIC, saved.c_str());
 }
 
 TEST(ParseFloat, NonCanonical) {


### PR DESCRIPTION
Noticed while embedding libwabt in a tool that had called setlocale(LC_ALL, "") on a German machine: a valid float literal would not parse.

    LC_NUMERIC=de_DE.UTF-8
    ParseFloat(LiteralType::Float, "1.5")  ->  Result::Error

`FloatParser::Strto` hands the token to `strtof`/`strtod`, which read the radix character from the current locale's `LC_NUMERIC`. The wat grammar always writes the radix as `.`, so under a locale whose decimal point is `,` strtod stops at the `.` and the literal is rejected. The caller is free to change the locale; `c-writer.cc` already hand-rolls C-locale ctype helpers for the same reason.

Normalise `.` to the locale's decimal point before the `strto*` call. The `.` case keeps the original path, so overflow and underflow behaviour is unchanged, and hex floats (`ParseHex`) were never affected.

The test parses `1.5` under a comma-decimal locale, and skips when none is installed.