### PR TITLE
Check memory64 addr+offset overflow in wasm2c store/atomic/simd ops

### DIFF
--- a/src/c-writer.cc
+++ b/src/c-writer.cc
@@ -5376,9 +5376,16 @@ void CWriter::Write(const StoreExpr& expr) {
   func = GetMemoryAPIString(*memory, func);
 
   Write(func, "(", ExternalInstancePtr(ModuleFieldType::Memory, memory->name),
-        ", (u64)(", StackVar(1), ")");
-  if (expr.offset != 0)
-    Write(" + ", expr.offset);
+        ", (u64)");
+  if (expr.offset == 0) {
+    Write("(", StackVar(1), ")");
+  } else if (memory->page_limits.is_64) {
+    // two u64's being added. Use checked addition
+    Write("checked_add_u64(", StackVar(1), ", ", expr.offset, "u)");
+  } else {
+    // two u32's being added and promoted to u64
+    Write("(", StackVar(1), ") + ", expr.offset);
+  }
   Write(", ", StackVar(0), ");", Newline());
   DropTypes(2);
 }
@@ -5836,11 +5843,14 @@ void CWriter::Write(const SimdLoadLaneExpr& expr) {
   Memory* memory = module_->memories[module_->GetMemoryIndex(expr.memidx)];
   Type result_type = expr.opcode.GetResultType();
   Write(StackVar(1, result_type), " = ", func, expr.val, "(",
-        ExternalInstancePtr(ModuleFieldType::Memory, memory->name), ", (u64)(",
-        StackVar(1), ")");
-
-  if (expr.offset != 0)
-    Write(" + ", expr.offset, "u");
+        ExternalInstancePtr(ModuleFieldType::Memory, memory->name), ", (u64)");
+  if (expr.offset == 0) {
+    Write("(", StackVar(1), ")");
+  } else if (memory->page_limits.is_64) {
+    Write("checked_add_u64(", StackVar(1), ", ", expr.offset, "u)");
+  } else {
+    Write("(", StackVar(1), ") + ", expr.offset, "u");
+  }
   Write(", ", StackVar(0));
   Write(");", Newline());
 
@@ -5863,11 +5873,14 @@ void CWriter::Write(const SimdStoreLaneExpr& expr) {
   Memory* memory = module_->memories[module_->GetMemoryIndex(expr.memidx)];
 
   Write(func, expr.val, "(",
-        ExternalInstancePtr(ModuleFieldType::Memory, memory->name), ", (u64)(",
-        StackVar(1), ")");
-
-  if (expr.offset != 0)
-    Write(" + ", expr.offset, "u");
+        ExternalInstancePtr(ModuleFieldType::Memory, memory->name), ", (u64)");
+  if (expr.offset == 0) {
+    Write("(", StackVar(1), ")");
+  } else if (memory->page_limits.is_64) {
+    Write("checked_add_u64(", StackVar(1), ", ", expr.offset, "u)");
+  } else {
+    Write("(", StackVar(1), ") + ", expr.offset, "u");
+  }
   Write(", ", StackVar(0));
   Write(");", Newline());
 
@@ -5909,10 +5922,14 @@ void CWriter::Write(const LoadSplatExpr& expr) {
   // clang-format on
   Type result_type = expr.opcode.GetResultType();
   Write(StackVar(0, result_type), " = ", func, "(",
-        ExternalInstancePtr(ModuleFieldType::Memory, memory->name), ", (u64)(",
-        StackVar(0), ")");
-  if (expr.offset != 0)
-    Write(" + ", expr.offset);
+        ExternalInstancePtr(ModuleFieldType::Memory, memory->name), ", (u64)");
+  if (expr.offset == 0) {
+    Write("(", StackVar(0), ")");
+  } else if (memory->page_limits.is_64) {
+    Write("checked_add_u64(", StackVar(0), ", ", expr.offset, "u)");
+  } else {
+    Write("(", StackVar(0), ") + ", expr.offset);
+  }
   Write(");", Newline());
 
   DropTypes(1);
