### PR TITLE
[interp] Use u64 table operands so out-of-range table64 indices trap

### DIFF
--- a/include/wabt/interp/interp.h
+++ b/include/wabt/interp/interp.h
@@ -827,26 +827,26 @@ class Table : public Extern {
 
   Result Match(Store&, const ImportType&, Trap::Ptr* out_trap) override;
 
-  bool IsValidRange(u32 offset, u32 size) const;
+  bool IsValidRange(u64 offset, u64 size) const;
 
-  Result Get(u32 offset, Ref* out) const;
-  Result Set(Store&, u32 offset, Ref);
-  Result Grow(Store&, u32 count, Ref);
-  Result Fill(Store&, u32 offset, Ref, u32 size);
+  Result Get(u64 offset, Ref* out) const;
+  Result Set(Store&, u64 offset, Ref);
+  Result Grow(Store&, u64 count, Ref);
+  Result Fill(Store&, u64 offset, Ref, u64 size);
   Result Init(Store&,
-              u32 dst_offset,
+              u64 dst_offset,
               const ElemSegment&,
               u32 src_offset,
               u32 size);
   static Result Copy(Store&,
                      Table& dst,
-                     u32 dst_offset,
+                     u64 dst_offset,
                      const Table& src,
-                     u32 src_offset,
-                     u32 size);
+                     u64 src_offset,
+                     u64 size);
 
   // Unsafe API.
-  Ref UnsafeGet(u32 offset) const;
+  Ref UnsafeGet(u64 offset) const;
 
   const ExternType& extern_type() override;
   const TableType& type() const;

--- a/src/interp/interp.cc
+++ b/src/interp/interp.cc
@@ -19,6 +19,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cinttypes>
+#include <limits>
 
 #include "wabt/interp/interp-math.h"
 
@@ -593,12 +594,12 @@ Result Table::Match(Store& store,
   return MatchImpl(store, import_type, type_, out_trap);
 }
 
