### PR TITLE
Fix DecodeInvalidOpcode for 9-bit opcode codes

### DIFF
--- a/include/wabt/opcode.h
+++ b/include/wabt/opcode.h
@@ -139,7 +139,7 @@ struct Opcode {
                                   uint32_t* out_code) {
     uint32_t prefix_code = ~static_cast<uint32_t>(e) + 1;
     *out_prefix = prefix_code >> MAX_OPCODE_BITS;
-    *out_code = prefix_code & 0xff;
+    *out_code = prefix_code & ((1 << MAX_OPCODE_BITS) - 1);
   }
 
   Info GetInfo() const;

--- a/src/test-binary-reader.cc
+++ b/src/test-binary-reader.cc
@@ -144,3 +144,14 @@ TEST(BinaryReader, OversizedSubsectionSize) {
   // Custom section errors are not fatal by default, but ensure no crash.
   (void)result;
 }
+
+TEST(Opcode, DecodeInvalidOpcode) {
+  Opcode opcode = Opcode::FromCode(0xfd, 0x13f);
+  EXPECT_TRUE(opcode.IsInvalid());
+  std::vector<uint8_t> bytes = opcode.GetBytes();
+  ASSERT_EQ(3u, bytes.size());
+  EXPECT_EQ(0xfdu, bytes[0]);
+  // 0x13f encoded as unsigned LEB128 is 0xbf 0x02.
+  EXPECT_EQ(0xbfu, bytes[1]);
+  EXPECT_EQ(0x02u, bytes[2]);
+}

--- a/test/binary/bad-opcode-prefix-leb.txt
+++ b/test/binary/bad-opcode-prefix-leb.txt
@@ -1,0 +1,16 @@
+;;; TOOL: run-gen-wasm-bad
+magic
+version
+section(TYPE) { count[1] function params[0] results[1] i32 }
+section(FUNCTION) { count[1] type[0] }
+section(CODE) {
+  count[1]
+  func {
+    locals[0]
+    invalid_op[0xfd 0xbf 0x02]
+  }
+}
+(;; STDERR ;;;
+000001b: error: unexpected opcode: 0xfd 0xbf 0x2
+000001b: error: unexpected opcode: 0xfd 0xbf 0x2
+;;; STDERR ;;)


### PR DESCRIPTION
When MAX_OPCODE_BITS was increased to 9, DecodeInvalidOpcode still used a hardcoded 0xff mask when unpacking the invalid opcode code. This caused any invalid opcode with a code >= 0x100 (such as unsupported SIMD opcodes) to be truncated to 8 bits when reported in error messages.

Use ((1 << MAX_OPCODE_BITS) - 1) instead of 0xff so that 9-bit opcode codes are correctly preserved when reporting invalid opcodes.

See #2779