### PR TITLE
[wasm2c] Write float constants independent of the host locale

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -713,6 +713,7 @@ if (BUILD_TESTS)
   # wabt-unittests
   set(UNITTESTS_SRCS
     src/test-binary-reader.cc
+    src/test-c-writer.cc
     src/test-interp.cc
     src/test-intrusive-list.cc
     src/test-literal.cc

--- a/src/c-writer.cc
+++ b/src/c-writer.cc
@@ -18,6 +18,8 @@
 
 #include <cctype>
 #include <cinttypes>
+#include <clocale>
+#include <cstring>
 #include <iterator>
 #include <limits>
 #include <map>
@@ -765,6 +767,28 @@ static char internal_toupper(uint8_t ch) {
   return (ch >= 'a' && ch <= 'z') ? (ch - 'a' + 'A') : ch;
 }
 
+// printf-family conversions render the radix character according to the
+// current LC_NUMERIC locale, but the generated C source must always use '.'.
+// Rewrite the locale's radix back to '.' so the emitted float constants don't
+// depend on a locale the caller might have changed (e.g. de_DE, where it is
+// ',').
+static void NormalizeFloatRadix(char* buffer) {
+  const char* point = localeconv()->decimal_point;
+  if (point == nullptr || point[0] == '\0' ||
+      (point[0] == '.' && point[1] == '\0')) {
+    return;
+  }
+  char* found = strstr(buffer, point);
+  if (found == nullptr) {
+    return;
+  }
+  *found = '.';
+  size_t point_len = strlen(point);
+  if (point_len > 1) {
+    memmove(found + 1, found + point_len, strlen(found + point_len) + 1);
+  }
+}
+
 // static
 std::string CWriter::Mangle(std::string_view name, bool double_underscores) {
   /*
@@ -1318,7 +1342,10 @@ void CWriter::Write(const Const& const_) {
         // Negative zero. Special-cased so it isn't written as -0 below.
         Writef("-0.f");
       } else {
-        Writef("%.9g", Bitcast<float>(f32_bits));
+        char buf[128];
+        snprintf(buf, sizeof(buf), "%.9g", Bitcast<float>(f32_bits));
+        NormalizeFloatRadix(buf);
+        Writef("%s", buf);
       }
       break;
     }
@@ -1344,6 +1371,7 @@ void CWriter::Write(const Const& const_) {
       } else {
         char buf[128];
         snprintf(buf, sizeof(buf), "%.17g", Bitcast<double>(f64_bits));
+        NormalizeFloatRadix(buf);
         // Append .0 if sprint didn't include a decimal point or use the
         // exponent ('e') form.  This is a workaround for an MSVC parsing
         // issue: https://github.com/WebAssembly/wabt/issues/2422

--- a/src/test-c-writer.cc
+++ b/src/test-c-writer.cc
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2026 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "gtest/gtest.h"
+
+#include <clocale>
+#include <string>
+#include <vector>
+
+#include "wabt/apply-names.h"
+#include "wabt/binary-reader-ir.h"
+#include "wabt/binary-reader.h"
+#include "wabt/c-writer.h"
+#include "wabt/error.h"
+#include "wabt/generate-names.h"
+#include "wabt/ir.h"
+#include "wabt/stream.h"
+#include "wabt/validator.h"
+
+using namespace wabt;
+
+namespace {
+
+// (module
+//   (global (export "g_f64") f64 (f64.const 1.5))
+//   (global (export "g_f32") f32 (f32.const 0.5)))
+const uint8_t s_float_globals[] = {
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x06, 0x15,
+    0x02, 0x7c, 0x00, 0x44, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0xf8, 0x3f, 0x0b, 0x7d, 0x00, 0x43, 0x00, 0x00, 0x00, 0x3f,
+    0x0b, 0x07, 0x11, 0x02, 0x05, 0x67, 0x5f, 0x66, 0x36, 0x34,
+    0x03, 0x00, 0x05, 0x67, 0x5f, 0x66, 0x33, 0x32, 0x03, 0x01,
+};
+
+std::string WriteCSource(const uint8_t* data, size_t size) {
+  Errors errors;
+  Module module;
+  ReadBinaryOptions read_options;
+  EXPECT_EQ(Result::Ok,
+            ReadBinaryIr("test", data, size, read_options, &errors, &module));
+  Features features;
+  ValidateOptions validate_options(features);
+  EXPECT_EQ(Result::Ok, ValidateModule(&module, &errors, validate_options));
+  EXPECT_EQ(Result::Ok, GenerateNames(&module));
+  EXPECT_EQ(Result::Ok, ApplyNames(&module));
+
+  MemoryStream c_stream, h_stream, h_impl_stream;
+  std::vector<Stream*> c_streams{&c_stream};
+  WriteCOptions options;
+  options.module_name = "test";
+  options.features = features;
+  EXPECT_EQ(Result::Ok, WriteC(std::move(c_streams), &h_stream, &h_impl_stream,
+                               "test.h", "test-impl.h", &module, options));
+  const OutputBuffer& buf = c_stream.output_buffer();
+  return std::string(buf.data.begin(), buf.data.end());
+}
+
+}  // namespace
+
+// The generated C source must use '.' as the radix for float constants.
+// snprintf renders the radix according to the current LC_NUMERIC locale, so
+// under a locale whose decimal point is ',' wasm2c used to emit "1,5" (invalid
+// C, or silently a comma expression). Output must not depend on the host
+// locale.
+TEST(CWriter, FloatConstLocaleIndependent) {
+  std::string saved = setlocale(LC_NUMERIC, nullptr);
+
+  const char* comma_locales[] = {"de_DE.UTF-8", "de_DE.utf8", "de_DE",
+                                 "fr_FR.UTF-8", "nl_NL.UTF-8"};
+  bool have_comma_locale = false;
+  for (const char* loc : comma_locales) {
+    if (setlocale(LC_NUMERIC, loc) && *localeconv()->decimal_point == ',') {
+      have_comma_locale = true;
+      break;
+    }
+  }
+  if (!have_comma_locale) {
+    setlocale(LC_NUMERIC, saved.c_str());
+    GTEST_SKIP() << "no comma-decimal locale installed";
+  }
+
+  std::string source = WriteCSource(s_float_globals, sizeof(s_float_globals));
+
+  setlocale(LC_NUMERIC, saved.c_str());
+
+  EXPECT_NE(source.find("1.5"), std::string::npos);
+  EXPECT_NE(source.find("0.5"), std::string::npos);
+  EXPECT_EQ(source.find("1,5"), std::string::npos);
+  EXPECT_EQ(source.find("0,5"), std::string::npos);
+}


### PR DESCRIPTION
Noticed while running wasm2c with the embedder's locale set to de_DE, where LC_NUMERIC makes the radix ','. The constant writer produced:

    instance->w2c_g0 = 1,5;

snprintf("%.9g"/"%.17g") in CWriter::Write(const Const&) takes the radix from the active locale, but the emitted C must use '.'. The comma is either a compile error or, in argument/initialiser position, a comma expression that quietly drops the fractional part. The f64 path is worse: the following strchr(buf, '.') no longer finds the radix, so it also appends ".0" and writes 1,5.0.

The .wat writer sidesteps this by emitting hex floats, and the parsing direction was already made locale-independent in literal.cc. This is the output side. The fix formats as before, then rewrites the locale's radix back to '.', so the generated C is byte-identical regardless of the locale the caller set. Output under the C locale is unchanged.

Added a unit test that writes a module with f32/f64 constants under a comma locale and checks the result uses '.'. It skips when no comma locale is installed, matching the existing parser test.