@@ -5934,10 +5951,14 @@ void CWriter::Write(const LoadZeroExpr& expr) {
 
   Type result_type = expr.opcode.GetResultType();
   Write(StackVar(0, result_type), " = ", func, "(",
-        ExternalInstancePtr(ModuleFieldType::Memory, memory->name), ", (u64)(",
-        StackVar(0), ")");
-  if (expr.offset != 0)
-    Write(" + ", expr.offset);
+        ExternalInstancePtr(ModuleFieldType::Memory, memory->name), ", (u64)");
+  if (expr.offset == 0) {
+    Write("(", StackVar(0), ")");
+  } else if (memory->page_limits.is_64) {
+    Write("checked_add_u64(", StackVar(0), ", ", expr.offset, "u)");
+  } else {
+    Write("(", StackVar(0), ") + ", expr.offset);
+  }
   Write(");", Newline());
 
   DropTypes(1);
@@ -5966,10 +5987,14 @@ void CWriter::Write(const AtomicLoadExpr& expr) {
 
   Type result_type = expr.opcode.GetResultType();
   Write(StackVar(0, result_type), " = ", func, "(",
-        ExternalInstancePtr(ModuleFieldType::Memory, memory->name), ", (u64)(",
-        StackVar(0), ")");
-  if (expr.offset != 0)
-    Write(" + ", expr.offset, "u");
+        ExternalInstancePtr(ModuleFieldType::Memory, memory->name), ", (u64)");
+  if (expr.offset == 0) {
+    Write("(", StackVar(0), ")");
+  } else if (memory->page_limits.is_64) {
+    Write("checked_add_u64(", StackVar(0), ", ", expr.offset, "u)");
+  } else {
+    Write("(", StackVar(0), ") + ", expr.offset, "u");
+  }
   Write(");", Newline());
   DropTypes(1);
   PushType(result_type);
@@ -5996,9 +6021,14 @@ void CWriter::Write(const AtomicStoreExpr& expr) {
   func = GetMemoryAPIString(*memory, func);
 
   Write(func, "(", ExternalInstancePtr(ModuleFieldType::Memory, memory->name),
-        ", (u64)(", StackVar(1), ")");
-  if (expr.offset != 0)
-    Write(" + ", expr.offset);
+        ", (u64)");
+  if (expr.offset == 0) {
+    Write("(", StackVar(1), ")");
+  } else if (memory->page_limits.is_64) {
+    Write("checked_add_u64(", StackVar(1), ", ", expr.offset, "u)");
+  } else {
+    Write("(", StackVar(1), ") + ", expr.offset);
+  }
   Write(", ", StackVar(0), ");", Newline());
   DropTypes(2);
 }
@@ -6060,10 +6090,14 @@ void CWriter::Write(const AtomicRmwExpr& expr) {
   Type result_type = expr.opcode.GetResultType();
 
   Write(StackVar(1, result_type), " = ", func, "(",
-        ExternalInstancePtr(ModuleFieldType::Memory, memory->name), ", (u64)(",
-        StackVar(1), ")");
-  if (expr.offset != 0)
-    Write(" + ", expr.offset);
+        ExternalInstancePtr(ModuleFieldType::Memory, memory->name), ", (u64)");
+  if (expr.offset == 0) {
+    Write("(", StackVar(1), ")");
+  } else if (memory->page_limits.is_64) {
+    Write("checked_add_u64(", StackVar(1), ", ", expr.offset, "u)");
+  } else {
+    Write("(", StackVar(1), ") + ", expr.offset);
+  }
   Write(", ", StackVar(0), ");", Newline());
   DropTypes(2);
   PushType(result_type);
