### PR TITLE
[cpp20] Modernize binary reader and writer APIs to use std::span

### DIFF
--- a/fuzzers/read_binary_interp_fuzzer.cc
+++ b/fuzzers/read_binary_interp_fuzzer.cc
@@ -40,7 +40,6 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   // validator's counts out of step).
   wabt::ReadBinaryOptions options(features, nullptr, false, true, false);
   std::vector<uint8_t> text = data_provider.ConsumeRemainingBytes<uint8_t>();
-  ReadBinaryInterp("<fuzzer>", text.data(), text.size(), options, &errors,
-                   &module);
+  ReadBinaryInterp("<fuzzer>", text, options, &errors, &module);
   return 0;
 }

--- a/fuzzers/read_binary_ir_fuzzer.cc
+++ b/fuzzers/read_binary_ir_fuzzer.cc
@@ -34,6 +34,6 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   // Add only feature related options, but no logging, stop_on_first_error, etc.
   wabt::ReadBinaryOptions options(features, nullptr, false, false, false);
   std::vector<uint8_t> text = data_provider.ConsumeRemainingBytes<uint8_t>();
-  ReadBinaryIr("", text.data(), text.size(), options, &errors, &module);
+  ReadBinaryIr("", text, options, &errors, &module);
   return 0;
 }

--- a/fuzzers/wasm2wat_fuzzer.cc
+++ b/fuzzers/wasm2wat_fuzzer.cc
@@ -21,6 +21,6 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   wabt::ReadBinaryOptions options;
   wabt::Errors errors;
   wabt::Module module;
-  wabt::ReadBinaryIr("dummy filename", data, size, options, &errors, &module);
+  wabt::ReadBinaryIr("dummy filename", {data, size}, options, &errors, &module);
   return 0;
 }

--- a/fuzzers/wasm_objdump_fuzzer.cc
+++ b/fuzzers/wasm_objdump_fuzzer.cc
@@ -24,19 +24,19 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   objdump_options.log_stream = nullptr;
 
   objdump_options.mode = wabt::ObjdumpMode::Prepass;
-  wabt::ReadBinaryObjdump(data, size, &objdump_options, &state);
+  wabt::ReadBinaryObjdump({data, size}, &objdump_options, &state);
 
   objdump_options.mode = wabt::ObjdumpMode::Headers;
-  wabt::ReadBinaryObjdump(data, size, &objdump_options, &state);
+  wabt::ReadBinaryObjdump({data, size}, &objdump_options, &state);
 
   objdump_options.mode = wabt::ObjdumpMode::Details;
-  wabt::ReadBinaryObjdump(data, size, &objdump_options, &state);
+  wabt::ReadBinaryObjdump({data, size}, &objdump_options, &state);
 
   objdump_options.mode = wabt::ObjdumpMode::Disassemble;
-  wabt::ReadBinaryObjdump(data, size, &objdump_options, &state);
+  wabt::ReadBinaryObjdump({data, size}, &objdump_options, &state);
 
   objdump_options.mode = wabt::ObjdumpMode::RawData;
-  wabt::ReadBinaryObjdump(data, size, &objdump_options, &state);
+  wabt::ReadBinaryObjdump({data, size}, &objdump_options, &state);
 
   return 0;
 }