-bool Table::IsValidRange(u32 offset, u32 size) const {
+bool Table::IsValidRange(u64 offset, u64 size) const {
   size_t elem_size = elements_.size();
   return size <= elem_size && offset <= elem_size - size;
 }
 
-Result Table::Get(u32 offset, Ref* out) const {
+Result Table::Get(u64 offset, Ref* out) const {
   if (IsValidRange(offset, 1)) {
     *out = elements_[offset];
     return Result::Ok;
@@ -606,12 +607,12 @@ Result Table::Get(u32 offset, Ref* out) const {
   return Result::Error;
 }
 
-Ref Table::UnsafeGet(u32 offset) const {
+Ref Table::UnsafeGet(u64 offset) const {
   assert(IsValidRange(offset, 1));
   return elements_[offset];
 }
 
-Result Table::Set(Store& store, u32 offset, Ref ref) {
+Result Table::Set(Store& store, u64 offset, Ref ref) {
   assert(store.HasValueType(ref, type_.element));
   if (IsValidRange(offset, 1)) {
     elements_[offset] = ref;
@@ -620,11 +621,18 @@ Result Table::Set(Store& store, u32 offset, Ref ref) {
   return Result::Error;
 }
 
-Result Table::Grow(Store& store, u32 count, Ref ref) {
+Result Table::Grow(Store& store, u64 count, Ref ref) {
   size_t old_size = elements_.size();
   u32 new_size;
   assert(store.HasValueType(ref, type_.element));
-  if (CanGrow<u32>(type_.limits, old_size, count, &new_size)) {
+  // Table sizes are bounded to 2^32-1 elements, so a delta that does not fit in
+  // a u32 can never succeed; checking here keeps the u64 count from being
+  // truncated by the u32 CanGrow below.
+  if (count > std::numeric_limits<u32>::max()) {
+    return Result::Error;
+  }
+  if (CanGrow<u32>(type_.limits, old_size, static_cast<u32>(count),
+                   &new_size)) {
     // Grow the limits of the table too, so that if it is used as an
     // import to another module its new size is honored.
     type_.limits.initial += count;
@@ -635,7 +643,7 @@ Result Table::Grow(Store& store, u32 count, Ref ref) {
   return Result::Error;
 }
 
-Result Table::Fill(Store& store, u32 offset, Ref ref, u32 size) {
+Result Table::Fill(Store& store, u64 offset, Ref ref, u64 size) {
   assert(store.HasValueType(ref, type_.element));
   if (IsValidRange(offset, size)) {
     std::fill(elements_.begin() + offset, elements_.begin() + offset + size,
@@ -646,7 +654,7 @@ Result Table::Fill(Store& store, u32 offset, Ref ref, u32 size) {
 }
 
 Result Table::Init(Store& store,
-                   u32 dst_offset,
+                   u64 dst_offset,
                    const ElemSegment& src,
                    u32 src_offset,
                    u32 size) {
@@ -663,10 +671,10 @@ Result Table::Init(Store& store,
 // static
 Result Table::Copy(Store& store,
                    Table& dst,
-                   u32 dst_offset,
+                   u64 dst_offset,
                    const Table& src,
-                   u32 src_offset,
-                   u32 size) {
+                   u64 src_offset,
+                   u64 size) {
   if (dst.IsValidRange(dst_offset, size) &&
       src.IsValidRange(src_offset, size) &&
       TypesMatch(dst.type_.element, src.type_.element)) {

--- a/test/interp/table64-oob.txt
+++ b/test/interp/table64-oob.txt
@@ -1,0 +1,28 @@
+;;; TOOL: run-interp
+;;; ARGS*: --enable-memory64
+(module
+  (table $t i64 10 funcref)
+
+  ;; Indices in [2^32, 2^32 + size) must trap, not wrap into a valid slot.
+  (func (export "get_wrap") (result funcref)
+    (table.get $t (i64.const 0x1_0000_0003)))
+  (func (export "set_wrap")
+    (table.set $t (i64.const 0x1_0000_0003) (ref.null func)))
+  (func (export "fill_wrap")
+    (table.fill $t (i64.const 0x1_0000_0000) (ref.null func) (i64.const 1)))
+
+  ;; A delta that does not fit in 32 bits must fail to grow.
+  (func (export "grow_overflow") (result i64)
+    (table.grow $t (ref.null func) (i64.const 0x1_0000_0000)))
+
+  ;; In-range access still works.
+  (func (export "get_ok") (result funcref)
+    (table.get $t (i64.const 3)))
+)
+(;; STDOUT ;;;
+get_wrap() => error: out of bounds table access: table.get at 4294967299 >= max value 10
+set_wrap() => error: out of bounds table access: table.set at 4294967299 >= max value 10
+fill_wrap() => error: out of bounds table access: table.fill out of bounds
+grow_overflow() => i64:18446744073709551615
+get_ok() => funcref:0
+;;; STDOUT ;;)


### PR DESCRIPTION
On a table declared with the i64 index type, an index past the end of the table does not trap as it should:

    $ wasm-interp --enable-memory64 --run-all-exports t.wasm
    get_oob() => funcref:0

The table has 10 slots and the index was `(i64.const 0x1_0000_0003)`. That is out of bounds, but it read slot 3.

table.get/set/fill/copy/init/grow pop their operands as u64 for an i64 table (PopPtr), then pass them to Table::Get/Set/Fill/Copy/Init/Grow, which take u32. The high half is dropped, so any index in [2^32, 2^32 + size) wraps to an in-range slot and the bounds check passes. table.set overwrites a live entry that way, and table.grow truncates a delta above 2^32 and reports success instead of failing.

Memory already takes u64 throughout for memory64, so this widens the Table side to match and rejects a grow delta that does not fit in u32. Behaviour for i32 tables is byte-identical. Added an interp test covering the wrap window.