### PR TITLE
Avoid string_view underflow in ParseCodeMetadataAnnotation

### DIFF
--- a/src/wast-parser.cc
+++ b/src/wast-parser.cc
@@ -2311,6 +2311,30 @@ Result WastParser::ParseCodeMetadataAnnotation(ExprList* exprs) {
   WABT_TRACE(ParseCodeMetadataAnnotation);
   Token tk = Consume();
   std::string_view name = tk.text();
+  if (name.find("metadata.code.") != 0) {
+    // Not a code metadata annotation. This can be reached when Peek admits a
+    // (@custom ...) annotation (only meaningful at module scope) into an
+    // instruction list. Discard it like any other unrecognised annotation
+    // rather than stripping a prefix that isn't there.
+    int indent = 1;
+    while (indent > 0) {
+      switch (Peek()) {
+        case TokenType::Lpar:
+        case TokenType::LparAnn:
+          indent++;
+          break;
+        case TokenType::Rpar:
+          indent--;
+          break;
+        case TokenType::Eof:
+          return ErrorExpected({"a close paren"});
+        default:
+          break;
+      }
+      Consume();
+    }
+    return Result::Ok;
+  }
   name.remove_prefix(sizeof("metadata.code.") - 1);
   std::string data_text;
   CHECK_RESULT(ParseQuotedText(&data_text, false));

--- a/test/dump/code-metadata-skip-custom.txt
+++ b/test/dump/code-metadata-skip-custom.txt
@@ -1,0 +1,30 @@
+;;; TOOL: run-objdump
+;;; ARGS0: --enable-annotations --enable-code-metadata
+;;; ARGS1: --headers
+;; A (@custom ...) annotation is only meaningful at module scope. When one
+;; appears in an instruction list it reaches ParseCodeMetadataAnnotation; it
+;; should be skipped like any other unrecognised annotation, while a real
+;; metadata.code annotation in the same body is still emitted.
+(module
+  (func $f (result i32)
+    (@custom "x")
+    (@metadata.code.test "aa") i32.const 1
+    return))
+(;; STDOUT ;;;
+
+code-metadata-skip-custom.wasm:	file format wasm 0x1
+
+Sections:
+
+     Type start=0x0000000a end=0x0000000f (size=0x00000005) count: 1
+ Function start=0x00000011 end=0x00000013 (size=0x00000002) count: 1
+   Custom start=0x00000015 end=0x0000002f (size=0x0000001a) "metadata.code.test"
+     Code start=0x00000031 end=0x00000038 (size=0x00000007) count: 1
+
+Code Disassembly:
+
+000033 func[0]:
+ 000034: 41 01                      | i32.const 1
+ 000036: 0f                         | return
+ 000037: 0b                         | end
+;;; STDOUT ;;)


### PR DESCRIPTION
ASAN, `wat2wasm --enable-annotations` on a `(@custom ...)` sat inside a function body:

    ERROR: AddressSanitizer: heap-buffer-overflow READ of size 8
      #5 std::__string_view_hash::operator()(std::string_view)
      #9 wabt::BinaryWriter::WriteExpr() binary-writer.cc:1189
      #11 wabt::BinaryWriter::WriteFunc() binary-writer.cc:1229

`ParseCodeMetadataAnnotation` strips the `metadata.code.` prefix with `remove_prefix(14)` and assumes it is always there. `ParseInstrList` hands it every `(@...)` annotation in an instruction list, and `Peek` admits the bare `(@custom ...)` token because that spelling is meaningful at module scope. On the 6-byte `custom` text `remove_prefix(14)` underflows the view length to ~2^64 and walks the data pointer past the token. The `CodeMetadataExpr` then keeps a name whose pointer and size are both rubbish. Nothing trips until the binary writer hashes that name as a map key, which is where ASAN fires.

The binary reader already guards the matching strip with `find("metadata.code.") == 0` in binary-reader.cc; the parser never got it. Reject annotations without the prefix.

Repro:

    (module
      (func
        (@custom "x")))

Turned up fuzzing wat2wasm with annotations enabled.
