### PR TITLE
Avoid out-of-bounds section_starts_ read on invalid reloc index

### DIFF
--- a/src/binary-reader-objdump.cc
+++ b/src/binary-reader-objdump.cc
@@ -2161,7 +2161,7 @@ Result BinaryReaderObjdump::OnDylinkNeeded(std::string_view so_name) {
 }
 
 Result BinaryReaderObjdump::OnRelocCount(Index count, Index section_index) {
-  BinaryReaderObjdumpBase::OnRelocCount(count, section_index);
+  CHECK_RESULT(BinaryReaderObjdumpBase::OnRelocCount(count, section_index));
   PrintDetails("  - relocations for section: %d (" PRIstringview ") [%d]\n",
                section_index,
                WABT_PRINTF_STRING_VIEW_ARG(GetSectionName(section_index)),

--- a/test/binary/bad-relocs.txt
+++ b/test/binary/bad-relocs.txt
@@ -4,7 +4,10 @@ magic
 version
 section("reloc.BAD") {
   reloc_section[99]
-  reloc_count[0]
+  reloc_count[1]
+  reloc_type[0]  ;; R_WASM_FUNCTION_INDEX_LEB
+  offset[0]
+  index[0]
 }
 (;; STDERR ;;;
 invalid relocation section index: 99
@@ -20,7 +23,6 @@ Section Details:
 
 Custom:
  - name: "reloc.BAD"
-  - relocations for section: 99 () [0]
 
 Code Disassembly:
 


### PR DESCRIPTION
UBSan, `wasm-objdump -x` on a crafted module:

    binary-reader-objdump.cc:69:12: runtime error: index 18446744073709551615 out of bounds for type 'const Offset[14]'
        #0 BinaryReaderObjdumpBase::GetSectionStart binary-reader-objdump.cc:69
        #1 BinaryReaderObjdump::OnReloc binary-reader-objdump.cc:2176

The input is a `reloc.*` custom section whose section index points past the last section. The base `OnRelocCount` spots that, sets `reloc_section_` to `BinarySection::Invalid` (`~0`) and returns `Error` to abort the section. The details-mode override dropped that result and returned `Ok`, so `ReadRelocSection` carried on into `OnReloc`, where `GetSectionStart(reloc_section_)` reads `section_starts_[(size_t)-1]`.

`Result` is not `[[nodiscard]]`, so the dropped error built clean. Propagating it with `CHECK_RESULT` rejects the bad index the same way the other reader modes already do.

`bad-relocs.txt` used a zero relocation count, so it never reached `OnReloc`; gave it one entry so it covers the read.