### PR TITLE
[wasm-decompile] Avoid out-of-range shift in load/store rewrite

### DIFF
--- a/src/decompiler.cc
+++ b/src/decompiler.cc
@@ -321,7 +321,7 @@ struct Decompiler {
         auto& const_exp = shift_exp.children[1];
         if (se.opcode == Opcode::I32Shl && const_exp.etype == ExprType::Const) {
           auto& ce = *cast<ConstExpr>(const_exp.e);
-          if (ce.const_.type() == Type::I32 &&
+          if (ce.const_.type() == Type::I32 && ce.const_.u32() < 64 &&
               (1ULL << ce.const_.u32()) == align) {
             // Pfew, case detected :( Lets re-write this in Haskell.
             // TODO: we're decompiling these twice.

--- a/test/decompile/loadstore.txt
+++ b/test/decompile/loadstore.txt
@@ -97,6 +97,15 @@
     i32.add
     i32.load offset=4
     i32.store offset=4
+    ;; A shift amount that is not a valid power-of-two alignment must not be
+    ;; used as a shift exponent for the rewrite; amounts >= 64 are out of range.
+    local.get 0
+    local.get 1
+    i32.const 64
+    i32.shl
+    i32.add
+    i32.load offset=0
+    drop
     ;; Test naming of absolute addresses referring to data sections.
     i32.const 16
     i32.load8_u offset=1  ;; Refers to the 'W'
@@ -129,6 +138,7 @@ export function f(a:{ a:float, b:float }, b:{ a:ushort, b:long }) { // func0
   a[b]:int = a[b]:int;
   a[b + 1]:int = a[b + 1]:int;
   (a + (b << 3))[1]:int = a[b + 1]:int;
+  (a + (b << 64))[0]:int;
   d_HelloWorld[7]:ubyte;
 }
 


### PR DESCRIPTION
UBSan, decompiling a module that addresses memory as (base + (index << n)):

    src/decompiler.cc:325:21: runtime error: shift exponent 64 is too large for 64-bit type 'unsigned long long'
        #0 wabt::Decompiler::LoadStore(...) decompiler.cc:325
        #1 wabt::Decompiler::DecompileExpr(...) decompiler.cc:489

The load/store printer recognises that address shape and tries to rewrite it to base[index], testing 1ULL << n against the access alignment. n is the i32.const operand of the i32.shl, read straight from the module. i32.shl masks its shift amount at runtime, so n is otherwise unconstrained; n >= 64 pushes the exponent past the width of the type and the shift is undefined.

Bounding n < 64 before the shift loses no real match, since the alignment it is compared against is always a small power of two. The unmatched shape then prints verbatim, the same as a mismatched shift already does.

Repro is a load of (local 0 + (local 1 << 64)): UBSan aborts at decompiler.cc:325 before, decompiles to (a + (b << 64))[0]:int after. Covered by the loadstore decompile test.