### PR TITLE
Update from C++17 to C++20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ project(WABT LANGUAGES C CXX VERSION 1.0.41)
 
 include(GNUInstallDirs)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
@@ -684,6 +684,13 @@ if (BUILD_TESTS)
 
     if (COMPILER_IS_GNU)
       target_compile_options(gtest PRIVATE "-Wno-maybe-uninitialized")
+    endif ()
+    if (EMSCRIPTEN OR APPLE)
+      # Only need for libc++-based platforms. Remove this once a new version
+      # of gtest is released:
+      # See https://github.com/google/googletest/issues/5004
+      target_compile_options(gtest PUBLIC "-Wno-conversion")
+      target_compile_options(gtest_main PRIVATE "-Wno-conversion")
     endif ()
   endif ()
 

--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -2605,7 +2605,7 @@ Result BinaryReader::ReadCustomSection(Index section_index,
     CHECK_RESULT(ReadDylink0Section(section_size));
   } else if (section_name == WABT_BINARY_SECTION_DYLINK) {
     CHECK_RESULT(ReadDylinkSection(section_size));
-  } else if (section_name.rfind(WABT_BINARY_SECTION_RELOC, 0) == 0) {
+  } else if (section_name.starts_with(WABT_BINARY_SECTION_RELOC)) {
     // Reloc sections always begin with "reloc."
     CHECK_RESULT(ReadRelocSection(section_size));
   } else if (section_name == WABT_BINARY_SECTION_TARGET_FEATURES) {
@@ -2613,7 +2613,7 @@ Result BinaryReader::ReadCustomSection(Index section_index,
   } else if (section_name == WABT_BINARY_SECTION_LINKING) {
     CHECK_RESULT(ReadLinkingSection(section_size));
   } else if (options_.features.code_metadata_enabled() &&
-             section_name.find(WABT_BINARY_SECTION_CODE_METADATA) == 0) {
+             section_name.starts_with(WABT_BINARY_SECTION_CODE_METADATA)) {
     std::string_view metadata_name = section_name;
     metadata_name.remove_prefix(sizeof(WABT_BINARY_SECTION_CODE_METADATA) - 1);
     CHECK_RESULT(ReadCodeMetadataSection(metadata_name, section_size));

--- a/src/binary-writer.cc
+++ b/src/binary-writer.cc
@@ -239,7 +239,7 @@ class SymbolTable {
   std::set<std::string_view> seen_names_;
 
   Result EnsureUnique(const std::string_view& name) {
-    if (seen_names_.count(name)) {
+    if (seen_names_.contains(name)) {
       fprintf(stderr,
               "error: duplicate symbol when writing relocatable "
               "binary: %s\n",
@@ -330,7 +330,7 @@ class SymbolTable {
     for (size_t i = 0; i < module->funcs.size(); ++i) {
       const Func* func = module->funcs[i];
       bool imported = i < module->num_func_imports;
-      bool exported = exported_funcs.count(i);
+      bool exported = exported_funcs.contains(i);
       CHECK_RESULT(AddSymbol(&functions_, func->name, imported, exported,
                              Symbol::Function{Index(i)}));
     }
@@ -338,7 +338,7 @@ class SymbolTable {
     for (size_t i = 0; i < module->tables.size(); ++i) {
       const Table* table = module->tables[i];
       bool imported = i < module->num_table_imports;
-      bool exported = exported_tables.count(i);
+      bool exported = exported_tables.contains(i);
       CHECK_RESULT(AddSymbol(&tables_, table->name, imported, exported,
                              Symbol::Table{Index(i)}));
     }
@@ -346,7 +346,7 @@ class SymbolTable {
     for (size_t i = 0; i < module->globals.size(); ++i) {
       const Global* global = module->globals[i];
       bool imported = i < module->num_global_imports;
-      bool exported = exported_globals.count(i);
+      bool exported = exported_globals.contains(i);
       CHECK_RESULT(AddSymbol(&globals_, global->name, imported, exported,
                              Symbol::Global{Index(i)}));
     }
@@ -1810,10 +1810,10 @@ Result BinaryWriter::WriteModule() {
     // we don't want to double-write.
     if ((custom.name == WABT_BINARY_SECTION_NAME &&
          options_.write_debug_names) ||
-        (custom.name.rfind(WABT_BINARY_SECTION_RELOC) == 0 &&
+        (custom.name.starts_with(WABT_BINARY_SECTION_RELOC) &&
          options_.relocatable) ||
         (custom.name == WABT_BINARY_SECTION_LINKING && options_.relocatable) ||
-        (custom.name.find(WABT_BINARY_SECTION_CODE_METADATA) == 0 &&
+        (custom.name.starts_with(WABT_BINARY_SECTION_CODE_METADATA) &&
          options_.features.code_metadata_enabled())) {
       continue;
     }

--- a/src/c-writer.cc
+++ b/src/c-writer.cc
@@ -892,12 +892,12 @@ void CWriter::ClaimName(SymbolSet& set,
 std::string CWriter::FindUniqueName(SymbolSet& set,
                                     std::string_view proposed_name) const {
   std::string unique{proposed_name};
-  if (set.find(unique) != set.end()) {
+  if (set.contains(unique)) {
     std::string base = unique + "_";
     size_t count = 0;
     do {
       unique = base + std::to_string(count++);
-    } while (set.find(unique) != set.end());
+    } while (set.contains(unique));
   }
   return unique;
 }
@@ -984,7 +984,7 @@ std::string CWriter::DefineGlobalScopeName(ModuleFieldType type,
 std::string CWriter::GetGlobalName(ModuleFieldType type,
                                    const std::string& name) const {
   std::string mangled = name + MangleField(type);
-  assert(global_sym_map_.count(mangled) == 1);
+  assert(global_sym_map_.contains(mangled));
   return global_sym_map_.at(mangled);
 }
 
@@ -999,7 +999,7 @@ std::string CWriter::DefineLocalScopeName(std::string_view name,
 std::string CWriter::GetLocalName(const std::string& name,
                                   bool is_label) const {
   std::string mangled = name + (is_label ? kLabelSuffix : kParamSuffix);
-  assert(local_sym_map_.count(mangled) == 1);
+  assert(local_sym_map_.contains(mangled));
   return local_sym_map_.at(mangled);
 }
 
@@ -1406,7 +1406,7 @@ static std::string GetMemoryAPIString(const Memory& memory, std::string api) {
   //
   // We don't need to do this for runtime routines; those can check the
   // wasm_rt_memory_t structure.
-  if (api.substr(0, 8) != "wasm_rt_" &&
+  if (!api.starts_with("wasm_rt_") &&
       memory.page_size == WABT_DEFAULT_PAGE_SIZE &&
       memory.page_limits.is_64 == false) {
     suffix += "_default32";
@@ -2391,7 +2391,7 @@ void CWriter::WriteFuncRefWrappers() {
   for (Index index : module_->used_func_refs) {
     assert(index < module_->funcs.size());
     const Func* func = module_->funcs[index];
-    if (unique_func_wrappers.count(func->name) == 0) {
+    if (!unique_func_wrappers.contains(func->name)) {
       WriteFuncRefWrapper(func);
       unique_func_wrappers.insert(func->name);
     }
@@ -2989,7 +2989,7 @@ void CWriter::PushFuncSection(std::string_view include_condition) {
 }
 
 bool CWriter::IsImport(const std::string& name) const {
-  return import_module_sym_map_.count(name);
+  return import_module_sym_map_.contains(name);
 }
 
 template <typename sources>
@@ -3105,7 +3105,7 @@ void CWriter::FinishFunction(size_t stack_var_section) {
   for (size_t i = 0; i < func_sections_.size(); ++i) {
     auto& [condition, stream] = func_sections_.at(i);
     std::unique_ptr<OutputBuffer> buf = stream.ReleaseOutputBuffer();
-    if (condition.empty() || func_includes_.count(condition)) {
+    if (condition.empty() || func_includes_.contains(condition)) {
       stream_->WriteData(buf->data.data(), buf->data.size());
     }
 

--- a/src/generate-names.cc
+++ b/src/generate-names.cc
@@ -156,7 +156,7 @@ void NameGenerator::GenerateAndBindName(BindingHash* bindings,
   unsigned disambiguator = 0;
   while (true) {
     GenerateName(prefix, index, disambiguator, str);
-    if (bindings->find(*str) == bindings->end()) {
+    if (!bindings->contains(*str)) {
       bindings->emplace(*str, Binding(index));
       break;
     }
@@ -182,7 +182,7 @@ void NameGenerator::MaybeUseAndBindName(BindingHash* bindings,
     unsigned disambiguator = 0;
     while (true) {
       GenerateName(name, kInvalidIndex, disambiguator, str);
-      if (bindings->find(*str) == bindings->end()) {
+      if (!bindings->contains(*str)) {
         bindings->emplace(*str, Binding(index));
         break;
       }

--- a/src/literal.cc
+++ b/src/literal.cc
@@ -137,21 +137,14 @@ class FloatWriter {
   static void WriteHex(char* out, size_t size, Uint bits);
 };
 
-// Return 1 if the non-NULL-terminated string starting with |start| and ending
-// with |end| starts with the NULL-terminated string |prefix|.
+// Return true if the non-NULL-terminated string starting with |start| and
+// ending with |end| starts with the NULL-terminated string |prefix|.
 template <typename T>
 // static
 bool FloatParser<T>::StringStartsWith(const char* start,
                                       const char* end,
                                       const char* prefix) {
-  while (start < end && *prefix) {
-    if (*start != *prefix) {
-      return false;
-    }
-    start++;
-    prefix++;
-  }
-  return *prefix == 0;
+  return std::string_view(start, end - start).starts_with(prefix);
 }
 
 // static

--- a/src/shared-validator.cc
+++ b/src/shared-validator.cc
@@ -257,7 +257,7 @@ Result SharedValidator::OnExport(const Location& loc,
                                  std::string_view name) {
   Result result = Result::Ok;
   auto name_str = std::string(name);
-  if (export_names_.find(name_str) != export_names_.end()) {
+  if (export_names_.contains(name_str)) {
     result |= PrintError(loc, "duplicate export \"" PRIstringview "\"",
                          WABT_PRINTF_STRING_VIEW_ARG(name));
   }
@@ -357,7 +357,7 @@ Result SharedValidator::OnDataSegment(const Location& loc,
 }
 
 Result SharedValidator::CheckDeclaredFunc(Var func_var) {
-  if (declared_funcs_.count(func_var.index()) == 0) {
+  if (!declared_funcs_.contains(func_var.index())) {
     return PrintError(func_var.loc,
                       "function %" PRIindex
                       " is not declared in any elem sections",

--- a/src/test-binary-reader.cc
+++ b/src/test-binary-reader.cc
@@ -69,7 +69,7 @@ TEST(BinaryReader, DisabledOpcodes) {
     // This relies on the binary reader checking whether the opcode is allowed
     // before reading any further data needed by the instruction.
     const std::string& message = reader.first_error.message;
-    EXPECT_EQ(0u, message.find("unexpected opcode"))
+    EXPECT_TRUE(message.starts_with("unexpected opcode"))
         << "Got error message: " << message;
   }
 }

--- a/src/tools/wasm-strip.cc
+++ b/src/tools/wasm-strip.cc
@@ -99,11 +99,11 @@ class BinaryReaderStrip : public BinaryReaderNop {
   Result BeginCustomSection(Index section_index,
                             Offset size,
                             std::string_view section_name) override {
-    if (sections_to_remove_.count(section_name) > 0) {
+    if (sections_to_remove_.contains(section_name)) {
       return Result::Ok;
     }
 
-    if (sections_to_keep_.count(section_name) > 0 ||
+    if (sections_to_keep_.contains(section_name) ||
         !sections_to_remove_.empty()) {
       stream_.WriteU8Enum(BinarySection::Custom, "section code");
       WriteU32Leb128(&stream_, size, "section size");

--- a/src/wast-parser.cc
+++ b/src/wast-parser.cc
@@ -595,7 +595,7 @@ TokenType WastParser::Peek(size_t n) {
         continue;
       }
       if ((options_->features.code_metadata_enabled() &&
-           cur.text().find("metadata.code.") == 0) ||
+           cur.text().starts_with("metadata.code.")) ||
           cur.text() == "custom") {
         tokens_.push_back(cur);
         continue;
@@ -2311,7 +2311,7 @@ Result WastParser::ParseCodeMetadataAnnotation(ExprList* exprs) {
   WABT_TRACE(ParseCodeMetadataAnnotation);
   Token tk = Consume();
   std::string_view name = tk.text();
-  if (name.find("metadata.code.") != 0) {
+  if (!name.starts_with("metadata.code.")) {
     // Not a code metadata annotation. This can be reached when Peek admits a
     // (@custom ...) annotation (only meaningful at module scope) into an
     // instruction list. Discard it like any other unrecognised annotation


### PR DESCRIPTION
Binaryen did this a while back in
https://github.com/WebAssembly/binaryen/pull/8218.

There we a couple of issue related to building on macOS 13.2.1 but I don't think we need to support building on such old versions of macOS here.  We still support deploying to macOS 10.14 via CMAKE_OSX_DEPLOYMENT_TARGET.

Use std::string::starts_with and std::string_view::starts_with in various places now that C++20 is available.

Also, adopt `.contains()` for std::map, std::set, and their unordered counterparts to replace verbose find/end and count checks.