### PR TITLE
Avoid front() on empty element expression in ElemSegment::GetFlags

### DIFF
--- a/src/ir.cc
+++ b/src/ir.cc
@@ -734,7 +734,8 @@ uint8_t ElemSegment::GetFlags(const Module* module,
         elem_type == Type::FuncRef &&
         std::all_of(elem_exprs.begin(), elem_exprs.end(),
                     [](const ExprList& elem_expr) {
-                      return elem_expr.front().type() == ExprType::RefFunc;
+                      return elem_expr.size() == 1 &&
+                             elem_expr.front().type() == ExprType::RefFunc;
                     });
 
     if (!all_ref_func) {

--- a/test/binary/elem-expr-empty-nocheck.txt
+++ b/test/binary/elem-expr-empty-nocheck.txt
@@ -1,0 +1,14 @@
+;;; TOOL: run-gen-wasm-nocheck
+magic
+version
+section(ELEM) {
+  count[1]
+  flags[5]
+  funcref
+  count[1]
+  end
+}
+(;; STDOUT ;;;
+(module
+  (elem (;0;) funcref))
+;;; STDOUT ;;)

--- a/test/run-tests.py
+++ b/test/run-tests.py
@@ -112,6 +112,11 @@ TOOLS = {
         ('ERROR', '1'),
         ('VERBOSE-ARGS', ['--print-cmd', '-v']),
     ],
+    'run-gen-wasm-nocheck': [
+        ('RUN', '%(gen_wasm_py)s %(in_file)s -o %(temp_file)s.wasm'),
+        ('RUN', '%(wasm2wat)s --no-check %(temp_file)s.wasm'),
+        ('VERBOSE-ARGS', ['--print-cmd', '-v']),
+    ],
     'run-gen-wasm-interp': [
         ('RUN', '%(gen_wasm_py)s %(in_file)s -o %(temp_file)s.wasm'),
         ('RUN', '%(wasm-interp)s --run-all-exports %(temp_file)s.wasm'),


### PR DESCRIPTION
Turned up running `wasm2wat --no-check` over hand-built binaries in a debug build.

The input is a module with one element segment holding a single empty element expression (the init expr is just the `end` byte):

    Assertion failed: (!empty()), function front, file intrusive-list.h, line 394.
    frame #4: wabt::intrusive_list<wabt::Expr>::front() const at intrusive-list.h:394
    frame #5: wabt::ElemSegment::GetFlags(...) const at ir.cc
    frame #6: wabt::WatWriter::WriteElemSegment(...) at wat-writer.cc:1605

The binary reader accepts an empty element expression, so `elem_exprs` can hold an empty `ExprList`. `GetFlags` calls `front()` on each expression to spot the `ref.func` shortcut before picking the encoding, and on an empty list that reads a null head pointer. A release build reads out of bounds instead of asserting. The flag helper is shared by the wat and binary writers, and `--no-check` skips validation, so nothing rejects the segment earlier.

`NameResolver::VisitElemSegment` already guards the same read with `elem_expr.size() == 1`. Used the same check here. A `ref.func` element expression is always one instruction, so output for valid modules does not change.

Regression test added under test/binary.