### PR TITLE
wasm2c: (Security) fix runtime overflows when running Wasm modules with memory64

### DIFF
--- a/wasm2c/wasm-rt-mem-impl-helper.inc
+++ b/wasm2c/wasm-rt-mem-impl-helper.inc
@@ -141,15 +141,19 @@ static uint64_t MEMORY_API_NAME(grow_memory_impl)(MEMORY_TYPE* memory,
                                                   uint64_t delta) {
   uint64_t old_pages = memory->pages;
   uint64_t new_pages = memory->pages + delta;
-  if (new_pages == 0) {
-    return 0;
+  if (delta == 0) {
+    return old_pages;
   }
   if (new_pages < old_pages || new_pages > memory->max_pages) {
     return (uint64_t)-1;
   }
-  uint64_t old_size = old_pages * memory->page_size;
-  uint64_t new_size = new_pages * memory->page_size;
-  uint64_t delta_size = delta * memory->page_size;
+
+  uint64_t old_size, new_size, delta_size;
+  if (u64_mult_overflow(old_pages, memory->page_size, &old_size) ||
+      u64_mult_overflow(new_pages, memory->page_size, &new_size) ||
+      u64_mult_overflow(delta, memory->page_size, &delta_size)) {
+    return (uint64_t)-1;
+  }
 
   int err = MEMORY_API_NAME(expand_data_allocation)(memory, old_size, new_size,
                                                     delta_size);

--- a/wasm2c/wasm-rt-mem-impl.c
+++ b/wasm2c/wasm-rt-mem-impl.c
@@ -140,6 +140,16 @@ static uint64_t get_alloc_size_for_mmap_default32(uint64_t max_pages) {
 
 #endif /* WASM_RT_USE_MMAP */
 
+static bool u64_mult_overflow(uint64_t a, uint64_t b, uint64_t* result) {
+  uint64_t x = a * b;
+  *result = x;
+  if (a != 0 && x / a != b) {
+    // overflow
+    return true;
+  }
+  return false;
+}
+
 // Include operations for memory
 #define WASM_RT_MEM_OPS
 #include "wasm-rt-mem-impl-helper.inc"


### PR DESCRIPTION
As part of routine audit we found a bugs in the wasm2c runtime for modules supporting memory64. Memory32 is not affected. 

**Security bug** When a memory64 module calls `memory.grow` with a delta value that causes `new_pages * page_size` to overflow `uint64_t` to zero, `realloc(ptr, 0)` is called, which frees the linear memory buffer on glibc. `expand_data_allocation` then returns an error code as `realloc` returns NULL. The caller `grow_memory_impl` returns `-1` (indicating failure) without updating `memory->data`, leaving a dangling pointer. Any subsequent memory access from the Wasm module reads or writes freed heap memory. 

**Non security bug** the delta check for a `0` delta has a typo. So there is a code path where `new_pages` wraps to 0 and returns 0 indicating successful memory grow even though memory wasn't updated. Since this doesn't update the memory field, this is just a functional bug.