### PR TITLE
wasm2c: fix to check address + offset addition for memory64

### DIFF
--- a/src/c-writer.cc
+++ b/src/c-writer.cc
@@ -5335,10 +5335,18 @@ void CWriter::Write(const LoadExpr& expr) {
 
   Type result_type = expr.opcode.GetResultType();
   Write(StackVar(0, result_type), " = ", func, "(",
-        ExternalInstancePtr(ModuleFieldType::Memory, memory->name), ", (u64)(",
-        StackVar(0), ")");
-  if (expr.offset != 0)
-    Write(" + ", expr.offset, "u");
+        ExternalInstancePtr(ModuleFieldType::Memory, memory->name), ", (u64)");
+  if (expr.offset == 0) {
+    Write("(", StackVar(0), ")");
+  } else {
+    if (memory->page_limits.is_64) {
+      // two u64's being added. Use checked addition
+      Write("checked_add_u64(", StackVar(0), ", ", expr.offset, "u)");
+    } else {
+      // two u32's being added and promoted to u64
+      Write("(", StackVar(0), ") + ", expr.offset, "u");
+    }
+  }
   Write(");", Newline());
   DropTypes(1);
   PushType(result_type);

--- a/src/prebuilt/wasm2c_source_declarations.cc
+++ b/src/prebuilt/wasm2c_source_declarations.cc
@@ -165,38 +165,46 @@ R"w2c_template(  (CHECK_CALL_INDIRECT(table, ft, x),       \
 R"w2c_template(   DO_CALL_INDIRECT(table, t, x, __VA_ARGS__))
 )w2c_template"
 R"w2c_template(
-static inline bool add_overflow(uint64_t a, uint64_t b, uint64_t* resptr) {
+static inline uint64_t checked_add_u64(uint64_t a, uint64_t b) {
+)w2c_template"
+R"w2c_template(  uint64_t ret;
 )w2c_template"
 R"w2c_template(#if __has_builtin(__builtin_add_overflow)
 )w2c_template"
-R"w2c_template(  return __builtin_add_overflow(a, b, resptr);
+R"w2c_template(  if (__builtin_add_overflow(a, b, &ret))
+)w2c_template"
+R"w2c_template(    TRAP(OOB);
 )w2c_template"
 R"w2c_template(#elif defined(_MSC_VER)
 )w2c_template"
-R"w2c_template(  return _addcarry_u64(0, a, b, resptr);
+R"w2c_template(  if (_addcarry_u64(0, a, b, &ret))
+)w2c_template"
+R"w2c_template(    TRAP(OOB);
 )w2c_template"
 R"w2c_template(#else
 )w2c_template"
-R"w2c_template(#error "Missing implementation of __builtin_add_overflow or _addcarry_u64"
+R"w2c_template(  ret = a + b;
+)w2c_template"
+R"w2c_template(  if (ret < a)
+)w2c_template"
+R"w2c_template(    TRAP(OOB);
 )w2c_template"
 R"w2c_template(#endif
+)w2c_template"
+R"w2c_template(  return ret;
 )w2c_template"
 R"w2c_template(}
 )w2c_template"
 R"w2c_template(
-#define RANGE_CHECK(mem, offset, len)              \
+#define RANGE_CHECK(mem, offset, len)            \
 )w2c_template"
-R"w2c_template(  do {                                             \
+R"w2c_template(  do {                                           \
 )w2c_template"
-R"w2c_template(    uint64_t res;                                  \
+R"w2c_template(    uint64_t res = checked_add_u64(offset, len); \
 )w2c_template"
-R"w2c_template(    if (UNLIKELY(add_overflow(offset, len, &res))) \
+R"w2c_template(    if (UNLIKELY(res > (mem)->size))             \
 )w2c_template"
-R"w2c_template(      TRAP(OOB);                                   \
-)w2c_template"
-R"w2c_template(    if (UNLIKELY(res > (mem)->size))               \
-)w2c_template"
-R"w2c_template(      TRAP(OOB);                                   \
+R"w2c_template(      TRAP(OOB);                                 \
 )w2c_template"
 R"w2c_template(  } while (0);
 )w2c_template"

--- a/src/template/wasm2c.declarations.c
+++ b/src/template/wasm2c.declarations.c
@@ -89,23 +89,27 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
   (CHECK_CALL_INDIRECT(table, ft, x),       \
    DO_CALL_INDIRECT(table, t, x, __VA_ARGS__))
 
