### PR TITLE
[wasm2c] Use locale-independent ctype in GenerateHeaderGuard

### DIFF
--- a/src/c-writer.cc
+++ b/src/c-writer.cc
@@ -761,6 +761,10 @@ static bool internal_ishexdigit(uint8_t ch) {
   return internal_isdigit(ch) || (ch >= 'A' && ch <= 'F');  // capitals only
 }
 
+static char internal_toupper(uint8_t ch) {
+  return (ch >= 'a' && ch <= 'z') ? (ch - 'a' + 'A') : ch;
+}
+
 // static
 std::string CWriter::Mangle(std::string_view name, bool double_underscores) {
   /*
@@ -1528,8 +1532,8 @@ void CWriter::WriteInitExprTerminal(const Expr* expr) {
 std::string CWriter::GenerateHeaderGuard() const {
   std::string result;
   for (char c : header_name_) {
-    if (isalnum(c) || c == '_') {
-      result += toupper(c);
+    if (internal_isalnum(c) || c == '_') {
+      result += internal_toupper(c);
     } else {
       result += '_';
     }


### PR DESCRIPTION
Spotted while reading CWriter for locale-sensitive calls.

    src/c-writer.cc:1531:  isalnum(c)    // c is plain `char`
    src/c-writer.cc:1532:  toupper(c)

header_name_ is the output header filename. char is signed on most targets, so any byte >= 0x80 (a non-ASCII output path) reaches these <cctype> calls as a negative value. Passing anything other than EOF or an unsigned char value to them is undefined behaviour. toupper is locale-sensitive on top of that.

The file already defines internal_isalpha/isdigit/isalnum/ishexdigit on uint8_t for this exact reason (the comment above them spells it out), used throughout Mangle. GenerateHeaderGuard was the lone holdout. Routed it through internal_isalnum plus a matching internal_toupper. Guards for ASCII header names come out byte-identical.