@@ -6091,10 +6125,14 @@ void CWriter::Write(const AtomicRmwCmpxchgExpr& expr) {
   Type result_type = expr.opcode.GetResultType();
 
   Write(StackVar(2, result_type), " = ", func, "(",
-        ExternalInstancePtr(ModuleFieldType::Memory, memory->name), ", (u64)(",
-        StackVar(2), ")");
-  if (expr.offset != 0)
-    Write(" + ", expr.offset);
+        ExternalInstancePtr(ModuleFieldType::Memory, memory->name), ", (u64)");
+  if (expr.offset == 0) {
+    Write("(", StackVar(2), ")");
+  } else if (memory->page_limits.is_64) {
+    Write("checked_add_u64(", StackVar(2), ", ", expr.offset, "u)");
+  } else {
+    Write("(", StackVar(2), ") + ", expr.offset);
+  }
   Write(", ", StackVar(1), ", ", StackVar(0), ");", Newline());
   DropTypes(3);
   PushType(result_type);

--- a/src/c-writer.cc
+++ b/src/c-writer.cc
@@ -469,6 +469,9 @@ class CWriter {
   void Write(const BinaryExpr&);
   void Write(const CompareExpr&);
   void Write(const ConvertExpr&);
+  void WriteMemoryAddress(Index stack_index,
+                          const Memory* memory,
+                          Address offset);
   void Write(const LoadExpr&);
   void Write(const StoreExpr&);
   void Write(const UnaryExpr&);
@@ -5299,6 +5302,24 @@ void CWriter::Write(const ConvertExpr& expr) {
   }
 }
 
+// Write the address operand of a memory access: the addend from the stack
+// plus the constant offset. For a 64-bit memory both values are u64, so the
+// addition can wrap; use checked addition, which traps on overflow. For a
+// 32-bit memory both values are u32 promoted to u64, so the addition cannot
+// overflow.
+void CWriter::WriteMemoryAddress(Index stack_index,
+                                 const Memory* memory,
+                                 Address offset) {
+  Write("(u64)");
+  if (offset == 0) {
+    Write("(", StackVar(stack_index), ")");
+  } else if (memory->page_limits.is_64) {
+    Write("checked_add_u64(", StackVar(stack_index), ", ", offset, "u)");
+  } else {
+    Write("(", StackVar(stack_index), ") + ", offset, "u");
+  }
+}
+
 void CWriter::Write(const LoadExpr& expr) {
   std::string func;
   // clang-format off
@@ -5335,18 +5356,8 @@ void CWriter::Write(const LoadExpr& expr) {
 
   Type result_type = expr.opcode.GetResultType();
   Write(StackVar(0, result_type), " = ", func, "(",
-        ExternalInstancePtr(ModuleFieldType::Memory, memory->name), ", (u64)");
-  if (expr.offset == 0) {
-    Write("(", StackVar(0), ")");
-  } else {
-    if (memory->page_limits.is_64) {
-      // two u64's being added. Use checked addition
-      Write("checked_add_u64(", StackVar(0), ", ", expr.offset, "u)");
-    } else {
-      // two u32's being added and promoted to u64
-      Write("(", StackVar(0), ") + ", expr.offset, "u");
-    }
-  }
+        ExternalInstancePtr(ModuleFieldType::Memory, memory->name), ", ");
+  WriteMemoryAddress(0, memory, expr.offset);
   Write(");", Newline());
   DropTypes(1);
   PushType(result_type);
@@ -5376,16 +5387,8 @@ void CWriter::Write(const StoreExpr& expr) {
   func = GetMemoryAPIString(*memory, func);
 
   Write(func, "(", ExternalInstancePtr(ModuleFieldType::Memory, memory->name),
-        ", (u64)");
-  if (expr.offset == 0) {
-    Write("(", StackVar(1), ")");
-  } else if (memory->page_limits.is_64) {
-    // two u64's being added. Use checked addition
-    Write("checked_add_u64(", StackVar(1), ", ", expr.offset, "u)");
-  } else {
-    // two u32's being added and promoted to u64
-    Write("(", StackVar(1), ") + ", expr.offset);
-  }
+        ", ");
+  WriteMemoryAddress(1, memory, expr.offset);
   Write(", ", StackVar(0), ");", Newline());
   DropTypes(2);
 }
