### PR TITLE
Check size overflow and calloc failure in wasm_rt_allocate_memory

### DIFF
--- a/wasm2c/wasm-rt-mem-impl-helper.inc
+++ b/wasm2c/wasm-rt-mem-impl-helper.inc
@@ -68,7 +68,10 @@ void MEMORY_API_NAME(wasm_rt_allocate_memory)(MEMORY_TYPE* memory,
                                               uint64_t max_pages,
                                               bool is64,
                                               uint32_t page_size) {
-  uint64_t byte_length = initial_pages * page_size;
+  uint64_t byte_length;
+  if (u64_mult_overflow(initial_pages, page_size, &byte_length)) {
+    abort();
+  }
   memory->size = byte_length;
   memory->pages = initial_pages;
   memory->max_pages = max_pages;
@@ -102,6 +105,9 @@ void MEMORY_API_NAME(wasm_rt_allocate_memory)(MEMORY_TYPE* memory,
 #endif
 
   memory->data = (MEMORY_CELL_TYPE)calloc(byte_length, 1);
+  if (byte_length != 0 && !memory->data) {
+    abort();
+  }
   memory->data_end = memory->data + byte_length;
 }
 


### PR DESCRIPTION
The memory64 overflow fix in 1c7bca9 only touched grow_memory_impl. wasm_rt_allocate_memory in the same file builds the byte length the same way and was left unchecked.

    initial_pages = 1 << 47, page_size = 65536  ->  byte_length = 2^63
    calloc(2^63, 1) -> NULL
    memory->data = NULL,  memory->size = 2^63

A memory64 module may declare an initial page count the validator accepts (up to ~2^48 pages at 64 KiB). At 2^47 pages the byte length is 2^63; calloc cannot satisfy it and returns NULL, but the result is never checked. data is left NULL while size holds the full length, so every generated RANGE_CHECK passes for any guest offset below size and each access writes to NULL + offset.

The multiply is unchecked too, so an initial near 2^48 wraps the length instead. grow_memory_impl already routes both cases through u64_mult_overflow and treats failure as fatal, and the mmap branch here already aborts on failure. The calloc branch did neither.

Now the length goes through u64_mult_overflow with an abort on overflow, and calloc returning NULL for a non-zero length aborts, matching the mmap branch. Valid modules allocate as before.

Found while reading the follow-up to 1c7bca9. Reproduced by calling wasm_rt_allocate_memory with is64 and 2^47 initial pages: before, data is NULL with size 2^63; after, it aborts during instantiation.