--- a/include/wabt/base-types.h
+++ b/include/wabt/base-types.h
@@ -19,12 +19,14 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <span>
 
 namespace wabt {
 
 using Index = uint32_t;    // An index into one of the many index spaces.
 using Address = uint64_t;  // An address or size in linear memory.
 using Offset = size_t;     // An offset into a host's file or memory buffer.
+using ByteSpan = std::span<const uint8_t>;
 
 constexpr Address kInvalidAddress = ~0;
 constexpr Index kInvalidIndex = ~0;

--- a/include/wabt/binary-reader-ir.h
+++ b/include/wabt/binary-reader-ir.h
@@ -26,7 +26,14 @@ struct Module;
 struct ReadBinaryOptions;
 
 Result ReadBinaryIr(const char* filename,
-                    const void* data,
+                    ByteSpan data,
+                    const ReadBinaryOptions& options,
+                    Errors*,
+                    Module* out_module);
+
+// TODO(sbc): Remove this old API. Use the ByteSpan overload instead.
+Result ReadBinaryIr(const char* filename,
+                    const uint8_t* data,
                     size_t size,
                     const ReadBinaryOptions& options,
                     Errors*,

--- a/include/wabt/binary-reader-logging.h
+++ b/include/wabt/binary-reader-logging.h
@@ -303,9 +303,7 @@ class BinaryReaderLogging : public BinaryReaderDelegate {
                           uint8_t flags) override;
   Result BeginDataSegmentInitExpr(Index index) override;
   Result EndDataSegmentInitExpr(Index index) override;
-  Result OnDataSegmentData(Index index,
-                           const void* data,
-                           Address size) override;
+  Result OnDataSegmentData(Index index, ByteSpan data) override;
   Result EndDataSegment(Index index) override;
   Result EndDataSection() override;
 
@@ -365,9 +363,7 @@ class BinaryReaderLogging : public BinaryReaderDelegate {
   Result EndDylinkSection() override;
 
   Result BeginGenericCustomSection(Offset size) override;
-  Result OnGenericCustomSection(std::string_view name,
-                                const void* data,
-                                Offset size) override;
+  Result OnGenericCustomSection(std::string_view name, ByteSpan data) override;
   Result EndGenericCustomSection() override;
 
   Result BeginTargetFeaturesSection(Offset size) override;
@@ -425,7 +421,7 @@ class BinaryReaderLogging : public BinaryReaderDelegate {
   Result BeginCodeMetadataSection(std::string_view name, Offset size) override;
   Result OnCodeMetadataFuncCount(Index count) override;
   Result OnCodeMetadataCount(Index function_index, Index count) override;
-  Result OnCodeMetadata(Offset offset, const void* data, Address size) override;
+  Result OnCodeMetadata(Offset offset, ByteSpan data) override;
   Result EndCodeMetadataSection() override;
 
  private:

--- a/include/wabt/binary-reader-nop.h
+++ b/include/wabt/binary-reader-nop.h
@@ -409,9 +409,7 @@ class BinaryReaderNop : public BinaryReaderDelegate {
   }
   Result BeginDataSegmentInitExpr(Index index) override { return Result::Ok; }
   Result EndDataSegmentInitExpr(Index index) override { return Result::Ok; }
-  Result OnDataSegmentData(Index index,
-                           const void* data,
-                           Address size) override {
+  Result OnDataSegmentData(Index index, ByteSpan data) override {
     return Result::Ok;
   }
   Result EndDataSegment(Index index) override { return Result::Ok; }
@@ -500,9 +498,7 @@ class BinaryReaderNop : public BinaryReaderDelegate {
   Result OnCodeMetadataCount(Index function_index, Index count) override {
     return Result::Ok;
   }
-  Result OnCodeMetadata(Offset offset,
-                        const void* data,
-                        Address size) override {
+  Result OnCodeMetadata(Offset offset, ByteSpan data) override {
     return Result::Ok;
   }
   Result EndCodeMetadataSection() override { return Result::Ok; }
@@ -541,9 +537,7 @@ class BinaryReaderNop : public BinaryReaderDelegate {
 
   /* Generic custom section */
   Result BeginGenericCustomSection(Offset size) override { return Result::Ok; }
-  Result OnGenericCustomSection(std::string_view name,
-                                const void* data,
-                                Offset size) override {
+  Result OnGenericCustomSection(std::string_view name, ByteSpan data) override {
     return Result::Ok;
   };
   Result EndGenericCustomSection() override { return Result::Ok; }

--- a/include/wabt/binary-reader-objdump.h
+++ b/include/wabt/binary-reader-objdump.h
@@ -89,6 +89,11 @@ struct ObjdumpState {
   std::map<Index, Index> function_types;
 };
 
+Result ReadBinaryObjdump(ByteSpan data,
+                         ObjdumpOptions* options,
+                         ObjdumpState* state);
+
+// TODO(sbc): Remove this old API. Use the ByteSpan overload instead.
 Result ReadBinaryObjdump(const uint8_t* data,
                          size_t size,
                          ObjdumpOptions* options,

--- a/include/wabt/binary-reader-stats.h
+++ b/include/wabt/binary-reader-stats.h
@@ -86,8 +86,7 @@ bool operator>=(const OpcodeInfo&, const OpcodeInfo&);
 
 using OpcodeInfoCounts = std::map<OpcodeInfo, size_t>;
 
-Result ReadBinaryOpcnt(const void* data,
-                       size_t size,
+Result ReadBinaryOpcnt(ByteSpan data,
                        const ReadBinaryOptions& options,
                        OpcodeInfoCounts* opcode_counts);
 

--- a/include/wabt/binary-reader.h
+++ b/include/wabt/binary-reader.h
@@ -74,11 +74,9 @@ enum class TableInitExprStatus {
 class BinaryReaderDelegate {
  public:
   struct State {
-    State(const uint8_t* data, Offset size)
-        : data(data), size(size), offset(0) {}
+    explicit State(ByteSpan data) : data(data), offset(0) {}
 
-    const uint8_t* data;
-    Offset size;
+    ByteSpan data;
     Offset offset;
   };
 
@@ -382,9 +380,7 @@ class BinaryReaderDelegate {
                                   uint8_t flags) = 0;
   virtual Result BeginDataSegmentInitExpr(Index index) = 0;
   virtual Result EndDataSegmentInitExpr(Index index) = 0;
-  virtual Result OnDataSegmentData(Index index,
-                                   const void* data,
-                                   Address size) = 0;
+  virtual Result OnDataSegmentData(Index index, ByteSpan data) = 0;
   virtual Result EndDataSegment(Index index) = 0;
   virtual Result EndDataSection() = 0;
 
@@ -457,8 +453,7 @@ class BinaryReaderDelegate {
   /* Generic custom section */
   virtual Result BeginGenericCustomSection(Offset size) = 0;
   virtual Result OnGenericCustomSection(std::string_view name,
-                                        const void* data,
-                                        Offset size) = 0;
+                                        ByteSpan data) = 0;
   virtual Result EndGenericCustomSection() = 0;
 
   /* Linking section */
@@ -514,16 +509,13 @@ class BinaryReaderDelegate {
                                           Offset size) = 0;
   virtual Result OnCodeMetadataFuncCount(Index count) = 0;
   virtual Result OnCodeMetadataCount(Index function_index, Index count) = 0;
-  virtual Result OnCodeMetadata(Offset offset,
-                                const void* data,
-                                Address size) = 0;
+  virtual Result OnCodeMetadata(Offset offset, ByteSpan data) = 0;
   virtual Result EndCodeMetadataSection() = 0;
 
   const State* state = nullptr;
 };
 
-Result ReadBinary(const void* data,
-                  size_t size,
+Result ReadBinary(ByteSpan data,
                   BinaryReaderDelegate* reader,
                   const ReadBinaryOptions& options);
 

--- a/include/wabt/interp/binary-reader-interp.h
+++ b/include/wabt/interp/binary-reader-interp.h
@@ -28,7 +28,14 @@ struct ReadBinaryOptions;
 namespace interp {
 
 Result ReadBinaryInterp(std::string_view filename,
-                        const void* data,
+                        ByteSpan data,
+                        const ReadBinaryOptions& options,
+                        Errors*,
+                        ModuleDesc* out_module);
+
+// TODO(sbc): Remove this old API. Use the ByteSpan overload instead.
+Result ReadBinaryInterp(std::string_view filename,
+                        const uint8_t* data,
                         size_t size,
                         const ReadBinaryOptions& options,
                         Errors*,

--- a/include/wabt/stream.h
+++ b/include/wabt/stream.h
@@ -19,6 +19,7 @@
 
 #include <cassert>
 #include <memory>
+#include <span>
 #include <vector>
 
 #include "wabt/common.h"
@@ -55,23 +56,32 @@ class Stream {
   void ClearOffset() { offset_ = 0; }
   void AddOffset(ssize_t delta);
 
-  void WriteData(const void* src,
-                 size_t size,
+  void WriteData(ByteSpan src,
                  const char* desc = nullptr,
                  PrintChars = PrintChars::No);
 
+  // TODO(sbc): Remove this old API. Use the ByteSpan overload instead.
+  // Convenience overload for raw pointers.
+  void WriteData(const void* src,
+                 size_t size,
+                 const char* desc = nullptr,
+                 PrintChars print_chars = PrintChars::No) {
+    WriteData({static_cast<const uint8_t*>(src), size}, desc, print_chars);
+  }
+
   template <typename T>
-  void WriteData(const std::vector<T> src,
+  void WriteData(std::span<const T> src,
                  const char* desc,
                  PrintChars print_chars = PrintChars::No) {
     if (!src.empty()) {
-      WriteData(src.data(), src.size() * sizeof(T), desc, print_chars);
+      WriteData(ByteSpan(reinterpret_cast<const uint8_t*>(src.data()),
+                         src.size_bytes()),
+                desc, print_chars);
     }
   }
 
   void WriteDataAt(size_t offset,
-                   const void* src,
-                   size_t size,
+                   ByteSpan data,
                    const char* desc = nullptr,
                    PrintChars = PrintChars::No);
 
@@ -112,8 +122,7 @@ class Stream {
   }
 
   // Dump memory as text, similar to the xxd format.
-  void WriteMemoryDump(const void* start,
-                       size_t size,
+  void WriteMemoryDump(ByteSpan data,
                        size_t offset = 0,
                        PrintChars print_chars = PrintChars::No,
                        const char* prefix = nullptr,
@@ -130,9 +139,7 @@ class Stream {
   virtual void Flush() {}
 
  protected:
-  virtual Result WriteDataImpl(size_t offset,
-                               const void* data,
-                               size_t size) = 0;
+  virtual Result WriteDataImpl(size_t offset, ByteSpan data) = 0;
   virtual Result MoveDataImpl(size_t dst_offset,
                               size_t src_offset,
                               size_t size) = 0;
@@ -185,7 +192,7 @@ class MemoryStream : public Stream {
   }
 
  protected:
-  Result WriteDataImpl(size_t offset, const void* data, size_t size) override;
+  Result WriteDataImpl(size_t offset, ByteSpan data) override;
   Result MoveDataImpl(size_t dst_offset,
                       size_t src_offset,
                       size_t size) override;
@@ -212,7 +219,7 @@ class FileStream : public Stream {
   void Flush() override;
 
  protected:
-  Result WriteDataImpl(size_t offset, const void* data, size_t size) override;
+  Result WriteDataImpl(size_t offset, ByteSpan data) override;
   Result MoveDataImpl(size_t dst_offset,
                       size_t src_offset,
                       size_t size) override;

--- a/src/binary-reader-ir.cc
+++ b/src/binary-reader-ir.cc
@@ -312,9 +312,7 @@ class BinaryReaderIR : public BinaryReaderNop {
                           uint8_t flags) override;
   Result BeginDataSegmentInitExpr(Index index) override;
   Result EndDataSegmentInitExpr(Index index) override;
-  Result OnDataSegmentData(Index index,
-                           const void* data,
-                           Address size) override;
+  Result OnDataSegmentData(Index index, ByteSpan data) override;
 
   Result OnModuleName(std::string_view module_name) override;
   Result OnFunctionNamesCount(Index num_functions) override;
@@ -328,9 +326,7 @@ class BinaryReaderIR : public BinaryReaderNop {
                      Index index,
                      std::string_view name) override;
 
-  Result OnGenericCustomSection(std::string_view name,
-                                const void* data,
-                                Offset size) override;
+  Result OnGenericCustomSection(std::string_view name, ByteSpan data) override;
 
   Result BeginTagSection(Offset size) override { return Result::Ok; }
   Result OnTagCount(Index count) override { return Result::Ok; }
@@ -358,7 +354,7 @@ class BinaryReaderIR : public BinaryReaderNop {
   Result BeginCodeMetadataSection(std::string_view name, Offset size) override;
   Result OnCodeMetadataFuncCount(Index count) override;
   Result OnCodeMetadataCount(Index function_index, Index count) override;
-  Result OnCodeMetadata(Offset offset, const void* data, Address size) override;
+  Result OnCodeMetadata(Offset offset, ByteSpan data) override;
 
   Result OnTagSymbol(Index index,
                      uint32_t flags,
@@ -1521,15 +1517,10 @@ Result BinaryReaderIR::EndDataSegmentInitExpr(Index index) {
   return EndInitExpr();
 }
 
-Result BinaryReaderIR::OnDataSegmentData(Index index,
-                                         const void* data,
-                                         Address size) {
+Result BinaryReaderIR::OnDataSegmentData(Index index, ByteSpan data) {
   assert(index == module_->data_segments.size() - 1);
   DataSegment* segment = module_->data_segments[index];
-  segment->data.resize(size);
-  if (size > 0) {
-    memcpy(segment->data.data(), data, size);
-  }
+  segment->data.assign(data.begin(), data.end());
   return Result::Ok;
 }
 
@@ -1756,11 +1747,8 @@ Result BinaryReaderIR::OnCodeMetadataCount(Index function_index, Index count) {
   return Result::Error;
 }
 
-Result BinaryReaderIR::OnCodeMetadata(Offset offset,
-                                      const void* data,
-                                      Address size) {
-  std::vector<uint8_t> data_(static_cast<const uint8_t*>(data),
-                             static_cast<const uint8_t*>(data) + size);
+Result BinaryReaderIR::OnCodeMetadata(Offset offset, ByteSpan data) {
+  std::vector<uint8_t> data_(data.begin(), data.end());
   auto meta = std::make_unique<CodeMetadataExpr>(current_metadata_name_,
                                                  std::move(data_));
   meta->loc.offset = offset;
@@ -1883,13 +1871,9 @@ Result BinaryReaderIR::OnTableSymbol(Index index,
 }
 
 Result BinaryReaderIR::OnGenericCustomSection(std::string_view name,
-                                              const void* data,
-                                              Offset size) {
+                                              ByteSpan data) {
   Custom custom = Custom(GetLocation(), name);
-  custom.data.resize(size);
-  if (size > 0) {
-    memcpy(custom.data.data(), data, size);
-  }
+  custom.data.assign(data.begin(), data.end());
   module_->customs.push_back(std::move(custom));
   return Result::Ok;
 }
@@ -1897,13 +1881,23 @@ Result BinaryReaderIR::OnGenericCustomSection(std::string_view name,
 }  // end anonymous namespace
 
 Result ReadBinaryIr(const char* filename,
-                    const void* data,
-                    size_t size,
+                    ByteSpan data,
                     const ReadBinaryOptions& options,
                     Errors* errors,
                     Module* out_module) {
   BinaryReaderIR reader(out_module, filename, errors);
-  return ReadBinary(data, size, &reader, options);
+  return ReadBinary(data, &reader, options);
+}
+
+// TODO(sbc): Remove this old API. Use the ByteSpan overload instead.
+Result ReadBinaryIr(const char* filename,
+                    const uint8_t* data,
+                    size_t size,
+                    const ReadBinaryOptions& options,
+                    Errors* errors,
+                    Module* out_module) {
+  return ReadBinaryIr(filename, ByteSpan(data, size), options, errors,
+                      out_module);
 }
 
 }  // namespace wabt

--- a/src/binary-reader-logging.cc
+++ b/src/binary-reader-logging.cc
@@ -464,12 +464,10 @@ Result BinaryReaderLogging::OnElemSegmentElemType(Index index, Type elem_type) {
   return reader_->OnElemSegmentElemType(index, elem_type);
 }
 
-Result BinaryReaderLogging::OnDataSegmentData(Index index,
-                                              const void* data,
-                                              Address size) {
+Result BinaryReaderLogging::OnDataSegmentData(Index index, ByteSpan data) {
   LOGF("OnDataSegmentData(index:%" PRIindex ", size:%" PRIaddress ")\n", index,
-       size);
-  return reader_->OnDataSegmentData(index, data, size);
+       static_cast<Address>(data.size()));
+  return reader_->OnDataSegmentData(index, data);
 }
 
 Result BinaryReaderLogging::OnModuleNameSubsection(Index index,
@@ -692,22 +690,20 @@ Result BinaryReaderLogging::BeginCodeMetadataSection(std::string_view name,
   Indent();
   return reader_->BeginCodeMetadataSection(name, size);
 }
-Result BinaryReaderLogging::OnCodeMetadata(Offset code_offset,
-                                           const void* data,
-                                           Address size) {
-  std::string_view content(static_cast<const char*>(data), size);
+Result BinaryReaderLogging::OnCodeMetadata(Offset code_offset, ByteSpan data) {
+  std::string_view content(reinterpret_cast<const char*>(data.data()),
+                           data.size());
   LOGF("OnCodeMetadata(offset: %" PRIzd ", data: \"" PRIstringview "\")\n",
        code_offset, WABT_PRINTF_STRING_VIEW_ARG(content));
-  return reader_->OnCodeMetadata(code_offset, data, size);
+  return reader_->OnCodeMetadata(code_offset, data);
 }
 
 Result BinaryReaderLogging::OnGenericCustomSection(std::string_view name,
-                                                   const void* data,
-                                                   Offset size) {
+                                                   ByteSpan data) {
   LOGF("OnGenericCustomSection(name: \"" PRIstringview "\", size: %" PRIzd
        ")\n",
-       WABT_PRINTF_STRING_VIEW_ARG(name), size);
-  return reader_->OnGenericCustomSection(name, data, size);
+       WABT_PRINTF_STRING_VIEW_ARG(name), data.size());
+  return reader_->OnGenericCustomSection(name, data);
 }
 
 #define DEFINE_BEGIN(name)                        \

--- a/src/binary-reader-objdump.cc
+++ b/src/binary-reader-objdump.cc
@@ -38,8 +38,7 @@ namespace {
 
 class BinaryReaderObjdumpBase : public BinaryReaderNop {
  public:
-  BinaryReaderObjdumpBase(const uint8_t* data,
-                          size_t size,
+  BinaryReaderObjdumpBase(ByteSpan data,
                           ObjdumpOptions* options,
                           ObjdumpState* state);
 
@@ -71,8 +70,7 @@ class BinaryReaderObjdumpBase : public BinaryReaderNop {
 
   ObjdumpOptions* options_;
   ObjdumpState* objdump_state_;
-  const uint8_t* data_;
-  size_t size_;
+  ByteSpan data_;
   bool print_details_ = false;
   bool in_function_body = false;
   BinarySection reloc_section_ = BinarySection::Invalid;
@@ -86,14 +84,12 @@ class BinaryReaderObjdumpBase : public BinaryReaderNop {
   std::unique_ptr<FileStream> err_stream_;
 };
 
-BinaryReaderObjdumpBase::BinaryReaderObjdumpBase(const uint8_t* data,
-                                                 size_t size,
+BinaryReaderObjdumpBase::BinaryReaderObjdumpBase(ByteSpan data,
                                                  ObjdumpOptions* options,
                                                  ObjdumpState* objdump_state)
     : options_(options),
       objdump_state_(objdump_state),
       data_(data),
-      size_(size),
       err_stream_(FileStream::CreateStderr()) {
   ZeroMemory(section_starts_);
 }
@@ -1071,8 +1067,7 @@ struct InitExpr {
 
 class BinaryReaderObjdump : public BinaryReaderObjdumpBase {
  public:
-  BinaryReaderObjdump(const uint8_t* data,
-                      size_t size,
+  BinaryReaderObjdump(ByteSpan data,
                       ObjdumpOptions* options,
                       ObjdumpState* state);
 
@@ -1209,9 +1204,7 @@ class BinaryReaderObjdump : public BinaryReaderObjdumpBase {
   Result BeginDataSegment(Index index,
                           Index memory_index,
                           uint8_t flags) override;
-  Result OnDataSegmentData(Index index,
-                           const void* data,
-                           Address size) override;
+  Result OnDataSegmentData(Index index, ByteSpan data) override;
 
   Result OnModuleName(std::string_view name) override;
   Result OnFunctionName(Index function_index,
@@ -1295,9 +1288,7 @@ class BinaryReaderObjdump : public BinaryReaderObjdumpBase {
   Result OnRefNullExpr(Type type) override;
   Result OnGlobalGetExpr(Index global_index) override;
   Result OnCodeMetadataCount(Index function_index, Index count) override;
-  Result OnCodeMetadata(Offset code_offset,
-                        const void* data,
-                        Address size) override;
+  Result OnCodeMetadata(Offset code_offset, ByteSpan data) override;
 
  private:
   Result EndInitExpr();
@@ -1333,11 +1324,10 @@ class BinaryReaderObjdump : public BinaryReaderObjdumpBase {
   }
 };
 
-BinaryReaderObjdump::BinaryReaderObjdump(const uint8_t* data,
-                                         size_t size,
+BinaryReaderObjdump::BinaryReaderObjdump(ByteSpan data,
                                          ObjdumpOptions* options,
                                          ObjdumpState* objdump_state)
-    : BinaryReaderObjdumpBase(data, size, options, objdump_state),
+    : BinaryReaderObjdumpBase(data, options, objdump_state),
       out_stream_(FileStream::CreateStdout()) {}
 
 Result BinaryReaderObjdump::BeginCustomSection(Index section_index,
@@ -1393,8 +1383,8 @@ Result BinaryReaderObjdump::BeginSection(Index section_index,
     case ObjdumpMode::RawData:
       if (section_match) {
         printf("\nContents of section %s:\n", section_name);
-        out_stream_->WriteMemoryDump(data_ + state->offset, size, state->offset,
-                                     PrintChars::Yes);
+        out_stream_->WriteMemoryDump(data_.subspan(state->offset, size),
+                                     state->offset, PrintChars::Yes);
       }
       break;
     case ObjdumpMode::Prepass:
@@ -2064,9 +2054,7 @@ Result BinaryReaderObjdump::BeginDataSegment(Index index,
   return Result::Ok;
 }
 
-Result BinaryReaderObjdump::OnDataSegmentData(Index index,
-                                              const void* src_data,
-                                              Address size) {
+Result BinaryReaderObjdump::OnDataSegmentData(Index index, ByteSpan data) {
   if (!ShouldPrintDetails()) {
     return Result::Ok;
   }
@@ -2081,15 +2069,14 @@ Result BinaryReaderObjdump::OnDataSegmentData(Index index,
   } else {
     PrintDetails(" memory=%" PRIindex, data_mem_index_);
   }
-  PrintDetails(" size=%" PRIaddress, size);
+  PrintDetails(" size=%zu", data.size());
   if (data_flags_ & SegPassive) {
     PrintDetails("\n");
   } else {
     PrintInitExpr(current_init_expr_, /*as_unsigned=*/true);
   }
 
-  out_stream_->WriteMemoryDump(src_data, size, data_offset_, PrintChars::Yes,
-                               "  - ");
+  out_stream_->WriteMemoryDump(data, data_offset_, PrintChars::Yes, "  - ");
 
   // Print relocations from this segment.
   if (!options_->relocs) {
@@ -2097,7 +2084,7 @@ Result BinaryReaderObjdump::OnDataSegmentData(Index index,
   }
 
   Offset data_start = GetSectionStart(BinarySection::Data);
-  Offset segment_start = state->offset - size;
+  Offset segment_start = state->offset - data.size();
   Offset segment_offset = segment_start - data_start;
   while (next_data_reloc_ < objdump_state_->data_relocations.size()) {
     const Reloc& reloc = objdump_state_->data_relocations[next_data_reloc_];
@@ -2468,15 +2455,13 @@ Result BinaryReaderObjdump::OnCodeMetadataCount(Index function_index,
   printf(":\n");
   return Result::Ok;
 }
-Result BinaryReaderObjdump::OnCodeMetadata(Offset code_offset,
-                                           const void* data,
-                                           Address size) {
+Result BinaryReaderObjdump::OnCodeMetadata(Offset code_offset, ByteSpan data) {
   if (!ShouldPrintDetails()) {
     return Result::Ok;
   }
   printf("    - meta[%" PRIzx "]:\n", code_offset);
 
-  out_stream_->WriteMemoryDump(data, size, 0, PrintChars::Yes, "     - ");
+  out_stream_->WriteMemoryDump(data, 0, PrintChars::Yes, "     - ");
   return Result::Ok;
 }
 
@@ -2508,8 +2493,7 @@ void ObjdumpLocalNames::Set(Index function_index,
       std::string(name);
 }
 
-Result ReadBinaryObjdump(const uint8_t* data,
-                         size_t size,
+Result ReadBinaryObjdump(ByteSpan data,
                          ObjdumpOptions* options,
                          ObjdumpState* state) {
   Features features;
@@ -2523,19 +2507,27 @@ Result ReadBinaryObjdump(const uint8_t* data,
   switch (options->mode) {
     case ObjdumpMode::Prepass: {
       read_options.skip_function_bodies = true;
-      BinaryReaderObjdumpPrepass reader(data, size, options, state);
-      return ReadBinary(data, size, &reader, read_options);
+      BinaryReaderObjdumpPrepass reader(data, options, state);
+      return ReadBinary(data, &reader, read_options);
     }
     case ObjdumpMode::Disassemble: {
-      BinaryReaderObjdumpDisassemble reader(data, size, options, state);
-      return ReadBinary(data, size, &reader, read_options);
+      BinaryReaderObjdumpDisassemble reader(data, options, state);
+      return ReadBinary(data, &reader, read_options);
     }
     default: {
       read_options.skip_function_bodies = true;
-      BinaryReaderObjdump reader(data, size, options, state);
-      return ReadBinary(data, size, &reader, read_options);
+      BinaryReaderObjdump reader(data, options, state);
+      return ReadBinary(data, &reader, read_options);
     }
   }
+}
+
+// TODO(sbc): Remove this old API. Use the ByteSpan overload instead.
+Result ReadBinaryObjdump(const uint8_t* data,
+                         size_t size,
+                         ObjdumpOptions* options,
+                         ObjdumpState* state) {
+  return ReadBinaryObjdump(ByteSpan(data, size), options, state);
 }
 
 }  // namespace wabt

--- a/src/binary-reader-stats.cc
+++ b/src/binary-reader-stats.cc
@@ -303,12 +303,11 @@ Result BinaryReaderOpcnt::OnEndExpr() {
 
 }  // end anonymous namespace
 
-Result ReadBinaryOpcnt(const void* data,
-                       size_t size,
+Result ReadBinaryOpcnt(ByteSpan data,
                        const ReadBinaryOptions& options,
                        OpcodeInfoCounts* counts) {
   BinaryReaderOpcnt reader(counts);
-  return ReadBinary(data, size, &reader, options);
+  return ReadBinary(data, &reader, options);
 }
 
 }  // namespace wabt

--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -76,10 +76,9 @@ class BinaryReader {
     bool stop_on_first_error;
   };
 
-  BinaryReader(const void* data,
-               size_t size,
-               BinaryReaderDelegate* delegate,
-               const ReadBinaryOptions& options);
+  explicit BinaryReader(ByteSpan data,
+                        BinaryReaderDelegate* delegate,
+                        const ReadBinaryOptions& options);
 
   Result ReadModule(const ReadModuleOptions& options);
 
@@ -127,10 +126,8 @@ class BinaryReader {
                                         const char* desc,
                                         const char* type);
   [[nodiscard]] Result ReadStr(std::string_view* out_str, const char* desc);
-  [[nodiscard]] Result ReadBytes(const void** out_data,
-                                 Address* out_data_size,
-                                 const char* desc);
-  [[nodiscard]] Result ReadBytesWithSize(const void** out_data,
+  [[nodiscard]] Result ReadBytes(ByteSpan* out_data, const char* desc);
+  [[nodiscard]] Result ReadBytesWithSize(ByteSpan* out_data,
                                          Offset size,
                                          const char* desc);
   [[nodiscard]] Result ReadIndex(Index* index, const char* desc);
@@ -230,12 +227,11 @@ class BinaryReader {
       ValueRestoreGuard<size_t, &BinaryReader::read_end_>;
 };
 
-BinaryReader::BinaryReader(const void* data,
-                           size_t size,
+BinaryReader::BinaryReader(ByteSpan data,
                            BinaryReaderDelegate* delegate,
                            const ReadBinaryOptions& options)
-    : read_end_(size),
-      state_(static_cast<const uint8_t*>(data), size),
+    : read_end_(data.size()),
+      state_(data),
       logging_delegate_(options.log_stream, delegate),
       delegate_(options.log_stream ? &logging_delegate_ : delegate),
       options_(options),
@@ -305,11 +301,11 @@ Result BinaryReader::ReadT(T* out_value,
   }
 #if WABT_BIG_ENDIAN
   uint8_t tmp[sizeof(T)];
-  memcpy(tmp, state_.data + state_.offset, sizeof(tmp));
+  memcpy(tmp, state_.data.data() + state_.offset, sizeof(tmp));
   SwapBytesSized(tmp, sizeof(tmp));
   memcpy(out_value, tmp, sizeof(T));
 #else
-  memcpy(out_value, state_.data + state_.offset, sizeof(T));
+  memcpy(out_value, state_.data.data() + state_.offset, sizeof(T));
 #endif
   state_.offset += sizeof(T);
   return Result::Ok;
@@ -343,8 +339,8 @@ template <typename T,
           char prefix,
           size_t (*ReadFn)(const uint8_t*, const uint8_t*, T*)>
 Result BinaryReader::ReadLeb128(T* out_value, const char* desc) {
-  const uint8_t* p = state_.data + state_.offset;
-  const uint8_t* end = state_.data + read_end_;
+  const uint8_t* p = state_.data.data() + state_.offset;
+  const uint8_t* end = state_.data.data() + read_end_;
   size_t bytes_read = ReadFn(p, end, out_value);
   ERROR_UNLESS(bytes_read > 0, "unable to read %c%zu leb128: %s", prefix,
                sizeof(T) * 8, desc);
@@ -435,7 +431,8 @@ Result BinaryReader::ReadStr(std::string_view* out_str, const char* desc) {
                "unable to read string: %s", desc);
 
   *out_str = std::string_view(
-      reinterpret_cast<const char*>(state_.data) + state_.offset, str_len);
+      reinterpret_cast<const char*>(state_.data.data()) + state_.offset,
+      str_len);
   state_.offset += str_len;
 
   ERROR_UNLESS(IsValidUtf8(out_str->data(), out_str->length()),
@@ -443,23 +440,19 @@ Result BinaryReader::ReadStr(std::string_view* out_str, const char* desc) {
   return Result::Ok;
 }
 
-Result BinaryReader::ReadBytes(const void** out_data,
-                               Address* out_data_size,
-                               const char* desc) {
+Result BinaryReader::ReadBytes(ByteSpan* out_data, const char* desc) {
   uint32_t data_size = 0;
   CHECK_RESULT(ReadU32Leb128(&data_size, "data size"));
-  CHECK_RESULT(ReadBytesWithSize(out_data, data_size, desc));
-  *out_data_size = data_size;
-  return Result::Ok;
+  return ReadBytesWithSize(out_data, data_size, desc);
 }
 
-Result BinaryReader::ReadBytesWithSize(const void** out_data,
+Result BinaryReader::ReadBytesWithSize(ByteSpan* out_data,
                                        Offset size,
                                        const char* desc) {
   ERROR_UNLESS(size <= read_end_ - state_.offset, "unable to read data: %s",
                desc);
 
-  *out_data = static_cast<const uint8_t*>(state_.data) + state_.offset;
+  *out_data = state_.data.subspan(state_.offset, size);
   state_.offset += size;
   return Result::Ok;
 }
@@ -2376,11 +2369,11 @@ Result BinaryReader::ReadTargetFeaturesSections(Offset section_size) {
 Result BinaryReader::ReadGenericCustomSection(std::string_view name,
                                               Offset section_size) {
   CALLBACK(BeginGenericCustomSection, section_size);
-  const void* data;
+  ByteSpan data;
   Offset custom_data_size = read_end_ - state_.offset;
   CHECK_RESULT(
       ReadBytesWithSize(&data, custom_data_size, "custom section data"));
-  CALLBACK(OnGenericCustomSection, name, data, custom_data_size);
+  CALLBACK(OnGenericCustomSection, name, data);
   CALLBACK0(EndGenericCustomSection);
   return Result::Ok;
 }
@@ -2587,10 +2580,9 @@ Result BinaryReader::ReadCodeMetadataSection(std::string_view name,
           "code offset out of order: %" PRIzx, code_offset);
       last_code_offset = code_offset;
 
-      Address data_size;
-      const void* data;
-      CHECK_RESULT(ReadBytes(&data, &data_size, "instance data"));
-      CALLBACK(OnCodeMetadata, code_offset, data, data_size);
+      ByteSpan data;
+      CHECK_RESULT(ReadBytes(&data, "instance data"));
+      CALLBACK(OnCodeMetadata, code_offset, data);
     }
   }
 
@@ -3099,10 +3091,9 @@ Result BinaryReader::ReadDataSection(Offset section_size) {
       CALLBACK(EndDataSegmentInitExpr, i);
     }
 
-    Address data_size;
-    const void* data;
-    CHECK_RESULT(ReadBytes(&data, &data_size, "data segment data"));
-    CALLBACK(OnDataSegmentData, i, data, data_size);
+    ByteSpan data;
+    CHECK_RESULT(ReadBytes(&data, "data segment data"));
+    CALLBACK(OnDataSegmentData, i, data);
     CALLBACK(EndDataSegment, i);
   }
   CALLBACK0(EndDataSection);
@@ -3124,12 +3115,12 @@ Result BinaryReader::ReadSections(const ReadSectionsOptions& options) {
   Index section_index = 0;
   bool seen_section_code[static_cast<int>(BinarySection::Last) + 1] = {false};
 
-  for (; state_.offset < state_.size; ++section_index) {
+  for (; state_.offset < state_.data.size(); ++section_index) {
     uint8_t section_code;
     Offset section_size;
     CHECK_RESULT(ReadU8(&section_code, "section code"));
     CHECK_RESULT(ReadOffset(&section_size, "section size"));
-    ERROR_UNLESS(section_size <= state_.size - state_.offset,
+    ERROR_UNLESS(section_size <= state_.data.size() - state_.offset,
                  "invalid section size: extends past end");
     ReadEndRestoreGuard guard(this);
     read_end_ = state_.offset + section_size;
@@ -3157,7 +3148,7 @@ Result BinaryReader::ReadSections(const ReadSectionsOptions& options) {
       seen_section_code[section_code] = true;
     }
 
-    ERROR_UNLESS(read_end_ <= state_.size,
+    ERROR_UNLESS(read_end_ <= state_.data.size(),
                  "invalid section size: extends past end");
 
     ERROR_UNLESS(
@@ -3311,11 +3302,10 @@ Result BinaryReader::ReadModule(const ReadModuleOptions& options) {
 
 }  // end anonymous namespace
 
-Result ReadBinary(const void* data,
-                  size_t size,
+Result ReadBinary(ByteSpan data,
                   BinaryReaderDelegate* delegate,
                   const ReadBinaryOptions& options) {
-  BinaryReader reader(data, size, delegate, options);
+  BinaryReader reader(data, delegate, options);
   return reader.ReadModule(
       BinaryReader::ReadModuleOptions{options.stop_on_first_error});
 }

--- a/src/binary-writer.cc
+++ b/src/binary-writer.cc
@@ -1921,8 +1921,7 @@ void BinaryWriter::WriteCodeMetadataSections() {
       for (auto& a : f.entries) {
         WriteU32Leb128(stream_, a.offset, "code offset");
         WriteU32Leb128(stream_, a.data.size(), "data length");
-        stream_->WriteData(a.data.data(), a.data.size(), "data",
-                           PrintChars::Yes);
+        stream_->WriteData(a.data, "data", PrintChars::Yes);
       }
     }
     EndSection();
@@ -1931,7 +1930,7 @@ void BinaryWriter::WriteCodeMetadataSections() {
   auto buf = tmp_stream.ReleaseOutputBuffer();
   stream_->MoveData(code_start_ + buf->data.size(), code_start_,
                     stream_->offset() - code_start_);
-  stream_->WriteDataAt(code_start_, buf->data.data(), buf->data.size());
+  stream_->WriteDataAt(code_start_, buf->data);
   stream_->AddOffset(buf->data.size());
   code_start_ += buf->data.size();
   section_count_ += 1;

--- a/src/c-writer.cc
+++ b/src/c-writer.cc
@@ -3134,7 +3134,7 @@ void CWriter::FinishFunction(size_t stack_var_section) {
     auto& [condition, stream] = func_sections_.at(i);
     std::unique_ptr<OutputBuffer> buf = stream.ReleaseOutputBuffer();
     if (condition.empty() || func_includes_.contains(condition)) {
-      stream_->WriteData(buf->data.data(), buf->data.size());
+      stream_->WriteData(buf->data);
     }
 
     if (i == stack_var_section) {

--- a/src/emscripten-helpers.cc
+++ b/src/emscripten-helpers.cc
@@ -139,7 +139,8 @@ WabtReadBinaryResult* wabt_read_binary(const void* data,
   // TODO(binji): Pass through from wabt_read_binary parameter.
   const char* filename = "<binary>";
   result->result =
-      wabt::ReadBinaryIr(filename, data, size, options, errors, module);
+      wabt::ReadBinaryIr(filename, {static_cast<const uint8_t*>(data), size},
+                         options, errors, module);
   result->module.reset(module);
   return result;
 }

--- a/src/interp/binary-reader-interp.cc
+++ b/src/interp/binary-reader-interp.cc
@@ -296,9 +296,7 @@ class BinaryReaderInterp : public BinaryReaderNop {
   Result BeginDataSegment(Index index,
                           Index memory_index,
                           uint8_t flags) override;
-  Result OnDataSegmentData(Index index,
-                           const void* data,
-                           Address size) override;
+  Result OnDataSegmentData(Index index, ByteSpan data) override;
 
  private:
   Location GetLocation() const;
@@ -855,14 +853,9 @@ Result BinaryReaderInterp::BeginDataSegment(Index index,
   return Result::Ok;
 }
 
-Result BinaryReaderInterp::OnDataSegmentData(Index index,
-                                             const void* src_data,
-                                             Address size) {
+Result BinaryReaderInterp::OnDataSegmentData(Index index, ByteSpan data) {
   DataDesc& dst_data = module_.datas.back();
-  if (size > 0) {
-    dst_data.data.resize(size);
-    memcpy(dst_data.data.data(), src_data, size);
-  }
+  dst_data.data.assign(data.begin(), data.end());
   return Result::Ok;
 }
 
@@ -1815,13 +1808,23 @@ Result BinaryReaderInterp::OnDelegateExpr(Index depth) {
 }  // namespace
 
 Result ReadBinaryInterp(std::string_view filename,
-                        const void* data,
-                        size_t size,
+                        ByteSpan data,
                         const ReadBinaryOptions& options,
                         Errors* errors,
                         ModuleDesc* out_module) {
   BinaryReaderInterp reader(out_module, filename, errors, options.features);
-  return ReadBinary(data, size, &reader, options);
+  return ReadBinary(data, &reader, options);
+}
+
+// TODO(sbc): Remove this old API. Use the ByteSpan overload instead.
+Result ReadBinaryInterp(std::string_view filename,
+                        const uint8_t* data,
+                        size_t size,
+                        const ReadBinaryOptions& options,
+                        Errors* errors,
+                        ModuleDesc* out_module) {
+  return ReadBinaryInterp(filename, ByteSpan(data, size), options, errors,
+                          out_module);
 }
 
 }  // namespace interp

--- a/src/interp/interp-wasm-c-api.cc
+++ b/src/interp/interp-wasm-c-api.cc
@@ -639,8 +639,10 @@ own wasm_module_t* wasm_module_new(wasm_store_t* store,
                                    const wasm_byte_vec_t* binary) {
   Errors errors;
   ModuleDesc module_desc;
-  if (Failed(ReadBinaryInterp("<internal>", binary->data, binary->size,
-                              GetOptions(), &errors, &module_desc))) {
+  if (Failed(ReadBinaryInterp(
+          "<internal>",
+          {reinterpret_cast<const uint8_t*>(binary->data), binary->size},
+          GetOptions(), &errors, &module_desc))) {
     FormatErrorsToFile(errors, Location::Type::Binary);
     return nullptr;
   }

--- a/src/leb128.cc
+++ b/src/leb128.cc
@@ -53,7 +53,7 @@ Offset WriteFixedU32Leb128At(Stream* stream,
   uint8_t data[MAX_U32_LEB128_BYTES];
   Offset length =
       WriteFixedU32Leb128Raw(data, data + MAX_U32_LEB128_BYTES, value);
-  stream->WriteDataAt(offset, data, length, desc);
+  stream->WriteDataAt(offset, {data, length}, desc);
   return length;
 }
 
@@ -79,7 +79,7 @@ Offset WriteU32Leb128At(Stream* stream,
   uint8_t data[MAX_U32_LEB128_BYTES];
   Offset length = 0;
   LEB128_LOOP_UNTIL(value == 0);
-  stream->WriteDataAt(offset, data, length, desc);
+  stream->WriteDataAt(offset, {data, length}, desc);
   return length;
 }
 

--- a/src/stream.cc
+++ b/src/stream.cc
@@ -36,25 +36,21 @@ void Stream::AddOffset(ssize_t delta) {
 }
 
 void Stream::WriteDataAt(size_t at,
-                         const void* src,
-                         size_t size,
+                         ByteSpan data,
                          const char* desc,
                          PrintChars print_chars) {
   if (Failed(result_)) {
     return;
   }
   if (log_stream_) {
-    log_stream_->WriteMemoryDump(src, size, at, print_chars, nullptr, desc);
+    log_stream_->WriteMemoryDump(data, at, print_chars, nullptr, desc);
   }
-  result_ = WriteDataImpl(at, src, size);
+  result_ = WriteDataImpl(at, data);
 }
 
-void Stream::WriteData(const void* src,
-                       size_t size,
-                       const char* desc,
-                       PrintChars print_chars) {
-  WriteDataAt(offset_, src, size, desc, print_chars);
-  offset_ += size;
+void Stream::WriteData(ByteSpan src, const char* desc, PrintChars print_chars) {
+  WriteDataAt(offset_, src, desc, print_chars);
+  offset_ += src.size();
 }
 
 void Stream::MoveData(size_t dst_offset, size_t src_offset, size_t size) {
@@ -88,22 +84,20 @@ void Stream::Writef(const char* format, ...) {
   WriteData(buffer, length);
 }
 
-void Stream::WriteMemoryDump(const void* start,
-                             size_t size,
+void Stream::WriteMemoryDump(ByteSpan data,
                              size_t offset,
                              PrintChars print_chars,
                              const char* prefix,
                              const char* desc) {
-  const uint8_t* p = static_cast<const uint8_t*>(start);
-  const uint8_t* end = p + size;
+  const uint8_t* p = data.data();
+  const uint8_t* end = p + data.size();
   while (p < end) {
     const uint8_t* line = p;
     const uint8_t* line_end = p + DUMP_OCTETS_PER_LINE;
     if (prefix) {
       Writef("%s", prefix);
     }
-    Writef("%07" PRIzx ": ", reinterpret_cast<intptr_t>(p) -
-                                 reinterpret_cast<intptr_t>(start) + offset);
+    Writef("%07" PRIzx ": ", static_cast<size_t>(p - data.data()) + offset);
     while (p < line_end) {
       for (int i = 0; i < DUMP_OCTETS_PER_GROUP; ++i, ++p) {
         if (p < end) {
@@ -187,18 +181,16 @@ void MemoryStream::Clear() {
     buf_.reset(new OutputBuffer());
 }
 
-Result MemoryStream::WriteDataImpl(size_t dst_offset,
-                                   const void* src,
-                                   size_t size) {
-  if (size == 0) {
+Result MemoryStream::WriteDataImpl(size_t dst_offset, ByteSpan data) {
+  if (data.empty()) {
     return Result::Ok;
   }
-  size_t end = dst_offset + size;
+  size_t end = dst_offset + data.size();
   if (end > buf_->data.size()) {
     buf_->data.resize(end);
   }
   uint8_t* dst = &buf_->data[dst_offset];
-  memcpy(dst, src, size);
+  memcpy(dst, data.data(), data.size());
   return Result::Ok;
 }
 
@@ -273,25 +265,25 @@ void FileStream::Flush() {
   }
 }
 
-Result FileStream::WriteDataImpl(size_t at, const void* data, size_t size) {
+Result FileStream::WriteDataImpl(size_t at, ByteSpan data) {
   if (!file_) {
     return Result::Error;
   }
-  if (size == 0) {
+  if (data.empty()) {
     return Result::Ok;
   }
   if (at != offset_) {
     if (fseek(file_, at, SEEK_SET) != 0) {
-      ERROR("fseek offset=%" PRIzd " failed, errno=%d\n", size, errno);
+      ERROR("fseek offset=%" PRIzd " failed, errno=%d\n", data.size(), errno);
       return Result::Error;
     }
     offset_ = at;
   }
-  if (fwrite(data, size, 1, file_) != 1) {
-    ERROR("fwrite size=%" PRIzd " failed, errno=%d\n", size, errno);
+  if (fwrite(data.data(), data.size(), 1, file_) != 1) {
+    ERROR("fwrite size=%" PRIzd " failed, errno=%d\n", data.size(), errno);
     return Result::Error;
   }
-  offset_ += size;
+  offset_ += data.size();
   return Result::Ok;
 }
 

--- a/src/test-binary-reader.cc
+++ b/src/test-binary-reader.cc
@@ -60,10 +60,8 @@ TEST(BinaryReader, DisabledOpcodes) {
         b[0], b[1], b[2],  // The instruction, padded with zeroes
         0x0b,              // end
     };
-    const size_t size = sizeof(data);
-
     BinaryReaderError reader;
-    Result result = ReadBinary(data, size, &reader, options);
+    Result result = ReadBinary(data, &reader, options);
     EXPECT_EQ(Result::Error, result);
 
     // This relies on the binary reader checking whether the opcode is allowed
@@ -93,7 +91,7 @@ TEST(BinaryReader, InvalidFunctionBodySize) {
 
   BinaryReaderError reader;
   ReadBinaryOptions options;
-  Result result = ReadBinary(data, sizeof(data), &reader, options);
+  Result result = ReadBinary(data, &reader, options);
   EXPECT_EQ(Result::Error, result);
   EXPECT_NE(std::string::npos,
             reader.first_error.message.find("invalid function body size"))
@@ -115,7 +113,7 @@ TEST(BinaryReader, OversizedSectionSize) {
 
   BinaryReaderError reader;
   ReadBinaryOptions options;
-  Result result = ReadBinary(data, sizeof(data), &reader, options);
+  Result result = ReadBinary(data, &reader, options);
   EXPECT_EQ(Result::Error, result);
   EXPECT_NE(std::string::npos,
             reader.first_error.message.find("invalid section size"))
@@ -140,7 +138,7 @@ TEST(BinaryReader, OversizedSubsectionSize) {
 
   BinaryReaderError reader;
   ReadBinaryOptions options;
-  Result result = ReadBinary(data, sizeof(data), &reader, options);
+  Result result = ReadBinary(data, &reader, options);
   // Custom section errors are not fatal by default, but ensure no crash.
   (void)result;
 }

--- a/src/test-interp.cc
+++ b/src/test-interp.cc
@@ -30,8 +30,8 @@ class InterpTest : public ::testing::Test {
   void ReadModule(const std::vector<u8>& data) {
     Errors errors;
     ReadBinaryOptions options;
-    Result result = ReadBinaryInterp("<internal>", data.data(), data.size(),
-                                     options, &errors, &module_desc_);
+    Result result =
+        ReadBinaryInterp("<internal>", data, options, &errors, &module_desc_);
     ASSERT_EQ(Result::Ok, result)
         << FormatErrorsToString(errors, Location::Type::Binary);
   }

--- a/src/tools/spectest-interp.cc
+++ b/src/tools/spectest-interp.cc
@@ -291,8 +291,8 @@ bool CheckIR(const std::string& filename, bool validate) {
 
   Errors errors;
   wabt::Module module;
-  if (Failed(ReadBinaryIr(filename.c_str(), file_data.data(), file_data.size(),
-                          options, &errors, &module))) {
+  if (Failed(ReadBinaryIr(filename.c_str(), file_data, options, &errors,
+                          &module))) {
     return false;
   }
 
@@ -1484,8 +1484,7 @@ interp::Module::Ptr CommandRunner::ReadModule(std::string_view module_filename,
   ReadBinaryOptions options(s_features, s_log_stream.get(), kReadDebugNames,
                             kStopOnFirstError, kFailOnCustomSectionError);
   ModuleDesc module_desc;
-  if (Failed(ReadBinaryInterp(module_filename, file_data.data(),
-                              file_data.size(), options, errors,
+  if (Failed(ReadBinaryInterp(module_filename, file_data, options, errors,
                               &module_desc))) {
     return {};
   }
@@ -1551,8 +1550,7 @@ wabt::Result CommandRunner::ReadMalformedBinaryModule(
   };
 
   BinaryReaderErrorLogging reader_delegate{errors};
-  return ReadBinary(file_data.data(), file_data.size(), &reader_delegate,
-                    options);
+  return ReadBinary(file_data, &reader_delegate, options);
 }
 
 wabt::Result CommandRunner::ReadMalformedModule(

--- a/src/tools/wasm-interp.cc
+++ b/src/tools/wasm-interp.cc
@@ -321,8 +321,7 @@ static Result ReadModule(const char* module_filename,
   const bool kFailOnCustomSectionError = true;
   ReadBinaryOptions options(s_features, s_log_stream.get(), kReadDebugNames,
                             kStopOnFirstError, kFailOnCustomSectionError);
-  CHECK_RESULT(ReadBinaryInterp(module_filename, file_data.data(),
-                                file_data.size(), options, errors,
+  CHECK_RESULT(ReadBinaryInterp(module_filename, file_data, options, errors,
                                 &module_desc));
 
   if (s_verbose) {

--- a/src/tools/wasm-objdump.cc
+++ b/src/tools/wasm-objdump.cc
@@ -75,9 +75,6 @@ Result dump_file(const char* filename) {
   std::vector<uint8_t> file_data;
   CHECK_RESULT(ReadFile(filename, &file_data));
 
-  uint8_t* data = file_data.data();
-  size_t size = file_data.size();
-
   // Perform serveral passed over the binary in order to print out different
   // types of information.
   s_objdump_options.filename = filename;
@@ -89,31 +86,31 @@ Result dump_file(const char* filename) {
 
   // Pass 0: Prepass
   s_objdump_options.mode = ObjdumpMode::Prepass;
-  result |= ReadBinaryObjdump(data, size, &s_objdump_options, &state);
+  result |= ReadBinaryObjdump(file_data, &s_objdump_options, &state);
   s_objdump_options.log_stream = nullptr;
 
   // Pass 1: Print the section headers
   if (s_objdump_options.headers) {
     s_objdump_options.mode = ObjdumpMode::Headers;
-    result |= ReadBinaryObjdump(data, size, &s_objdump_options, &state);
+    result |= ReadBinaryObjdump(file_data, &s_objdump_options, &state);
   }
 
   // Pass 2: Print extra information based on section type
   if (s_objdump_options.details) {
     s_objdump_options.mode = ObjdumpMode::Details;
-    result |= ReadBinaryObjdump(data, size, &s_objdump_options, &state);
+    result |= ReadBinaryObjdump(file_data, &s_objdump_options, &state);
   }
 
   // Pass 3: Disassemble code section
   if (s_objdump_options.disassemble) {
     s_objdump_options.mode = ObjdumpMode::Disassemble;
-    result |= ReadBinaryObjdump(data, size, &s_objdump_options, &state);
+    result |= ReadBinaryObjdump(file_data, &s_objdump_options, &state);
   }
 
   // Pass 4: Dump to raw contents of the sections
   if (s_objdump_options.raw) {
     s_objdump_options.mode = ObjdumpMode::RawData;
-    result |= ReadBinaryObjdump(data, size, &s_objdump_options, &state);
+    result |= ReadBinaryObjdump(file_data, &s_objdump_options, &state);
   }
 
   return result;

--- a/src/tools/wasm-stats.cc
+++ b/src/tools/wasm-stats.cc
@@ -154,8 +154,7 @@ int ProgramMain(int argc, char** argv) {
   if (Succeeded(result)) {
     OpcodeInfoCounts counts;
     s_read_binary_options.features = s_features;
-    result = ReadBinaryOpcnt(file_data.data(), file_data.size(),
-                             s_read_binary_options, &counts);
+    result = ReadBinaryOpcnt(file_data, s_read_binary_options, &counts);
     if (Succeeded(result)) {
       stream.Writef("Total opcodes: %" PRIzd "\n\n", SumCounts(counts));
 

--- a/src/tools/wasm-strip.cc
+++ b/src/tools/wasm-strip.cc
@@ -88,7 +88,7 @@ class BinaryReaderStrip : public BinaryReaderNop {
     }
     stream_.WriteU8Enum(section_type, "section code");
     WriteU32Leb128(&stream_, size, "section size");
-    stream_.WriteData(state->data + state->offset, size, "section data");
+    stream_.WriteData(state->data.subspan(state->offset, size), "section data");
     return Result::Ok;
   }
 
@@ -107,7 +107,8 @@ class BinaryReaderStrip : public BinaryReaderNop {
         !sections_to_remove_.empty()) {
       stream_.WriteU8Enum(BinarySection::Custom, "section code");
       WriteU32Leb128(&stream_, size, "section size");
-      stream_.WriteData(state->data + section_start_, size, "section data");
+      stream_.WriteData(state->data.subspan(section_start_, size),
+                        "section data");
     }
     return Result::Ok;
   }
@@ -142,7 +143,7 @@ int ProgramMain(int argc, char** argv) {
                             kStopOnFirstError, kFailOnCustomSectionError);
 
   BinaryReaderStrip reader(v_sections_to_keep, v_sections_to_remove, &errors);
-  result = ReadBinary(file_data.data(), file_data.size(), &reader, options);
+  result = ReadBinary(file_data, &reader, options);
   FormatErrorsToFile(errors, Location::Type::Binary);
   if (Failed(result)) {
     return Result::Error;

--- a/src/tools/wasm-validate.cc
+++ b/src/tools/wasm-validate.cc
@@ -78,8 +78,8 @@ int ProgramMain(int argc, char** argv) {
     ReadBinaryOptions options(s_features, s_log_stream.get(),
                               s_read_debug_names, kStopOnFirstError,
                               s_fail_on_custom_section_error);
-    result = ReadBinaryIr(s_infile.c_str(), file_data.data(), file_data.size(),
-                          options, &errors, &module);
+    result =
+        ReadBinaryIr(s_infile.c_str(), file_data, options, &errors, &module);
     if (Succeeded(result)) {
       ValidateOptions options(s_features);
       result = ValidateModule(&module, &errors, options);

--- a/src/tools/wasm2c.cc
+++ b/src/tools/wasm2c.cc
@@ -132,8 +132,8 @@ Result Wasm2cMain(Errors& errors) {
   ReadBinaryOptions options(s_write_c_options.features, s_log_stream.get(),
                             s_read_debug_names, kStopOnFirstError,
                             kFailOnCustomSectionError);
-  CHECK_RESULT(ReadBinaryIr(s_infile.c_str(), file_data.data(),
-                            file_data.size(), options, &errors, &module));
+  CHECK_RESULT(
+      ReadBinaryIr(s_infile.c_str(), file_data, options, &errors, &module));
   CHECK_RESULT(ValidateModule(&module, &errors, s_write_c_options.features));
   CHECK_RESULT(GenerateNames(&module));
   /* TODO(binji): This shouldn't fail; if a name can't be applied

--- a/src/tools/wasm2wat-fuzz.cc
+++ b/src/tools/wasm2wat-fuzz.cc
@@ -25,6 +25,6 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   wabt::ReadBinaryOptions options;
   wabt::Errors errors;
   wabt::Module module;
-  wabt::ReadBinaryIr("dummy filename", data, size, options, &errors, &module);
+  wabt::ReadBinaryIr("dummy filename", {data, size}, options, &errors, &module);
   return 0;
 }

--- a/src/tools/wasm2wat.cc
+++ b/src/tools/wasm2wat.cc
@@ -111,8 +111,8 @@ int ProgramMain(int argc, char** argv) {
     ReadBinaryOptions options(s_features, s_log_stream.get(),
                               s_read_debug_names, kStopOnFirstError,
                               s_fail_on_custom_section_error);
-    result = ReadBinaryIr(s_infile.c_str(), file_data.data(), file_data.size(),
-                          options, &errors, &module);
+    result =
+        ReadBinaryIr(s_infile.c_str(), file_data, options, &errors, &module);
     if (Succeeded(result)) {
       if (Succeeded(result) && s_validate) {
         ValidateOptions options(s_features);

--- a/src/tools/wat2wasm.cc
+++ b/src/tools/wat2wasm.cc
@@ -104,7 +104,7 @@ static void WriteBufferToFile(std::string_view filename,
       stream->Writef(";; dump\n");
     }
     if (!buffer.data.empty()) {
-      stream->WriteMemoryDump(buffer.data.data(), buffer.data.size());
+      stream->WriteMemoryDump(buffer.data);
     }
   }
 

--- a/src/wast-parser.cc
+++ b/src/wast-parser.cc
@@ -3813,8 +3813,7 @@ Result WastParser::ParseModuleCommand(Script* script, CommandPtr* out_command) {
       Errors errors;
       const char* filename = "<text>";
       if (options_->parse_binary_modules) {
-        ReadBinaryIr(filename, bsm->data.data(), bsm->data.size(), options,
-                     &errors, module);
+        ReadBinaryIr(filename, bsm->data, options, &errors, module);
       }
       module->name = bsm->name;
       module->loc = bsm->loc;


### PR DESCRIPTION
Replace legacy raw pointer and size pairs with std::span<const uint8_t>
(aliased to `ByteSpan`) across WABT's binary reader interfaces, writer
streams, parser callbacks, and public entry points.

This greatly improves type safety, simplifies call sites (allowing vectors
and arrays to be passed directly), and aligns WABT with modern C++20
standards.

Highlights:
- Fixes a performance bug in Stream::WriteData where passing std::vector
  accidentally triggered a full copy-by-value of the vector's contents.
  The template overload now correctly accepts std::span (zero-copy).
- Simplifies various writing call sites (e.g. in binary-writer, c-writer,
  and wasm-strip) by passing vectors directly or leveraging subspan.