-static inline bool add_overflow(uint64_t a, uint64_t b, uint64_t* resptr) {
+static inline uint64_t checked_add_u64(uint64_t a, uint64_t b) {
+  uint64_t ret;
 #if __has_builtin(__builtin_add_overflow)
-  return __builtin_add_overflow(a, b, resptr);
+  if (__builtin_add_overflow(a, b, &ret))
+    TRAP(OOB);
 #elif defined(_MSC_VER)
-  return _addcarry_u64(0, a, b, resptr);
+  if (_addcarry_u64(0, a, b, &ret))
+    TRAP(OOB);
 #else
-#error "Missing implementation of __builtin_add_overflow or _addcarry_u64"
+  ret = a + b;
+  if (ret < a)
+    TRAP(OOB);
 #endif
+  return ret;
 }
 
-#define RANGE_CHECK(mem, offset, len)              \
-  do {                                             \
-    uint64_t res;                                  \
-    if (UNLIKELY(add_overflow(offset, len, &res))) \
-      TRAP(OOB);                                   \
-    if (UNLIKELY(res > (mem)->size))               \
-      TRAP(OOB);                                   \
+#define RANGE_CHECK(mem, offset, len)            \
+  do {                                           \
+    uint64_t res = checked_add_u64(offset, len); \
+    if (UNLIKELY(res > (mem)->size))             \
+      TRAP(OOB);                                 \
   } while (0);
 
 #if WASM_RT_USE_SEGUE_FOR_THIS_MODULE && WASM_RT_SANITY_CHECKS

--- a/test/wasm2c/add.txt
+++ b/test/wasm2c/add.txt
@@ -156,23 +156,27 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
   (CHECK_CALL_INDIRECT(table, ft, x),       \
    DO_CALL_INDIRECT(table, t, x, __VA_ARGS__))
 
-static inline bool add_overflow(uint64_t a, uint64_t b, uint64_t* resptr) {
+static inline uint64_t checked_add_u64(uint64_t a, uint64_t b) {
+  uint64_t ret;
 #if __has_builtin(__builtin_add_overflow)
-  return __builtin_add_overflow(a, b, resptr);
+  if (__builtin_add_overflow(a, b, &ret))
+    TRAP(OOB);
 #elif defined(_MSC_VER)
-  return _addcarry_u64(0, a, b, resptr);
+  if (_addcarry_u64(0, a, b, &ret))
+    TRAP(OOB);
 #else
-#error "Missing implementation of __builtin_add_overflow or _addcarry_u64"
+  ret = a + b;
+  if (ret < a)
+    TRAP(OOB);
 #endif
+  return ret;
 }
 
-#define RANGE_CHECK(mem, offset, len)              \
-  do {                                             \
-    uint64_t res;                                  \
-    if (UNLIKELY(add_overflow(offset, len, &res))) \
-      TRAP(OOB);                                   \
-    if (UNLIKELY(res > (mem)->size))               \
-      TRAP(OOB);                                   \
+#define RANGE_CHECK(mem, offset, len)            \
+  do {                                           \
+    uint64_t res = checked_add_u64(offset, len); \
+    if (UNLIKELY(res > (mem)->size))             \
+      TRAP(OOB);                                 \
   } while (0);
 
 #if WASM_RT_USE_SEGUE_FOR_THIS_MODULE && WASM_RT_SANITY_CHECKS

--- a/test/wasm2c/check-imports.txt
+++ b/test/wasm2c/check-imports.txt
@@ -181,23 +181,27 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
   (CHECK_CALL_INDIRECT(table, ft, x),       \
    DO_CALL_INDIRECT(table, t, x, __VA_ARGS__))
 
-static inline bool add_overflow(uint64_t a, uint64_t b, uint64_t* resptr) {
+static inline uint64_t checked_add_u64(uint64_t a, uint64_t b) {
+  uint64_t ret;
 #if __has_builtin(__builtin_add_overflow)
-  return __builtin_add_overflow(a, b, resptr);
+  if (__builtin_add_overflow(a, b, &ret))
+    TRAP(OOB);
 #elif defined(_MSC_VER)
-  return _addcarry_u64(0, a, b, resptr);
+  if (_addcarry_u64(0, a, b, &ret))
+    TRAP(OOB);
 #else
-#error "Missing implementation of __builtin_add_overflow or _addcarry_u64"
+  ret = a + b;
+  if (ret < a)
+    TRAP(OOB);
 #endif
+  return ret;
 }
 
-#define RANGE_CHECK(mem, offset, len)              \
-  do {                                             \
-    uint64_t res;                                  \
-    if (UNLIKELY(add_overflow(offset, len, &res))) \
-      TRAP(OOB);                                   \
-    if (UNLIKELY(res > (mem)->size))               \
-      TRAP(OOB);                                   \
+#define RANGE_CHECK(mem, offset, len)            \
+  do {                                           \
+    uint64_t res = checked_add_u64(offset, len); \
+    if (UNLIKELY(res > (mem)->size))             \
+      TRAP(OOB);                                 \
   } while (0);
 
 #if WASM_RT_USE_SEGUE_FOR_THIS_MODULE && WASM_RT_SANITY_CHECKS

--- a/test/wasm2c/export-names.txt
+++ b/test/wasm2c/export-names.txt
@@ -181,23 +181,27 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
   (CHECK_CALL_INDIRECT(table, ft, x),       \
    DO_CALL_INDIRECT(table, t, x, __VA_ARGS__))
 
-static inline bool add_overflow(uint64_t a, uint64_t b, uint64_t* resptr) {
+static inline uint64_t checked_add_u64(uint64_t a, uint64_t b) {
+  uint64_t ret;
 #if __has_builtin(__builtin_add_overflow)
-  return __builtin_add_overflow(a, b, resptr);
+  if (__builtin_add_overflow(a, b, &ret))
+    TRAP(OOB);
 #elif defined(_MSC_VER)
-  return _addcarry_u64(0, a, b, resptr);
+  if (_addcarry_u64(0, a, b, &ret))
+    TRAP(OOB);
 #else
-#error "Missing implementation of __builtin_add_overflow or _addcarry_u64"
+  ret = a + b;
+  if (ret < a)
+    TRAP(OOB);
 #endif
+  return ret;
 }
 
-#define RANGE_CHECK(mem, offset, len)              \
-  do {                                             \
-    uint64_t res;                                  \
-    if (UNLIKELY(add_overflow(offset, len, &res))) \
-      TRAP(OOB);                                   \
-    if (UNLIKELY(res > (mem)->size))               \
-      TRAP(OOB);                                   \
+#define RANGE_CHECK(mem, offset, len)            \
+  do {                                           \
+    uint64_t res = checked_add_u64(offset, len); \
+    if (UNLIKELY(res > (mem)->size))             \
+      TRAP(OOB);                                 \
   } while (0);
 
 #if WASM_RT_USE_SEGUE_FOR_THIS_MODULE && WASM_RT_SANITY_CHECKS

--- a/test/wasm2c/hello.txt
+++ b/test/wasm2c/hello.txt
@@ -188,23 +188,27 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
   (CHECK_CALL_INDIRECT(table, ft, x),       \
    DO_CALL_INDIRECT(table, t, x, __VA_ARGS__))
 
-static inline bool add_overflow(uint64_t a, uint64_t b, uint64_t* resptr) {
+static inline uint64_t checked_add_u64(uint64_t a, uint64_t b) {
+  uint64_t ret;
 #if __has_builtin(__builtin_add_overflow)
-  return __builtin_add_overflow(a, b, resptr);
+  if (__builtin_add_overflow(a, b, &ret))
+    TRAP(OOB);
 #elif defined(_MSC_VER)
-  return _addcarry_u64(0, a, b, resptr);
+  if (_addcarry_u64(0, a, b, &ret))
+    TRAP(OOB);
 #else
-#error "Missing implementation of __builtin_add_overflow or _addcarry_u64"
+  ret = a + b;
+  if (ret < a)
+    TRAP(OOB);
 #endif
+  return ret;
 }
 
-#define RANGE_CHECK(mem, offset, len)              \
-  do {                                             \
-    uint64_t res;                                  \
-    if (UNLIKELY(add_overflow(offset, len, &res))) \
-      TRAP(OOB);                                   \
-    if (UNLIKELY(res > (mem)->size))               \
-      TRAP(OOB);                                   \
+#define RANGE_CHECK(mem, offset, len)            \
+  do {                                           \
+    uint64_t res = checked_add_u64(offset, len); \
+    if (UNLIKELY(res > (mem)->size))             \
+      TRAP(OOB);                                 \
   } while (0);
 
 #if WASM_RT_USE_SEGUE_FOR_THIS_MODULE && WASM_RT_SANITY_CHECKS

--- a/test/wasm2c/minimal.txt
+++ b/test/wasm2c/minimal.txt
@@ -150,23 +150,27 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
   (CHECK_CALL_INDIRECT(table, ft, x),       \
    DO_CALL_INDIRECT(table, t, x, __VA_ARGS__))
 
-static inline bool add_overflow(uint64_t a, uint64_t b, uint64_t* resptr) {
+static inline uint64_t checked_add_u64(uint64_t a, uint64_t b) {
+  uint64_t ret;
 #if __has_builtin(__builtin_add_overflow)
-  return __builtin_add_overflow(a, b, resptr);
+  if (__builtin_add_overflow(a, b, &ret))
+    TRAP(OOB);
 #elif defined(_MSC_VER)
-  return _addcarry_u64(0, a, b, resptr);
+  if (_addcarry_u64(0, a, b, &ret))
+    TRAP(OOB);
 #else
-#error "Missing implementation of __builtin_add_overflow or _addcarry_u64"
+  ret = a + b;
+  if (ret < a)
+    TRAP(OOB);
 #endif
+  return ret;
 }
 
-#define RANGE_CHECK(mem, offset, len)              \
-  do {                                             \
-    uint64_t res;                                  \
-    if (UNLIKELY(add_overflow(offset, len, &res))) \
-      TRAP(OOB);                                   \
-    if (UNLIKELY(res > (mem)->size))               \
-      TRAP(OOB);                                   \
+#define RANGE_CHECK(mem, offset, len)            \
+  do {                                           \
+    uint64_t res = checked_add_u64(offset, len); \
+    if (UNLIKELY(res > (mem)->size))             \
+      TRAP(OOB);                                 \
   } while (0);
 
 #if WASM_RT_USE_SEGUE_FOR_THIS_MODULE && WASM_RT_SANITY_CHECKS

--- a/test/wasm2c/tail-calls.txt
+++ b/test/wasm2c/tail-calls.txt
@@ -180,23 +180,27 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
   (CHECK_CALL_INDIRECT(table, ft, x),       \
    DO_CALL_INDIRECT(table, t, x, __VA_ARGS__))
 
-static inline bool add_overflow(uint64_t a, uint64_t b, uint64_t* resptr) {
+static inline uint64_t checked_add_u64(uint64_t a, uint64_t b) {
+  uint64_t ret;
 #if __has_builtin(__builtin_add_overflow)
-  return __builtin_add_overflow(a, b, resptr);
+  if (__builtin_add_overflow(a, b, &ret))
+    TRAP(OOB);
 #elif defined(_MSC_VER)
-  return _addcarry_u64(0, a, b, resptr);
+  if (_addcarry_u64(0, a, b, &ret))
+    TRAP(OOB);
 #else
-#error "Missing implementation of __builtin_add_overflow or _addcarry_u64"
+  ret = a + b;
+  if (ret < a)
+    TRAP(OOB);
 #endif
+  return ret;
 }
 
-#define RANGE_CHECK(mem, offset, len)              \
-  do {                                             \
-    uint64_t res;                                  \
-    if (UNLIKELY(add_overflow(offset, len, &res))) \
-      TRAP(OOB);                                   \
-    if (UNLIKELY(res > (mem)->size))               \
-      TRAP(OOB);                                   \
+#define RANGE_CHECK(mem, offset, len)            \
+  do {                                           \
+    uint64_t res = checked_add_u64(offset, len); \
+    if (UNLIKELY(res > (mem)->size))             \
+      TRAP(OOB);                                 \
   } while (0);
 
 #if WASM_RT_USE_SEGUE_FOR_THIS_MODULE && WASM_RT_SANITY_CHECKS


### PR DESCRIPTION
As part of routine audit we found a bugs in the wasm2c code-generation for modules supporting memory64. Memory32 is not affected. 

The wasm2c code generator for `LoadExpr` and `StoreExpr` emits `(u64)(addr) + offset` as `uint64_t` addition. This is fine for memory32 due to the `uint64_t` promotion but hides an overflow for memory64 load/store that will violate Wasm semantics (but not break security).

When the addr and offset addition overflow in Memory64 (e.g., addr=1 + offset=0xFFFFFFFFFFFFFFFF wraps to 0), the wrapped value is passed to `i32_store`/`i32_load`, where `MEMCHECK_GENERAL` -> `RANGE_CHECK` only checks the already-wrapped (small) value against `mem->size`. The overflow is undetected and the access succeeds at the wrong address instead of trapping.
