### PR TITLE
Add -Wno-gnu-folding-constant when compiling c api examples

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -753,7 +753,7 @@ if (BUILD_TESTS)
     if (COMPILER_IS_MSVC)
       set_target_properties(${EXENAME} PROPERTIES COMPILE_FLAGS "-wd4311")
     else ()
-      set_target_properties(${EXENAME} PROPERTIES COMPILE_FLAGS "-std=gnu11 -Wno-pointer-to-int-cast")
+      set_target_properties(${EXENAME} PROPERTIES COMPILE_FLAGS "-std=gnu11 -Wno-gnu-folding-constant -Wno-pointer-to-int-cast")
     endif ()
 
     target_link_libraries(${EXENAME} wasm Threads::Threads)


### PR DESCRIPTION
I'm not sure why this starting showing up as a failure on the macos-latest build.  I'm guess it was some kind of system updated that give us a newer version of clang.

I'm also not sure why `-std=gnu11` wasn't enough to enable this extension.