@@ -5843,14 +5846,8 @@ void CWriter::Write(const SimdLoadLaneExpr& expr) {
   Memory* memory = module_->memories[module_->GetMemoryIndex(expr.memidx)];
   Type result_type = expr.opcode.GetResultType();
   Write(StackVar(1, result_type), " = ", func, expr.val, "(",
-        ExternalInstancePtr(ModuleFieldType::Memory, memory->name), ", (u64)");
-  if (expr.offset == 0) {
-    Write("(", StackVar(1), ")");
-  } else if (memory->page_limits.is_64) {
-    Write("checked_add_u64(", StackVar(1), ", ", expr.offset, "u)");
-  } else {
-    Write("(", StackVar(1), ") + ", expr.offset, "u");
-  }
+        ExternalInstancePtr(ModuleFieldType::Memory, memory->name), ", ");
+  WriteMemoryAddress(1, memory, expr.offset);
   Write(", ", StackVar(0));
   Write(");", Newline());
 
@@ -5873,14 +5870,8 @@ void CWriter::Write(const SimdStoreLaneExpr& expr) {
   Memory* memory = module_->memories[module_->GetMemoryIndex(expr.memidx)];
 
   Write(func, expr.val, "(",
-        ExternalInstancePtr(ModuleFieldType::Memory, memory->name), ", (u64)");
-  if (expr.offset == 0) {
-    Write("(", StackVar(1), ")");
-  } else if (memory->page_limits.is_64) {
-    Write("checked_add_u64(", StackVar(1), ", ", expr.offset, "u)");
-  } else {
-    Write("(", StackVar(1), ") + ", expr.offset, "u");
-  }
+        ExternalInstancePtr(ModuleFieldType::Memory, memory->name), ", ");
+  WriteMemoryAddress(1, memory, expr.offset);
   Write(", ", StackVar(0));
   Write(");", Newline());
 
@@ -5922,14 +5913,8 @@ void CWriter::Write(const LoadSplatExpr& expr) {
   // clang-format on
   Type result_type = expr.opcode.GetResultType();
   Write(StackVar(0, result_type), " = ", func, "(",
-        ExternalInstancePtr(ModuleFieldType::Memory, memory->name), ", (u64)");
-  if (expr.offset == 0) {
-    Write("(", StackVar(0), ")");
-  } else if (memory->page_limits.is_64) {
-    Write("checked_add_u64(", StackVar(0), ", ", expr.offset, "u)");
-  } else {
-    Write("(", StackVar(0), ") + ", expr.offset);
-  }
+        ExternalInstancePtr(ModuleFieldType::Memory, memory->name), ", ");
+  WriteMemoryAddress(0, memory, expr.offset);
   Write(");", Newline());
 
   DropTypes(1);
@@ -5951,14 +5936,8 @@ void CWriter::Write(const LoadZeroExpr& expr) {
 
   Type result_type = expr.opcode.GetResultType();
   Write(StackVar(0, result_type), " = ", func, "(",
-        ExternalInstancePtr(ModuleFieldType::Memory, memory->name), ", (u64)");
-  if (expr.offset == 0) {
-    Write("(", StackVar(0), ")");
-  } else if (memory->page_limits.is_64) {
-    Write("checked_add_u64(", StackVar(0), ", ", expr.offset, "u)");
-  } else {
-    Write("(", StackVar(0), ") + ", expr.offset);
-  }
+        ExternalInstancePtr(ModuleFieldType::Memory, memory->name), ", ");
+  WriteMemoryAddress(0, memory, expr.offset);
   Write(");", Newline());
 
   DropTypes(1);
@@ -5987,14 +5966,8 @@ void CWriter::Write(const AtomicLoadExpr& expr) {
 
   Type result_type = expr.opcode.GetResultType();
   Write(StackVar(0, result_type), " = ", func, "(",
-        ExternalInstancePtr(ModuleFieldType::Memory, memory->name), ", (u64)");
-  if (expr.offset == 0) {
-    Write("(", StackVar(0), ")");
-  } else if (memory->page_limits.is_64) {
-    Write("checked_add_u64(", StackVar(0), ", ", expr.offset, "u)");
-  } else {
-    Write("(", StackVar(0), ") + ", expr.offset, "u");
-  }
+        ExternalInstancePtr(ModuleFieldType::Memory, memory->name), ", ");
+  WriteMemoryAddress(0, memory, expr.offset);
   Write(");", Newline());
   DropTypes(1);
   PushType(result_type);
