### PR TITLE
[interp] Stop on first error in the binary reader fuzzer

### DIFF
--- a/fuzzers/read_binary_interp_fuzzer.cc
+++ b/fuzzers/read_binary_interp_fuzzer.cc
@@ -33,8 +33,12 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   if (data_provider.ConsumeBool()) { features.enable_##variable(); }
 #include "wabt/feature.def"
 #undef WABT_FEATURE
-  // Add only feature related options, but no logging, stop_on_first_error, etc.
-  wabt::ReadBinaryOptions options(features, nullptr, false, false, false);
+  // Add only feature related options, but no logging etc. The interp reader is
+  // only meant to read valid modules, so stop on the first error instead of
+  // continuing in collect-all-errors mode (the validator keeps counting
+  // declarations the reader has already rejected, leaving its vectors and the
+  // validator's counts out of step).
+  wabt::ReadBinaryOptions options(features, nullptr, false, true, false);
   std::vector<uint8_t> text = data_provider.ConsumeRemainingBytes<uint8_t>();
   ReadBinaryInterp("<fuzzer>", text.data(), text.size(), options, &errors,
                    &module);


### PR DESCRIPTION
The interp binary reader is only meant to read valid modules. Every `ReadBinaryInterp` caller runs with `stop_on_first_error=true` except `read_binary_interp_fuzzer.cc`, which passed `false`.

In collect-all-errors mode the `SharedValidator` keeps counting declarations the reader has already rejected. For example a function whose type index is out of range: `OnFunction` skips the append, but the validator still counts it. So the reader's `func_types_`/`module_.funcs` vectors and the validator's counts drift apart, and later callbacks index past the end (`BeginFunctionBody`, `OnExport`, `OnReturnCallExpr`).

Per the review, rather than adding reader-side guards for a mode the interp reader was never meant to support, this stops the fuzzer on the first error like every other caller, so the reader is no longer driven over invalid modules.