### PR TITLE
Avoid Var::name() on function-level branches in decompiler

### DIFF
--- a/src/decompiler.cc
+++ b/src/decompiler.cc
@@ -220,6 +220,17 @@ struct Decompiler {
     return name[0] == '$' ? name.substr(1) : name;
   }
 
+  // A branch that targets the function's implicit outermost label is left as
+  // an index by the name-resolution passes (there is no block label to use),
+  // so it must not be routed through Var::name(). Such a branch leaves the
+  // function, i.e. it is a return.
+  std::string BranchTarget(const Var& var, LabelType lt) {
+    if (!var.is_name())
+      return "return";
+    return cat(lt == LabelType::Loop ? "continue " : "goto ",
+               VarName(var.name()));
+  }
+
   template <ExprType T>
   Value Get(const VarExpr<T>& ve) {
     return Value{{std::string(VarName(ve.var.name()))}, Precedence::Atomic};
@@ -564,15 +575,12 @@ struct Decompiler {
       }
       case ExprType::Br: {
         auto be = cast<BrExpr>(n.e);
-        return Value{{(n.u.lt == LabelType::Loop ? "continue " : "goto ") +
-                      VarName(be->var.name())},
-                     Precedence::None};
+        return Value{{BranchTarget(be->var, n.u.lt)}, Precedence::None};
       }
       case ExprType::BrIf: {
         auto bie = cast<BrIfExpr>(n.e);
-        auto jmp = n.u.lt == LabelType::Loop ? "continue" : "goto";
         return WrapChild(args[0], "if (",
-                         cat(") ", jmp, " ", VarName(bie->var.name())),
+                         cat(") ", BranchTarget(bie->var, n.u.lt)),
                          Precedence::None);
       }
       case ExprType::Return: {
@@ -599,11 +607,13 @@ struct Decompiler {
         auto bte = cast<BrTableExpr>(n.e);
         std::string ts = "br_table[";
         for (auto& v : bte->targets) {
-          ts += VarName(v.name());
+          ts += v.is_name() ? VarName(v.name()) : std::string_view("return");
           ts += ", ";
         }
         ts += "..";
-        ts += VarName(bte->default_target.name());
+        ts += bte->default_target.is_name()
+                  ? VarName(bte->default_target.name())
+                  : std::string_view("return");
         ts += "](";
         return WrapChild(args[0], ts, ")", Precedence::Atomic);
       }

--- a/test/decompile/br-function-level.txt
+++ b/test/decompile/br-function-level.txt
@@ -1,0 +1,31 @@
+;;; TOOL: run-wasm-decompile
+
+(module
+  ;; Branches that target the function's implicit outermost label. These are
+  ;; left as an index by name resolution (no block label exists for them), so
+  ;; the decompiler must treat them as a return rather than calling name().
+  (func $br (block (loop (br 2))))
+  (func $br_if (param i32) (block (loop local.get 0 (br_if 2))))
+  (func $br_table (param i32) (block (loop local.get 0 (br_table 2 0 1)))))
+(;; STDOUT ;;;
+function f_a() { // func0
+  loop L_b {
+    return
+  }
+  label B_a:
+}
+
+function f_b(a:int) { // func1
+  loop L_b {
+    if (a) return
+  }
+  label B_a:
+}
+
+function f_c(a:int) { // func2
+  loop L_b {
+    br_table[return, L_b, ..B_a](a)
+  }
+  label B_a:
+}
+;;; STDOUT ;;)


### PR DESCRIPTION
Found while fuzzing wasm-decompile.

    Assertion failed: (is_name()), function name, file ir.h, line 82.

A branch whose target is the function's implicit outermost label is left as an index by the name resolution passes, since there is no block label to attach to it. DecompileExpr then called Var::name() on that index var. ir.h keeps index_ and name_ in a union, so this reads the inactive std::string member; with NDEBUG the assert is gone and it dereferences a garbage pointer instead.

Smallest repro, decompiles to a return:

    (func (block (loop (br 2))))

br_if and br_table with a function-level target reach the same path. Routed the three branch sites through a helper that emits return when the target is unnamed.