@@ -6021,14 +5994,8 @@ void CWriter::Write(const AtomicStoreExpr& expr) {
   func = GetMemoryAPIString(*memory, func);
 
   Write(func, "(", ExternalInstancePtr(ModuleFieldType::Memory, memory->name),
-        ", (u64)");
-  if (expr.offset == 0) {
-    Write("(", StackVar(1), ")");
-  } else if (memory->page_limits.is_64) {
-    Write("checked_add_u64(", StackVar(1), ", ", expr.offset, "u)");
-  } else {
-    Write("(", StackVar(1), ") + ", expr.offset);
-  }
+        ", ");
+  WriteMemoryAddress(1, memory, expr.offset);
   Write(", ", StackVar(0), ");", Newline());
   DropTypes(2);
 }
@@ -6090,14 +6057,8 @@ void CWriter::Write(const AtomicRmwExpr& expr) {
   Type result_type = expr.opcode.GetResultType();
 
   Write(StackVar(1, result_type), " = ", func, "(",
-        ExternalInstancePtr(ModuleFieldType::Memory, memory->name), ", (u64)");
-  if (expr.offset == 0) {
-    Write("(", StackVar(1), ")");
-  } else if (memory->page_limits.is_64) {
-    Write("checked_add_u64(", StackVar(1), ", ", expr.offset, "u)");
-  } else {
-    Write("(", StackVar(1), ") + ", expr.offset);
-  }
+        ExternalInstancePtr(ModuleFieldType::Memory, memory->name), ", ");
+  WriteMemoryAddress(1, memory, expr.offset);
   Write(", ", StackVar(0), ");", Newline());
   DropTypes(2);
   PushType(result_type);
@@ -6125,14 +6086,8 @@ void CWriter::Write(const AtomicRmwCmpxchgExpr& expr) {
   Type result_type = expr.opcode.GetResultType();
 
   Write(StackVar(2, result_type), " = ", func, "(",
-        ExternalInstancePtr(ModuleFieldType::Memory, memory->name), ", (u64)");
-  if (expr.offset == 0) {
-    Write("(", StackVar(2), ")");
-  } else if (memory->page_limits.is_64) {
-    Write("checked_add_u64(", StackVar(2), ", ", expr.offset, "u)");
-  } else {
-    Write("(", StackVar(2), ") + ", expr.offset);
-  }
+        ExternalInstancePtr(ModuleFieldType::Memory, memory->name), ", ");
+  WriteMemoryAddress(2, memory, expr.offset);
   Write(", ", StackVar(1), ", ", StackVar(0), ");", Newline());
   DropTypes(3);
   PushType(result_type);


### PR DESCRIPTION
Comparing wasm2c output either side of 4bedf7c ("check address + offset addition for memory64"):

    // load  (fixed in 4bedf7c)
    i64_load(&M0, (u64)checked_add_u64(var_j0, 16u));
    // store (still unchecked)
    i64_store(&M0, (u64)(var_j0) + 16, var_j1);

That commit only converted `CWriter::Write(const LoadExpr&)`. For an i64 memory the store still adds the static offset with a wrapping `+`, and so do the SIMD lane/splat/zero and atomic emitters.

How I hit it: memory64 module, `i64.store offset=16` at address `0xFFFFFFFFFFFFFFF0`. The sum overflows u64 to 0, the generated `RANGE_CHECK` sees an in-range address, and the write lands at guest address 0. Per the spec that access should trap; the load form already does after 4bedf7c.

Applied the same `checked_add_u64` guard to `StoreExpr`, `SimdLoadLaneExpr`, `SimdStoreLaneExpr`, `LoadSplatExpr`, `LoadZeroExpr`, `AtomicLoadExpr`, `AtomicStoreExpr`, `AtomicRmwExpr` and `AtomicRmwCmpxchgExpr` for `is_64` memories. The 32-bit output is byte for byte unchanged. The wasm2c spec tests (memory64, threads, simd) still pass.