### PR TITLE
wasm2c: Move to O3 optimizations for wasm2c spec compliance tests

### DIFF
--- a/test/run-spec-wasm2c.py
+++ b/test/run-spec-wasm2c.py
@@ -464,14 +464,14 @@ def Compile(cc, c_filename, out_dir, use_c11, *cflags):
         args += cstd_flag + ['/nologo', '/MDd', '/c', c_filename, '/Fo' + o_filename]
     else:
         # See "Compiling the wasm2c output" section of wasm2c/README.md
-        # When compiling with -O2, GCC and clang require '-fno-optimize-sibling-calls'
+        # When compiling with -O2/-O3, GCC and clang require '-fno-optimize-sibling-calls'
         # and '-frounding-math' to maintain conformance with the spec tests
         # (GCC also requires '-fsignaling-nans')
         if use_c11:
             args.append('-std=c11')
         else:
             args.append('-std=c99')
-        args += ['-c', c_filename, '-o', o_filename, '-O2',
+        args += ['-c', c_filename, '-o', o_filename, '-O3',
                  '-Wall', '-Werror', '-Wno-unused',
                  '-Wno-array-bounds',
                  '-Wno-ignored-optimization-argument',


### PR DESCRIPTION
This fixes an inconsistency between the README for wasm2c and what the test suite has re optimization levels. The readme [indicates](https://github.com/WebAssembly/wabt/blob/main/wasm2c/README.md?plain=1#L124) that `-O3` is fine, but the [test suite](https://github.com/WebAssembly/wabt/blob/main/test/run-spec-wasm2c.py#L474) only tests with `-O2`. From my testing on GCC/clang, the wasm2c generated code works fine at `-O3` and passes the spec test suite. I think we can move the test suite to it. (If however, anyone knows of any issues with`-O3` for the spec tests or other tests, we should update the readme instead to explicitly require `-O2`)