### PR TITLE
[validator] Allow call_indirect/return_call_indirect table elements to be subtypes of funcref

### DIFF
--- a/src/shared-validator.cc
+++ b/src/shared-validator.cc
@@ -856,7 +856,8 @@ Result SharedValidator::OnCallIndirect(const Location& loc,
   TableType table_type;
   result |= CheckFuncTypeIndex(sig_var, &func_type);
   result |= CheckTableIndex(table_var, &table_type);
-  if (table_type.element != Type::FuncRef) {
+  if (table_type.element == Type::Any ||
+      Failed(typechecker_.CheckType(table_type.element, Type::FuncRef))) {
     result |= PrintError(
         loc,
         "type mismatch: call_indirect must reference table of funcref type");
@@ -1221,7 +1222,8 @@ Result SharedValidator::OnReturnCallIndirect(const Location& loc,
   TableType table_type;
   result |= CheckFuncTypeIndex(sig_var, &func_type);
   result |= CheckTableIndex(table_var, &table_type);
-  if (table_type.element != Type::FuncRef) {
+  if (table_type.element == Type::Any ||
+      Failed(typechecker_.CheckType(table_type.element, Type::FuncRef))) {
     result |= PrintError(loc,
                          "type mismatch: return_call_indirect must reference "
                          "table of funcref type");

--- a/test/typecheck/bad-callindirect-table-externref.txt
+++ b/test/typecheck/bad-callindirect-table-externref.txt
@@ -1,0 +1,18 @@
+;;; TOOL: wat2wasm
+;;; ARGS*: --enable-all
+;;; ERROR: 1
+(module
+  (type $t (func (param i32) (result i32)))
+  (table 2 externref)
+  (elem (i32.const 0) externref (ref.null extern) (ref.null extern))
+  (func (param i32) (result i32)
+    local.get 0
+    i32.const 0
+    call_indirect (type $t)
+  )
+)
+(;; STDERR ;;;
+out/test/typecheck/bad-callindirect-table-externref.txt:11:5: error: type mismatch: call_indirect must reference table of funcref type
+    call_indirect (type $t)
+    ^^^^^^^^^^^^^
+;;; STDERR ;;)

--- a/test/typecheck/bad-returncallindirect-table-externref.txt
+++ b/test/typecheck/bad-returncallindirect-table-externref.txt
@@ -1,0 +1,18 @@
+;;; TOOL: wat2wasm
+;;; ARGS*: --enable-all
+;;; ERROR: 1
+(module
+  (type $t (func (param i32) (result i32)))
+  (table 2 externref)
+  (elem (i32.const 0) externref (ref.null extern) (ref.null extern))
+  (func (param i32) (result i32)
+    local.get 0
+    i32.const 0
+    return_call_indirect (type $t)
+  )
+)
+(;; STDERR ;;;
+out/test/typecheck/bad-returncallindirect-table-externref.txt:11:5: error: type mismatch: return_call_indirect must reference table of funcref type
+    return_call_indirect (type $t)
+    ^^^^^^^^^^^^^^^^^^^^
+;;; STDERR ;;)

--- a/test/typecheck/callindirect-typed-ref.txt
+++ b/test/typecheck/callindirect-typed-ref.txt
@@ -1,0 +1,16 @@
+;;; TOOL: wat2wasm
+;;; ARGS*: --enable-all
+(module
+  (type $sig (func (param i32) (result i32)))
+  (table 2 (ref null $sig))
+  (func (param i32) (result i32)
+    local.get 0
+    i32.const 0
+    call_indirect (type $sig)
+  )
+  (func (param i32) (result i32)
+    local.get 0
+    i32.const 0
+    return_call_indirect (type $sig)
+  )
+)


### PR DESCRIPTION
This PR resolves an issue where the validator rejects valid WebAssembly modules using typed function references (such as `(ref null $sig)`) with `call_indirect` and `return_call_indirect`. 
Currently, `SharedValidator` performs a strict equality check (`table_type.element != Type::FuncRef`), which rejects valid subtypes of `funcref` in indirect calls.
**Changes:**
- Replaced the strict equality check in `src/shared-validator.cc` with `typechecker_.CheckType` to correctly check for subtypes of `funcref`.
- Handled out-of-range table index checks to maintain compatibility with existing spec test outputs.

Fixes: #2523
