### PR TITLE
Avoid front() on an empty element expression in the validator

### DIFF
--- a/src/validator.cc
+++ b/src/validator.cc
@@ -946,8 +946,9 @@ Result Validator::CheckModule() {
 
       // Element expr.
       for (auto&& elem_expr : f->elem_segment.elem_exprs) {
-        result_ |= validator_.BeginInitExpr(elem_expr.front().loc,
-                                            f->elem_segment.elem_type);
+        const Location& loc =
+            elem_expr.empty() ? field.loc : elem_expr.front().loc;
+        result_ |= validator_.BeginInitExpr(loc, f->elem_segment.elem_type);
         ExprVisitor visitor(this);
         result_ |= visitor.VisitExprList(const_cast<ExprList&>(elem_expr));
         result_ |= validator_.EndInitExpr();

--- a/test/binary/bad-elem-expr-empty.txt
+++ b/test/binary/bad-elem-expr-empty.txt
@@ -1,0 +1,14 @@
+;;; TOOL: run-gen-wasm-bad
+magic
+version
+section(ELEM) {
+  count[1]
+  flags[5]              ;; passive, element expressions
+  reftype[funcref]
+  elemcount[1]
+  end                   ;; element expression with no instructions
+}
+(;; STDERR ;;;
+out/test/binary/bad-elem-expr-empty/bad-elem-expr-empty.wasm:000000c: error: type mismatch in initializer expression, expected [funcref] but got []
+out/test/binary/bad-elem-expr-empty/bad-elem-expr-empty.wasm:000000c: error: type mismatch in initializer expression, expected [funcref] but got []
+;;; STDERR ;;)


### PR DESCRIPTION
the validator picks each element expression's diagnostic location with elem_expr.front().loc, which dereferences a null list head when the element expression is empty (an init expr that is only the trailing end byte, which the binary reader accepts), so fall back to the segment location and let the existing constant-expression check reject it with the same type-mismatch error already produced for an empty global or data init expr; reachable from untrusted .wasm via wasm-validate, wasm2wat and wasm-decompile, which all validate by default.