### PR TITLE
Mark Result as [[nodiscard]] and fix associated errors

### DIFF
--- a/include/wabt/result.h
+++ b/include/wabt/result.h
@@ -19,7 +19,7 @@
 
 namespace wabt {
 
-struct Result {
+struct [[nodiscard]] Result {
   enum Enum {
     Ok,
     Error,

--- a/include/wabt/shared-validator.h
+++ b/include/wabt/shared-validator.h
@@ -63,7 +63,7 @@ class SharedValidator {
     return typechecker_.GetCatchCount(depth, out_count);
   }
 
-  Result WABT_PRINTF_FORMAT(3, 4)
+  void WABT_PRINTF_FORMAT(3, 4)
       PrintError(const Location& loc, const char* fmt, ...);
 
   void OnTypecheckerError(const char* msg);
@@ -343,8 +343,8 @@ class SharedValidator {
 
   TypeVector ToTypeVector(Index count, const Type* types);
 
-  void SaveLocalRefs();
-  void RestoreLocalRefs(Result result);
+  Result SaveLocalRefs();
+  Result RestoreLocalRefs(Result result);
   void IgnoreLocalRefs();
 
   ValidateOptions options_;

--- a/include/wabt/type-checker.h
+++ b/include/wabt/type-checker.h
@@ -176,7 +176,7 @@ class TypeChecker {
   void PushLabel(LabelType label_type,
                  const TypeVector& param_types,
                  const TypeVector& result_types);
-  Result PopLabel();
+  void PopLabel();
   Result CheckLabelType(Label* label, LabelType label_type);
   Result Check2LabelTypes(Label* label,
                           LabelType label_type1,

--- a/src/apply-names.cc
+++ b/src/apply-names.cc
@@ -351,7 +351,7 @@ Result NameApplier::OnBrOnNullExpr(BrOnNullExpr* expr) {
 
 Result NameApplier::OnBrTableExpr(BrTableExpr* expr) {
   for (Var& target : expr->targets) {
-    UseNameForLabelVar(&target);
+    CHECK_RESULT(UseNameForLabelVar(&target));
   }
 
   return UseNameForLabelVar(&expr->default_target);
@@ -372,7 +372,7 @@ Result NameApplier::BeginTryTableExpr(TryTableExpr* expr) {
     if (!catch_.IsCatchAll()) {
       CHECK_RESULT(UseNameForTagVar(&catch_.tag));
     }
-    UseNameForLabelVar(&catch_.target);
+    CHECK_RESULT(UseNameForLabelVar(&catch_.target));
   }
   PushLabel(expr->block.label);
   return Result::Ok;
@@ -499,23 +499,23 @@ Result NameApplier::VisitTag(Tag* tag) {
 Result NameApplier::VisitExport(Index export_index, Export* export_) {
   switch (export_->kind) {
     case ExternalKind::Func:
-      UseNameForFuncVar(&export_->var);
+      CHECK_RESULT(UseNameForFuncVar(&export_->var));
       break;
 
     case ExternalKind::Table:
-      UseNameForTableVar(&export_->var);
+      CHECK_RESULT(UseNameForTableVar(&export_->var));
       break;
 
     case ExternalKind::Memory:
-      UseNameForMemoryVar(&export_->var);
+      CHECK_RESULT(UseNameForMemoryVar(&export_->var));
       break;
 
     case ExternalKind::Global:
-      UseNameForGlobalVar(&export_->var);
+      CHECK_RESULT(UseNameForGlobalVar(&export_->var));
       break;
 
     case ExternalKind::Tag:
-      UseNameForTagVar(&export_->var);
+      CHECK_RESULT(UseNameForTagVar(&export_->var));
       break;
   }
   return Result::Ok;

--- a/src/binary-reader-ir.cc
+++ b/src/binary-reader-ir.cc
@@ -1338,7 +1338,7 @@ Result BinaryReaderIR::OnDelegateExpr(Index depth) {
 
   try_->delegate_target = Var(depth, GetLocation());
 
-  PopLabel();
+  CHECK_RESULT(PopLabel());
   return Result::Ok;
 }
 
@@ -1692,25 +1692,25 @@ Result BinaryReaderIR::OnNameEntry(NameSectionSubsection type,
     case NameSectionSubsection::Field:
       break;
     case NameSectionSubsection::Type:
-      SetTypeName(index, name);
+      return SetTypeName(index, name);
       break;
     case NameSectionSubsection::Tag:
-      SetTagName(index, name);
+      return SetTagName(index, name);
       break;
     case NameSectionSubsection::Global:
-      SetGlobalName(index, name);
+      return SetGlobalName(index, name);
       break;
     case NameSectionSubsection::Table:
-      SetTableName(index, name);
+      return SetTableName(index, name);
       break;
     case NameSectionSubsection::DataSegment:
-      SetDataSegmentName(index, name);
+      return SetDataSegmentName(index, name);
       break;
     case NameSectionSubsection::Memory:
-      SetMemoryName(index, name);
+      return SetMemoryName(index, name);
       break;
     case NameSectionSubsection::ElemSegment:
-      SetElemSegmentName(index, name);
+      return SetElemSegmentName(index, name);
       break;
   }
   return Result::Ok;

--- a/src/binary-reader-objdump.cc
+++ b/src/binary-reader-objdump.cc
@@ -238,7 +238,8 @@ class BinaryReaderObjdumpPrepass : public BinaryReaderObjdumpBase {
   Result BeginSection(Index section_index,
                       BinarySection section_code,
                       Offset size) override {
-    BinaryReaderObjdumpBase::BeginSection(section_index, section_code, size);
+    CHECK_RESULT(BinaryReaderObjdumpBase::BeginSection(section_index,
+                                                       section_code, size));
     if (section_code != BinarySection::Custom) {
       objdump_state_->section_names.Set(section_index,
                                         wabt::GetSectionName(section_code));
@@ -501,7 +502,7 @@ Result BinaryReaderObjdumpPrepass::OnReloc(RelocType type,
                                            Offset offset,
                                            Index index,
                                            uint32_t addend) {
-  BinaryReaderObjdumpBase::OnReloc(type, offset, index, addend);
+  CHECK_RESULT(BinaryReaderObjdumpBase::OnReloc(type, offset, index, addend));
   if (reloc_section_ == BinarySection::Code) {
     objdump_state_->code_relocations.emplace_back(type, offset, index, addend);
   } else if (reloc_section_ == BinarySection::Data) {
@@ -576,7 +577,7 @@ std::string BinaryReaderObjdumpDisassemble::BlockSigToString(Type type) const {
 }
 
 Result BinaryReaderObjdumpDisassemble::OnOpcode(Opcode opcode) {
-  BinaryReaderObjdumpBase::OnOpcode(opcode);
+  CHECK_RESULT(BinaryReaderObjdumpBase::OnOpcode(opcode));
   if (!in_function_body) {
     return Result::Ok;
   }
@@ -1345,7 +1346,8 @@ Result BinaryReaderObjdump::BeginCustomSection(Index section_index,
 Result BinaryReaderObjdump::BeginSection(Index section_index,
                                          BinarySection section_code,
                                          Offset size) {
-  BinaryReaderObjdumpBase::BeginSection(section_index, section_code, size);
+  CHECK_RESULT(
+      BinaryReaderObjdumpBase::BeginSection(section_index, section_code, size));
 
   // |section_name| and |match_name| are identical for known sections. For
   // custom sections, |section_name| is "Custom", but |match_name| is the name
@@ -1993,7 +1995,7 @@ Result BinaryReaderObjdump::OnRefNullExpr(Type type) {
 }
 
 Result BinaryReaderObjdump::OnOpcode(Opcode opcode) {
-  BinaryReaderObjdumpBase::OnOpcode(opcode);
+  CHECK_RESULT(BinaryReaderObjdumpBase::OnOpcode(opcode));
   if (ReadingInitExpr() && opcode != Opcode::End) {
     InitInst i{};
     i.opcode = current_opcode;

--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -98,57 +98,51 @@ class BinaryReader {
   };
 
   void WABT_PRINTF_FORMAT(2, 3) PrintError(const char* format, ...);
-  [[nodiscard]] Result ReadOpcode(Opcode* out_value, const char* desc);
+  Result ReadOpcode(Opcode* out_value, const char* desc);
   template <typename T>
-  [[nodiscard]] Result ReadT(T* out_value,
-                             const char* type_name,
-                             const char* desc);
+  Result ReadT(T* out_value, const char* type_name, const char* desc);
   template <typename T,
             char prefix,
             size_t (*ReadFn)(const uint8_t*, const uint8_t*, T*)>
-  [[nodiscard]] Result ReadLeb128(T* out_value, const char* desc);
-  [[nodiscard]] Result ReadU8(uint8_t* out_value, const char* desc);
-  [[nodiscard]] Result ReadU16(uint16_t* out_value, const char* desc);
-  [[nodiscard]] Result ReadU32(uint32_t* out_value, const char* desc);
-  [[nodiscard]] Result ReadF32(uint32_t* out_value, const char* desc);
-  [[nodiscard]] Result ReadF64(uint64_t* out_value, const char* desc);
-  [[nodiscard]] Result ReadV128(v128* out_value, const char* desc);
-  [[nodiscard]] Result ReadU32Leb128(uint32_t* out_value, const char* desc);
-  [[nodiscard]] Result ReadU64Leb128(uint64_t* out_value, const char* desc);
-  [[nodiscard]] Result ReadU32OrU64Leb128(uint64_t* out_value,
-                                          bool is_64,
-                                          const char* desc);
-  [[nodiscard]] Result ReadS32Leb128(uint32_t* out_value, const char* desc);
-  [[nodiscard]] Result ReadS64Leb128(uint64_t* out_value, const char* desc);
-  [[nodiscard]] Result ReadType(Type* out_value, const char* desc);
-  [[nodiscard]] Result ReadRefType(Type* out_value, const char* desc);
-  [[nodiscard]] Result ReadExternalKind(ExternalKind* out_value,
-                                        const char* desc,
-                                        const char* type);
-  [[nodiscard]] Result ReadStr(std::string_view* out_str, const char* desc);
-  [[nodiscard]] Result ReadBytes(ByteSpan* out_data, const char* desc);
-  [[nodiscard]] Result ReadBytesWithSize(ByteSpan* out_data,
-                                         Offset size,
-                                         const char* desc);
-  [[nodiscard]] Result ReadIndex(Index* index, const char* desc);
-  [[nodiscard]] Result ReadOffset(Offset* offset, const char* desc);
-  [[nodiscard]] Result ReadAlignment(Address* align_log2, const char* desc);
-  [[nodiscard]] Result CheckAlignment(Address* align_log2, const char* desc);
-  [[nodiscard]] Result TakeHasMemidx(Address* align_log2, bool* has_memidx);
-  [[nodiscard]] Result ReadMemidx(Index* memidx, const char* desc);
-  [[nodiscard]] Result ReadMemLocation(Address* alignment_log2,
-                                       Index* memidx,
-                                       Address* offset,
-                                       const char* desc_align,
-                                       const char* desc_memidx,
-                                       const char* desc_offset,
-                                       uint8_t* lane_val = nullptr);
-  [[nodiscard]] Result CallbackMemLocation(const Address* alignment_log2,
-                                           const Index* memidx,
-                                           const Address* offset,
-                                           const uint8_t* lane_val = nullptr);
-  [[nodiscard]] Result ReadCount(Index* index, const char* desc);
-  [[nodiscard]] Result ReadField(TypeMut* out_value);
+  Result ReadLeb128(T* out_value, const char* desc);
+  Result ReadU8(uint8_t* out_value, const char* desc);
+  Result ReadU16(uint16_t* out_value, const char* desc);
+  Result ReadU32(uint32_t* out_value, const char* desc);
+  Result ReadF32(uint32_t* out_value, const char* desc);
+  Result ReadF64(uint64_t* out_value, const char* desc);
+  Result ReadV128(v128* out_value, const char* desc);
+  Result ReadU32Leb128(uint32_t* out_value, const char* desc);
+  Result ReadU64Leb128(uint64_t* out_value, const char* desc);
+  Result ReadU32OrU64Leb128(uint64_t* out_value, bool is_64, const char* desc);
+  Result ReadS32Leb128(uint32_t* out_value, const char* desc);
+  Result ReadS64Leb128(uint64_t* out_value, const char* desc);
+  Result ReadType(Type* out_value, const char* desc);
+  Result ReadRefType(Type* out_value, const char* desc);
+  Result ReadExternalKind(ExternalKind* out_value,
+                          const char* desc,
+                          const char* type);
+  Result ReadStr(std::string_view* out_str, const char* desc);
+  Result ReadBytes(ByteSpan* out_data, const char* desc);
+  Result ReadBytesWithSize(ByteSpan* out_data, Offset size, const char* desc);
+  Result ReadIndex(Index* index, const char* desc);
+  Result ReadOffset(Offset* offset, const char* desc);
+  Result ReadAlignment(Address* align_log2, const char* desc);
+  Result CheckAlignment(Address* align_log2, const char* desc);
+  Result TakeHasMemidx(Address* align_log2, bool* has_memidx);
+  Result ReadMemidx(Index* memidx, const char* desc);
+  Result ReadMemLocation(Address* alignment_log2,
+                         Index* memidx,
+                         Address* offset,
+                         const char* desc_align,
+                         const char* desc_memidx,
+                         const char* desc_offset,
+                         uint8_t* lane_val = nullptr);
+  Result CallbackMemLocation(const Address* alignment_log2,
+                             const Index* memidx,
+                             const Address* offset,
+                             const uint8_t* lane_val = nullptr);
+  Result ReadCount(Index* index, const char* desc);
+  Result ReadField(TypeMut* out_value);
 
   bool IsConcreteReferenceType(Type::Enum);
   bool IsConcreteType(Type);
@@ -156,48 +150,42 @@ class BinaryReader {
 
   Index NumTotalFuncs();
 
-  [[nodiscard]] Result ReadInitExpr(Index index);
-  [[nodiscard]] Result ReadTable(Limits* out_elem_limits);
-  [[nodiscard]] Result ReadMemory(Limits* out_page_limits,
-                                  uint32_t* out_page_size);
-  [[nodiscard]] Result ReadGlobalHeader(Type* out_type, bool* out_mutable);
-  [[nodiscard]] Result ReadTagType(Index* out_sig_index);
-  [[nodiscard]] Result ReadAddress(Address* out_value,
-                                   Index memory,
-                                   const char* desc);
-  [[nodiscard]] Result ReadFunctionBody(Offset end_offset);
+  Result ReadInitExpr(Index index);
+  Result ReadTable(Limits* out_elem_limits);
+  Result ReadMemory(Limits* out_page_limits, uint32_t* out_page_size);
+  Result ReadGlobalHeader(Type* out_type, bool* out_mutable);
+  Result ReadTagType(Index* out_sig_index);
+  Result ReadAddress(Address* out_value, Index memory, const char* desc);
+  Result ReadFunctionBody(Offset end_offset);
   // ReadInstructions reads until end_offset or the nesting depth reaches zero.
-  [[nodiscard]] Result ReadInstructions(Offset end_offset, const char* context);
-  [[nodiscard]] Result ReadNameSection(Offset section_size);
-  [[nodiscard]] Result ReadRelocSection(Offset section_size);
-  [[nodiscard]] Result ReadDylinkSection(Offset section_size);
-  [[nodiscard]] Result ReadGenericCustomSection(std::string_view name,
-                                                Offset section_size);
-  [[nodiscard]] Result ReadDylink0Section(Offset section_size);
-  [[nodiscard]] Result ReadTargetFeaturesSections(Offset section_size);
-  [[nodiscard]] Result ReadLinkingSection(Offset section_size);
-  [[nodiscard]] Result ReadCodeMetadataSection(std::string_view name,
-                                               Offset section_size);
-  [[nodiscard]] Result ReadCustomSection(Index section_index,
-                                         Offset section_size);
-  [[nodiscard]] Result ReadTypeSection(Offset section_size);
-  [[nodiscard]] Result ReadImport(Index i,
-                                  std::string_view module_name,
-                                  std::string_view field_name,
-                                  ExternalKind kind);
-  [[nodiscard]] Result ReadImportSection(Offset section_size);
-  [[nodiscard]] Result ReadFunctionSection(Offset section_size);
-  [[nodiscard]] Result ReadTableSection(Offset section_size);
-  [[nodiscard]] Result ReadMemorySection(Offset section_size);
-  [[nodiscard]] Result ReadGlobalSection(Offset section_size);
-  [[nodiscard]] Result ReadExportSection(Offset section_size);
-  [[nodiscard]] Result ReadStartSection(Offset section_size);
-  [[nodiscard]] Result ReadElemSection(Offset section_size);
-  [[nodiscard]] Result ReadCodeSection(Offset section_size);
-  [[nodiscard]] Result ReadDataSection(Offset section_size);
-  [[nodiscard]] Result ReadDataCountSection(Offset section_size);
-  [[nodiscard]] Result ReadTagSection(Offset section_size);
-  [[nodiscard]] Result ReadSections(const ReadSectionsOptions& options);
+  Result ReadInstructions(Offset end_offset, const char* context);
+  Result ReadNameSection(Offset section_size);
+  Result ReadRelocSection(Offset section_size);
+  Result ReadDylinkSection(Offset section_size);
+  Result ReadGenericCustomSection(std::string_view name, Offset section_size);
+  Result ReadDylink0Section(Offset section_size);
+  Result ReadTargetFeaturesSections(Offset section_size);
+  Result ReadLinkingSection(Offset section_size);
+  Result ReadCodeMetadataSection(std::string_view name, Offset section_size);
+  Result ReadCustomSection(Index section_index, Offset section_size);
+  Result ReadTypeSection(Offset section_size);
+  Result ReadImport(Index i,
+                    std::string_view module_name,
+                    std::string_view field_name,
+                    ExternalKind kind);
+  Result ReadImportSection(Offset section_size);
+  Result ReadFunctionSection(Offset section_size);
+  Result ReadTableSection(Offset section_size);
+  Result ReadMemorySection(Offset section_size);
+  Result ReadGlobalSection(Offset section_size);
+  Result ReadExportSection(Offset section_size);
+  Result ReadStartSection(Offset section_size);
+  Result ReadElemSection(Offset section_size);
+  Result ReadCodeSection(Offset section_size);
+  Result ReadDataSection(Offset section_size);
+  Result ReadDataCountSection(Offset section_size);
+  Result ReadTagSection(Offset section_size);
+  Result ReadSections(const ReadSectionsOptions& options);
   Result ReportUnexpectedOpcode(Opcode opcode, const char* message = nullptr);
 
   size_t read_end_ = 0;  // Either the section end or data_size.

--- a/src/error-formatter.cc
+++ b/src/error-formatter.cc
@@ -53,7 +53,8 @@ std::string FormatError(const Error& error,
 
   LexerSourceLineFinder::SourceLine source_line;
   if (line_finder) {
-    line_finder->GetSourceLine(loc, source_line_max_length, &source_line);
+    // TODO: how should we handle errors?
+    (void)line_finder->GetSourceLine(loc, source_line_max_length, &source_line);
   }
 
   if (!source_line.line.empty()) {

--- a/src/generate-names.cc
+++ b/src/generate-names.cc
@@ -417,14 +417,16 @@ Result NameGenerator::VisitModule(Module* module) {
     CHECK_RESULT(VisitExport(export_));
   }
 
-  VisitAll(module->globals, &NameGenerator::VisitGlobal);
-  VisitAll(module->types, &NameGenerator::VisitType);
-  VisitAll(module->funcs, &NameGenerator::VisitFunc);
-  VisitAll(module->tables, &NameGenerator::VisitTable);
-  VisitAll(module->memories, &NameGenerator::VisitMemory);
-  VisitAll(module->tags, &NameGenerator::VisitTag);
-  VisitAll(module->data_segments, &NameGenerator::VisitDataSegment);
-  VisitAll(module->elem_segments, &NameGenerator::VisitElemSegment);
+  CHECK_RESULT(VisitAll(module->globals, &NameGenerator::VisitGlobal));
+  CHECK_RESULT(VisitAll(module->types, &NameGenerator::VisitType));
+  CHECK_RESULT(VisitAll(module->funcs, &NameGenerator::VisitFunc));
+  CHECK_RESULT(VisitAll(module->tables, &NameGenerator::VisitTable));
+  CHECK_RESULT(VisitAll(module->memories, &NameGenerator::VisitMemory));
+  CHECK_RESULT(VisitAll(module->tags, &NameGenerator::VisitTag));
+  CHECK_RESULT(
+      VisitAll(module->data_segments, &NameGenerator::VisitDataSegment));
+  CHECK_RESULT(
+      VisitAll(module->elem_segments, &NameGenerator::VisitElemSegment));
   module_ = nullptr;
   return Result::Ok;
 }

--- a/src/interp/interp.cc
+++ b/src/interp/interp.cc
@@ -580,7 +580,8 @@ Table::Table(Store& store, TableType type, Ref init_ref)
     : Extern(skind), type_(type) {
   elements_.resize(type.limits.initial);
   if (init_ref != Ref::Null) {
-    Fill(store, 0, init_ref, type.limits.initial);
+    Result result = Fill(store, 0, init_ref, type.limits.initial);
+    assert(Succeeded(result));
   }
 }
 
@@ -637,8 +638,7 @@ Result Table::Grow(Store& store, u64 count, Ref ref) {
     // import to another module its new size is honored.
     type_.limits.initial += count;
     elements_.resize(new_size);
-    Fill(store, old_size, ref, new_size - old_size);
-    return Result::Ok;
+    return Fill(store, old_size, ref, new_size - old_size);
   }
   return Result::Error;
 }

--- a/src/lexer-source-line-finder.cc
+++ b/src/lexer-source-line-finder.cc
@@ -25,7 +25,8 @@ namespace wabt {
 LexerSourceLineFinder::LexerSourceLineFinder(
     std::unique_ptr<LexerSource> source)
     : source_(std::move(source)), next_line_start_(0) {
-  source_->Seek(0);
+  Result result = source_->Seek(0);
+  assert(Succeeded(result));
   // Line 0 should not be used; but it makes indexing simpler.
   line_ranges_.emplace_back(0, 0);
 }

--- a/src/resolve-names.cc
+++ b/src/resolve-names.cc
@@ -546,7 +546,8 @@ void NameResolver::VisitFunc(Func* func) {
     PrintDuplicateBindingsError(a, b, desc);
   });
 
-  visitor_.VisitFunc(func);
+  // TODO: what should we do about errors?
+  (void)visitor_.VisitFunc(func);
   current_func_ = nullptr;
 }
 
@@ -575,7 +576,8 @@ void NameResolver::VisitExport(Export* export_) {
 }
 
 void NameResolver::VisitGlobal(Global* global) {
-  visitor_.VisitExprList(global->init_expr);
+  // TODO: what should we do about errors?
+  (void)visitor_.VisitExprList(global->init_expr);
 }
 
 void NameResolver::VisitTag(Tag* tag) {
@@ -586,13 +588,15 @@ void NameResolver::VisitTag(Tag* tag) {
 
 void NameResolver::VisitTable(Table* table) {
   if (!table->init_expr.empty()) {
-    visitor_.VisitExprList(table->init_expr);
+    // TODO: what should we do about errors?
+    (void)visitor_.VisitExprList(table->init_expr);
   }
 }
 
 void NameResolver::VisitElemSegment(ElemSegment* segment) {
   ResolveTableVar(&segment->table_var);
-  visitor_.VisitExprList(segment->offset);
+  // TODO: what should we do about errors?
+  (void)visitor_.VisitExprList(segment->offset);
   for (ExprList& elem_expr : segment->elem_exprs) {
     if (elem_expr.size() == 1 &&
         elem_expr.front().type() == ExprType::RefFunc) {
@@ -603,7 +607,8 @@ void NameResolver::VisitElemSegment(ElemSegment* segment) {
 
 void NameResolver::VisitDataSegment(DataSegment* segment) {
   ResolveMemoryVar(&segment->memory_var);
-  visitor_.VisitExprList(segment->offset);
+  // TODO: what should we do about errors?
+  (void)visitor_.VisitExprList(segment->offset);
 }
 
 Result NameResolver::VisitModule(Module* module) {
@@ -638,18 +643,21 @@ Result NameResolver::VisitModule(Module* module) {
 
 void NameResolver::VisitScriptModule(ScriptModule* script_module) {
   if (auto* tsm = dyn_cast<TextScriptModule>(script_module)) {
-    VisitModule(&tsm->module);
+    // TODO: what should we do about errors?
+    (void)VisitModule(&tsm->module);
   }
 }
 
 void NameResolver::VisitCommand(Command* command) {
   switch (command->type) {
     case CommandType::Module:
-      VisitModule(&cast<ModuleCommand>(command)->module);
+      // TODO: what should we do about errors?
+      (void)VisitModule(&cast<ModuleCommand>(command)->module);
       break;
 
     case CommandType::ScriptModule:
-      VisitModule(&cast<ScriptModuleCommand>(command)->module);
+      // TODO: what should we do about errors?
+      (void)VisitModule(&cast<ScriptModuleCommand>(command)->module);
       break;
 
     case CommandType::Action:

--- a/src/shared-validator.cc
+++ b/src/shared-validator.cc
@@ -37,12 +37,11 @@ SharedValidator::SharedValidator(Errors* errors,
       [this](const char* msg) { OnTypecheckerError(msg); });
 }
 
-Result WABT_PRINTF_FORMAT(3, 4) SharedValidator::PrintError(const Location& loc,
-                                                            const char* format,
-                                                            ...) {
+void WABT_PRINTF_FORMAT(3, 4) SharedValidator::PrintError(const Location& loc,
+                                                          const char* format,
+                                                          ...) {
   WABT_SNPRINTF_ALLOCA(buffer, length, format);
   errors_->emplace_back(ErrorLevel::Error, loc, filename_, buffer);
-  return Result::Error;
 }
 
 void SharedValidator::OnTypecheckerError(const char* msg) {
@@ -57,9 +56,10 @@ Result SharedValidator::OnFuncType(const Location& loc,
                                    Index type_index) {
   Result result = Result::Ok;
   if (!options_.features.multi_value_enabled() && result_count > 1) {
-    result |= PrintError(loc,
-                         "multiple result values are not supported without "
-                         "multi-value enabled.");
+    PrintError(loc,
+               "multiple result values are not supported without "
+               "multi-value enabled.");
+    result |= Result::Error;
   }
   if (options_.features.reference_types_enabled()) {
     for (Index i = 0; i < param_count; i++) {
@@ -103,21 +103,23 @@ Result SharedValidator::CheckLimits(const Location& loc,
                                     const char* desc) {
   Result result = Result::Ok;
   if (limits.initial > absolute_max) {
-    result |=
-        PrintError(loc, "initial %s (%" PRIu64 ") must be <= (%" PRIu64 ")",
-                   desc, limits.initial, absolute_max);
+    PrintError(loc, "initial %s (%" PRIu64 ") must be <= (%" PRIu64 ")", desc,
+               limits.initial, absolute_max);
+    result |= Result::Error;
   }
 
   if (limits.has_max) {
     if (limits.max > absolute_max) {
-      result |= PrintError(loc, "max %s (%" PRIu64 ") must be <= (%" PRIu64 ")",
-                           desc, limits.max, absolute_max);
+      PrintError(loc, "max %s (%" PRIu64 ") must be <= (%" PRIu64 ")", desc,
+                 limits.max, absolute_max);
+      result |= Result::Error;
     }
 
     if (limits.max < limits.initial) {
-      result |= PrintError(
-          loc, "max %s (%" PRIu64 ") must be >= initial %s (%" PRIu64 ")", desc,
-          limits.max, desc, limits.initial);
+      PrintError(loc,
+                 "max %s (%" PRIu64 ") must be >= initial %s (%" PRIu64 ")",
+                 desc, limits.max, desc, limits.initial);
+      result |= Result::Error;
     }
   }
   return result;
@@ -132,25 +134,30 @@ Result SharedValidator::OnTable(const Location& loc,
   // Must be checked by parser or binary reader.
   assert(elem_type.IsRef());
   if (tables_.size() > 0 && !options_.features.reference_types_enabled()) {
-    result |= PrintError(loc, "only one table allowed");
+    PrintError(loc, "only one table allowed");
+    result |= Result::Error;
   }
   uint64_t absolute_max = limits.is_64 ? UINT64_MAX : UINT32_MAX;
   result |= CheckLimits(loc, limits, absolute_max, "elems");
 
   if (limits.is_shared) {
-    result |= PrintError(loc, "tables may not be shared");
+    PrintError(loc, "tables may not be shared");
+    result |= Result::Error;
   }
   if (options_.features.reference_types_enabled()) {
     if (!elem_type.IsRef()) {
-      result |= PrintError(loc, "ables may only contain reference types");
+      PrintError(loc, "ables may only contain reference types");
+      result |= Result::Error;
     } else if (import_status == TableImportStatus::TableIsNotImported &&
                init_provided ==
                    TableInitExprStatus::TableWithoutInitExpression &&
                !elem_type.IsNullableRef()) {
-      result |= PrintError(loc, "missing table initializer");
+      PrintError(loc, "missing table initializer");
+      result |= Result::Error;
     }
   } else if (elem_type != Type::FuncRef) {
-    result |= PrintError(loc, "tables must have funcref type");
+    PrintError(loc, "tables must have funcref type");
+    result |= Result::Error;
   }
 
   result |= CheckReferenceType(loc, elem_type, "tables");
@@ -164,14 +171,17 @@ Result SharedValidator::OnMemory(const Location& loc,
                                  uint32_t page_size) {
   Result result = Result::Ok;
   if (memories_.size() > 0 && !options_.features.multi_memory_enabled()) {
-    result |= PrintError(loc, "only one memory block allowed");
+    PrintError(loc, "only one memory block allowed");
+    result |= Result::Error;
   }
 
   if (page_size != WABT_DEFAULT_PAGE_SIZE) {
     if (!options_.features.custom_page_sizes_enabled()) {
-      result |= PrintError(loc, "only default page size (64 KiB) is allowed");
+      PrintError(loc, "only default page size (64 KiB) is allowed");
+      result |= Result::Error;
     } else if (page_size != 1) {
-      result |= PrintError(loc, "only page sizes of 1 B or 64 KiB are allowed");
+      PrintError(loc, "only page sizes of 1 B or 64 KiB are allowed");
+      result |= Result::Error;
     }
   }
 
@@ -181,9 +191,11 @@ Result SharedValidator::OnMemory(const Location& loc,
 
   if (limits.is_shared) {
     if (!options_.features.threads_enabled()) {
-      result |= PrintError(loc, "memories may not be shared");
+      PrintError(loc, "memories may not be shared");
+      result |= Result::Error;
     } else if (!limits.has_max) {
-      result |= PrintError(loc, "shared memories must have max sizes");
+      PrintError(loc, "shared memories must have max sizes");
+      result |= Result::Error;
     }
   }
 
@@ -196,7 +208,8 @@ Result SharedValidator::OnGlobalImport(const Location& loc,
                                        bool mutable_) {
   Result result = Result::Ok;
   if (mutable_ && !options_.features.mutable_globals_enabled()) {
-    result |= PrintError(loc, "mutable globals cannot be imported");
+    PrintError(loc, "mutable globals cannot be imported");
+    result |= Result::Error;
   }
   globals_.push_back(GlobalType{type, mutable_});
   ++num_imported_globals_;
@@ -231,10 +244,11 @@ Result SharedValidator::CheckReferenceType(const Location& loc,
     auto iter = func_types_.find(index);
 
     if (iter == func_types_.end()) {
-      return PrintError(loc,
-                        "reference %" PRIindex
-                        " is out of range (max: %" PRIindex ") in %s",
-                        index, num_types_, desc);
+      PrintError(loc,
+                 "reference %" PRIindex " is out of range (max: %" PRIindex
+                 ") in %s",
+                 index, num_types_, desc);
+      return Result::Error;
     }
   }
 
@@ -246,7 +260,8 @@ Result SharedValidator::OnTag(const Location& loc, Var sig_var) {
   FuncType type;
   result |= CheckFuncTypeIndex(sig_var, &type);
   if (!type.results.empty()) {
-    result |= PrintError(loc, "Tag signature must have 0 results.");
+    PrintError(loc, "Tag signature must have 0 results.");
+    result |= Result::Error;
   }
   tags_.push_back(TagType{type.params});
   return result;
@@ -259,8 +274,9 @@ Result SharedValidator::OnExport(const Location& loc,
   Result result = Result::Ok;
   auto name_str = std::string(name);
   if (export_names_.contains(name_str)) {
-    result |= PrintError(loc, "duplicate export \"" PRIstringview "\"",
-                         WABT_PRINTF_STRING_VIEW_ARG(name));
+    PrintError(loc, "duplicate export \"" PRIstringview "\"",
+               WABT_PRINTF_STRING_VIEW_ARG(name));
+    result |= Result::Error;
   }
   export_names_.insert(name_str);
 
@@ -292,15 +308,18 @@ Result SharedValidator::OnExport(const Location& loc,
 Result SharedValidator::OnStart(const Location& loc, Var func_var) {
   Result result = Result::Ok;
   if (starts_++ > 0) {
-    result |= PrintError(loc, "only one start function allowed");
+    PrintError(loc, "only one start function allowed");
+    result |= Result::Error;
   }
   FuncType func_type;
   result |= CheckFuncIndex(func_var, &func_type);
   if (func_type.params.size() != 0) {
-    result |= PrintError(loc, "start function must be nullary");
+    PrintError(loc, "start function must be nullary");
+    result |= Result::Error;
   }
   if (func_type.results.size() != 0) {
-    result |= PrintError(loc, "start function must not return anything");
+    PrintError(loc, "start function must not return anything");
+    result |= Result::Error;
   }
   return result;
 }
@@ -334,8 +353,8 @@ Result SharedValidator::OnElemSegmentElemType(const Location& loc,
     auto iter = func_types_.find(index);
 
     if (iter == func_types_.end()) {
-      result |=
-          PrintError(loc, "reference %" PRIindex " is out of range", index);
+      PrintError(loc, "reference %" PRIindex " is out of range", index);
+      result |= Result::Error;
     }
   }
 
@@ -359,10 +378,10 @@ Result SharedValidator::OnDataSegment(const Location& loc,
 
 Result SharedValidator::CheckDeclaredFunc(Var func_var) {
   if (!declared_funcs_.contains(func_var.index())) {
-    return PrintError(func_var.loc,
-                      "function %" PRIindex
-                      " is not declared in any elem sections",
-                      func_var.index());
+    PrintError(func_var.loc,
+               "function %" PRIindex " is not declared in any elem sections",
+               func_var.index());
+    return Result::Error;
   }
   return Result::Ok;
 }
@@ -380,9 +399,10 @@ Result SharedValidator::EndModule() {
 
 Result SharedValidator::CheckIndex(Var var, Index max_index, const char* desc) {
   if (var.index() >= max_index) {
-    return PrintError(
-        var.loc, "%s variable out of range: %" PRIindex " (max %" PRIindex ")",
-        desc, var.index(), max_index);
+    PrintError(var.loc,
+               "%s variable out of range: %" PRIindex " (max %" PRIindex ")",
+               desc, var.index(), max_index);
+    return Result::Error;
   }
   return Result::Ok;
 }
@@ -405,8 +425,9 @@ Result SharedValidator::CheckLocalIndex(Var local_var, Type* out_type) {
       [](Index index, const LocalDecl& decl) { return index < decl.end; });
   if (iter == locals_.end()) {
     // TODO: better error
-    return PrintError(local_var.loc, "local variable out of range (max %u)",
-                      GetLocalCount());
+    PrintError(local_var.loc, "local variable out of range (max %u)",
+               GetLocalCount());
+    return Result::Error;
   }
   *out_type = iter->type;
   return Result::Ok;
@@ -421,8 +442,8 @@ Result SharedValidator::CheckFuncTypeIndex(Var sig_var, FuncType* out) {
 
   auto iter = func_types_.find(sig_var.index());
   if (iter == func_types_.end()) {
-    return PrintError(sig_var.loc, "type %d is not a function",
-                      sig_var.index());
+    PrintError(sig_var.loc, "type %d is not a function", sig_var.index());
+    return Result::Error;
   }
 
   if (out) {
@@ -473,8 +494,8 @@ Result SharedValidator::CheckBlockSignature(const Location& loc,
     result |= CheckFuncTypeIndex(Var(sig_index, loc), &func_type);
 
     if (!func_type.params.empty() && !options_.features.multi_value_enabled()) {
-      result |= PrintError(loc, "%s params not currently supported.",
-                           opcode.GetName());
+      PrintError(loc, "%s params not currently supported.", opcode.GetName());
+      result |= Result::Error;
     }
     // Multiple results without --enable-multi-value is checked above in
     // OnType.
@@ -487,8 +508,8 @@ Result SharedValidator::CheckBlockSignature(const Location& loc,
       auto iter = func_types_.find(index);
 
       if (iter == func_types_.end()) {
-        result |=
-            PrintError(loc, "reference %" PRIindex " is out of range", index);
+        PrintError(loc, "reference %" PRIindex " is out of range", index);
+        result |= Result::Error;
       }
     }
 
@@ -504,25 +525,27 @@ Index SharedValidator::GetFunctionTypeIndex(Index func_index) const {
   return funcs_[func_index].type_index;
 }
 
-void SharedValidator::SaveLocalRefs() {
+Result SharedValidator::SaveLocalRefs() {
   if (!local_ref_is_set_.empty()) {
     Label* label;
-    typechecker_.GetLabel(0, &label);
+    CHECK_RESULT(typechecker_.GetLabel(0, &label));
     label->local_ref_is_set_ = local_ref_is_set_;
   }
+  return Result::Ok;
 }
 
-void SharedValidator::RestoreLocalRefs(Result result) {
+Result SharedValidator::RestoreLocalRefs(Result result) {
   if (!local_ref_is_set_.empty()) {
     if (Succeeded(result)) {
       Label* label;
-      typechecker_.GetLabel(0, &label);
+      CHECK_RESULT(typechecker_.GetLabel(0, &label));
       assert(local_ref_is_set_.size() == label->local_ref_is_set_.size());
       local_ref_is_set_ = label->local_ref_is_set_;
     } else {
       IgnoreLocalRefs();
     }
   }
+  return Result::Ok;
 }
 
 void SharedValidator::IgnoreLocalRefs() {
@@ -675,9 +698,10 @@ Result SharedValidator::OnAtomicFence(const Location& loc,
                                       uint32_t consistency_model) {
   Result result = CheckInstr(Opcode::AtomicFence, loc);
   if (consistency_model != 0) {
-    result |= PrintError(
-        loc, "unexpected atomic.fence consistency model (expected 0): %u",
-        consistency_model);
+    PrintError(loc,
+               "unexpected atomic.fence consistency model (expected 0): %u",
+               consistency_model);
+    result |= Result::Error;
   }
   result |= typechecker_.OnAtomicFence(consistency_model);
   return result;
@@ -791,7 +815,7 @@ Result SharedValidator::OnBlock(const Location& loc, Type sig_type) {
   result |= CheckBlockSignature(loc, Opcode::Block, sig_type, &param_types,
                                 &result_types);
   result |= typechecker_.OnBlock(param_types, result_types);
-  SaveLocalRefs();
+  result |= SaveLocalRefs();
   return result;
 }
 
@@ -858,9 +882,10 @@ Result SharedValidator::OnCallIndirect(const Location& loc,
   result |= CheckTableIndex(table_var, &table_type);
   if (table_type.element == Type::Any ||
       Failed(typechecker_.CheckType(table_type.element, Type::FuncRef))) {
-    result |= PrintError(
+    PrintError(
         loc,
         "type mismatch: call_indirect must reference table of funcref type");
+    result |= Result::Error;
   }
   result |= typechecker_.OnCallIndirect(func_type.params, func_type.results,
                                         table_type.limits);
@@ -888,7 +913,7 @@ Result SharedValidator::OnCatch(const Location& loc,
     result |= CheckTagIndex(tag_var, &tag_type);
     result |= typechecker_.OnCatch(tag_type.params);
   }
-  RestoreLocalRefs(result);
+  result |= RestoreLocalRefs(result);
   return result;
 }
 
@@ -943,13 +968,13 @@ Result SharedValidator::OnElse(const Location& loc) {
   // not the else itself.
   Result result = Result::Ok;
   result |= typechecker_.OnElse();
-  RestoreLocalRefs(result);
+  result |= RestoreLocalRefs(result);
   return result;
 }
 
 Result SharedValidator::OnEnd(const Location& loc) {
   Result result = CheckInstr(Opcode::End, loc);
-  RestoreLocalRefs(result);
+  result |= RestoreLocalRefs(result);
   result |= typechecker_.OnEnd();
   return result;
 }
@@ -961,13 +986,15 @@ Result SharedValidator::OnGlobalGet(const Location& loc, Var global_var) {
   result |= typechecker_.OnGlobalGet(global_type.type);
   if (Succeeded(result) && in_init_expr_) {
     if (global_var.index() >= num_imported_globals_) {
-      result |= PrintError(
+      PrintError(
           global_var.loc,
           "initializer expression can only reference an imported global");
+      result |= Result::Error;
     }
     if (global_type.mutable_) {
-      result |= PrintError(
-          loc, "initializer expression cannot reference a mutable global");
+      PrintError(loc,
+                 "initializer expression cannot reference a mutable global");
+      result |= Result::Error;
     }
   }
 
@@ -979,9 +1006,10 @@ Result SharedValidator::OnGlobalSet(const Location& loc, Var global_var) {
   GlobalType global_type;
   result |= CheckGlobalIndex(global_var, &global_type);
   if (!global_type.mutable_) {
-    result |= PrintError(
-        loc, "can't global.set on immutable global at index %" PRIindex ".",
-        global_var.index());
+    PrintError(loc,
+               "can't global.set on immutable global at index %" PRIindex ".",
+               global_var.index());
+    result |= Result::Error;
   }
   result |= typechecker_.OnGlobalSet(global_type.type);
   return result;
@@ -993,7 +1021,7 @@ Result SharedValidator::OnIf(const Location& loc, Type sig_type) {
   result |= CheckBlockSignature(loc, Opcode::If, sig_type, &param_types,
                                 &result_types);
   result |= typechecker_.OnIf(param_types, result_types);
-  SaveLocalRefs();
+  result |= SaveLocalRefs();
   return result;
 }
 
@@ -1049,7 +1077,8 @@ Result SharedValidator::OnLocalGet(const Location& loc, Var local_var) {
     auto it = local_refs_map_.find(local_var.index());
     if (it != local_refs_map_.end() &&
         !local_ref_is_set_[it->second.local_ref_is_set]) {
-      return PrintError(local_var.loc, "uninitialized local reference");
+      PrintError(local_var.loc, "uninitialized local reference");
+      return Result::Error;
     }
   }
   return result;
@@ -1091,7 +1120,7 @@ Result SharedValidator::OnLoop(const Location& loc, Type sig_type) {
   result |= CheckBlockSignature(loc, Opcode::Loop, sig_type, &param_types,
                                 &result_types);
   result |= typechecker_.OnLoop(param_types, result_types);
-  SaveLocalRefs();
+  result |= SaveLocalRefs();
   return result;
 }
 
@@ -1190,8 +1219,9 @@ Result SharedValidator::OnRefNull(const Location& loc, Var func_type_var) {
     case Type::ExternRef:
       break;
     default:
-      result |= PrintError(
+      PrintError(
           loc, "Only ref, externref, exnref, funcref are allowed for ref.null");
+      result |= Result::Error;
       break;
   }
 
@@ -1224,9 +1254,10 @@ Result SharedValidator::OnReturnCallIndirect(const Location& loc,
   result |= CheckTableIndex(table_var, &table_type);
   if (table_type.element == Type::Any ||
       Failed(typechecker_.CheckType(table_type.element, Type::FuncRef))) {
-    result |= PrintError(loc,
-                         "type mismatch: return_call_indirect must reference "
-                         "table of funcref type");
+    PrintError(loc,
+               "type mismatch: return_call_indirect must reference "
+               "table of funcref type");
+    result |= Result::Error;
   }
   result |= typechecker_.OnReturnCallIndirect(
       func_type.params, func_type.results, table_type.limits);
@@ -1262,16 +1293,16 @@ Result SharedValidator::OnSelect(const Location& loc,
       auto iter = func_types_.find(index);
 
       if (iter == func_types_.end()) {
-        result |=
-            PrintError(loc, "reference %" PRIindex " is out of range", index);
+        PrintError(loc, "reference %" PRIindex " is out of range", index);
+        result |= Result::Error;
       }
     }
   }
 
   if (result_count > 1) {
-    result |=
-        PrintError(loc, "invalid arity in select instruction: %" PRIindex ".",
-                   result_count);
+    PrintError(loc, "invalid arity in select instruction: %" PRIindex ".",
+               result_count);
+    result |= Result::Error;
   } else {
     result |= typechecker_.OnSelect(ToTypeVector(result_count, result_types));
   }
@@ -1424,7 +1455,7 @@ Result SharedValidator::OnTry(const Location& loc, Type sig_type) {
   result |= CheckBlockSignature(loc, Opcode::Try, sig_type, &param_types,
                                 &result_types);
   result |= typechecker_.OnTry(param_types, result_types);
-  SaveLocalRefs();
+  result |= SaveLocalRefs();
   return result;
 }
 
@@ -1459,7 +1490,7 @@ Result SharedValidator::EndTryTable(const Location& loc, Type sig_type) {
   result |= CheckBlockSignature(loc, Opcode::TryTable, sig_type, &param_types,
                                 &result_types);
   result |= typechecker_.EndTryTable(param_types, result_types);
-  SaveLocalRefs();
+  result |= SaveLocalRefs();
   return result;
 }
 

--- a/src/test-interp.cc
+++ b/src/test-interp.cc
@@ -612,10 +612,12 @@ TEST_F(InterpGCTest, Collect_TableCycle) {
   auto t2 = Table::New(store_, tt, Ref::Null);
   auto t3 = Table::New(store_, tt, Ref::Null);
 
-  t1->Set(store_, 0, t1->self());  // t1 references itself.
-  t2->Set(store_, 0, t3->self());
-  t3->Set(store_, 0, t2->self());  // t2 and t3 reference each other.
-  t3->Set(store_, 1, t1->self());  // t3 also references t1.
+  Result result = Result::Ok;
+  result |= t1->Set(store_, 0, t1->self());  // t1 references itself.
+  result |= t2->Set(store_, 0, t3->self());
+  result |= t3->Set(store_, 0, t2->self());  // t2 and t3 reference each other.
+  result |= t3->Set(store_, 1, t1->self());  // t3 also references t1.
+  ASSERT_EQ(Result::Ok, result);
 
   auto after_new = store_.object_count();
   EXPECT_EQ(before_new + 3, after_new);
@@ -715,7 +717,8 @@ TEST_F(InterpGCTest, Collect_DeepRecursion) {
   for (size_t i = 1; i < table_count; i++) {
     Table::Ptr new_table = Table::New(store_, tt, Ref::Null);
 
-    new_table->Set(store_, 0, prev_table->self());
+    Result result = new_table->Set(store_, 0, prev_table->self());
+    ASSERT_EQ(Result::Ok, result);
 
     prev_table.reset();
     prev_table = std::move(new_table);

--- a/src/tools/wasm-interp.cc
+++ b/src/tools/wasm-interp.cc
@@ -422,11 +422,13 @@ static Result ReadAndRunModule(const char* module_filename) {
   CHECK_RESULT(InstantiateModule(imports, module, &instance));
 
   if (s_run_all_exports) {
-    RunAllExports(instance, &errors);
+    // TODO: what should we do about errors?
+    (void)RunAllExports(instance, &errors);
   }
 
   if (!s_run_exports.empty()) {
-    RunSpecificExports(instance, &errors, s_run_exports);
+    // TODO: what should we do about errors?
+    (void)RunSpecificExports(instance, &errors, s_run_exports);
   }
 #ifdef WITH_WASI
   if (s_wasi) {

--- a/src/tools/wasm2c.cc
+++ b/src/tools/wasm2c.cc
@@ -138,7 +138,7 @@ Result Wasm2cMain(Errors& errors) {
   CHECK_RESULT(GenerateNames(&module));
   /* TODO(binji): This shouldn't fail; if a name can't be applied
    * (because the index is invalid, say) it should just be skipped. */
-  ApplyNames(&module);
+  (void)ApplyNames(&module);
 
   if (!s_outfile.empty()) {
     std::string header_name_full =

--- a/src/tools/wat2wasm.cc
+++ b/src/tools/wat2wasm.cc
@@ -96,8 +96,8 @@ static void ParseOptions(int argc, char* argv[]) {
   parser.Parse(argc, argv);
 }
 
-static void WriteBufferToFile(std::string_view filename,
-                              const OutputBuffer& buffer) {
+static Result WriteBufferToFile(std::string_view filename,
+                                const OutputBuffer& buffer) {
   if (s_dump_module) {
     std::unique_ptr<FileStream> stream = FileStream::CreateStdout();
     if (s_verbose) {
@@ -109,10 +109,11 @@ static void WriteBufferToFile(std::string_view filename,
   }
 
   if (filename == "-") {
-    buffer.WriteToStdout();
+    CHECK_RESULT(buffer.WriteToStdout());
   } else {
-    buffer.WriteToFile(filename);
+    CHECK_RESULT(buffer.WriteToFile(filename));
   }
+  return Result::Ok;
 }
 
 static std::string DefaultOuputName(std::string_view input_name) {
@@ -155,7 +156,7 @@ int ProgramMain(int argc, char** argv) {
       if (s_outfile.empty()) {
         s_outfile = DefaultOuputName(s_infile);
       }
-      WriteBufferToFile(s_outfile.c_str(), stream.output_buffer());
+      result = WriteBufferToFile(s_outfile.c_str(), stream.output_buffer());
     }
   }
 

--- a/src/type-checker.cc
+++ b/src/type-checker.cc
@@ -156,9 +156,8 @@ void TypeChecker::PushLabel(LabelType label_type,
                             type_stack_.size());
 }
 
-Result TypeChecker::PopLabel() {
+void TypeChecker::PopLabel() {
   label_stack_.pop_back();
-  return Result::Ok;
 }
 
 Result TypeChecker::CheckLabelType(Label* label, LabelType label_type) {

--- a/src/validator.cc
+++ b/src/validator.cc
@@ -1101,14 +1101,16 @@ void ScriptValidator::CheckCommand(const Command* command) {
     case CommandType::Module: {
       Validator module_validator(errors_, &cast<ModuleCommand>(command)->module,
                                  options_);
-      module_validator.CheckModule();
+      // TODO: what should we do about errors?
+      (void)module_validator.CheckModule();
       break;
     }
 
     case CommandType::ScriptModule: {
       Validator module_validator(
           errors_, &cast<ScriptModuleCommand>(command)->module, options_);
-      module_validator.CheckModule();
+      // TODO: what should we do about errors?
+      (void)module_validator.CheckModule();
       break;
     }
 

--- a/src/wast-lexer.cc
+++ b/src/wast-lexer.cc
@@ -400,7 +400,8 @@ Token WastLexer::GetStringToken(TokenType token_type) {
             uint32_t scalar_value = 0;
 
             while (IsHexDigit(PeekChar())) {
-              ParseHexdigit(*cursor_++, &digit);
+              Result result = ParseHexdigit(*cursor_++, &digit);
+              assert(Succeeded(result));
 
               scalar_value = (scalar_value << 4) | digit;
               // Maximum value of a unicode code point.

--- a/src/wast-parser.cc
+++ b/src/wast-parser.cc
@@ -1299,7 +1299,8 @@ Result WastParser::ParseModule(std::unique_ptr<Module>* out_module) {
                           lexer_->Filename(), "empty module");
   } else {
     ConsumeIfLpar();
-    ErrorExpected({"a module field", "a module"});
+    // Intentionally continuing to report additional errors.
+    (void)ErrorExpected({"a module field", "a module"});
   }
 
   EXPECT(Eof);
@@ -1332,7 +1333,8 @@ Result WastParser::ParseScript(std::unique_ptr<Script>* out_script) {
                           lexer_->Filename(), "empty script");
   } else {
     ConsumeIfLpar();
-    ErrorExpected({"a module field", "a command"});
+    // Intentionally continuing to report additional errors.
+    (void)ErrorExpected({"a module field", "a command"});
   }
 
   EXPECT(Eof);
@@ -3365,7 +3367,7 @@ Result WastParser::ParseLabelOpt(std::string* out_label) {
   WABT_TRACE(ParseLabelOpt);
   if (PeekMatch(TokenType::Var)) {
     Token token = Consume();
-    ParseVarText(token, out_label);
+    CHECK_RESULT(ParseVarText(token, out_label));
   } else {
     out_label->clear();
   }
@@ -3513,7 +3515,8 @@ Result WastParser::ParseExpr(ExprList* exprs) {
               break;
             }
             default:
-              ErrorExpected({"catch", "catch_all", "delegate"});
+              // Intentionally continuing to report additional errors.
+              (void)ErrorExpected({"catch", "catch_all", "delegate"});
               break;
           }
         }
@@ -3813,7 +3816,8 @@ Result WastParser::ParseModuleCommand(Script* script, CommandPtr* out_command) {
       Errors errors;
       const char* filename = "<text>";
       if (options_->parse_binary_modules) {
-        ReadBinaryIr(filename, bsm->data, options, &errors, module);
+        // TODO: what should we do about errors?
+        (void)ReadBinaryIr(filename, bsm->data, options, &errors, module);
       }
       module->name = bsm->name;
       module->loc = bsm->loc;

--- a/src/wat-writer.cc
+++ b/src/wat-writer.cc
@@ -1199,17 +1199,19 @@ Result WatWriter::ExprVisitorDelegate::OnLoadZeroExpr(LoadZeroExpr* expr) {
 }
 
 void WatWriter::WriteExpr(const Expr* expr) {
-  WABT_TRACE(WriteExprList);
+  WABT_TRACE(WriteExpr);
   ExprVisitorDelegate delegate(this);
   ExprVisitor visitor(&delegate);
-  visitor.VisitExpr(const_cast<Expr*>(expr));
+  // TODO: what should we do about errors?
+  (void)visitor.VisitExpr(const_cast<Expr*>(expr));
 }
 
 void WatWriter::WriteExprList(const ExprList& exprs) {
   WABT_TRACE(WriteExprList);
   ExprVisitorDelegate delegate(this);
   ExprVisitor visitor(&delegate);
-  visitor.VisitExprList(const_cast<ExprList&>(exprs));
+  // TODO: what should we do about errors?
+  (void)visitor.VisitExprList(const_cast<ExprList&>(exprs));
 }
 
 void WatWriter::WriteFoldedExpr(const Expr* expr) {


### PR DESCRIPTION
This CL fixes a fuzzer error caused by unintentionally ignoring a failure. Instead of just fixing the one case, I figured I'd fix them all.

In a handful of cases, I wasn't sure how errors should be propagated. Please feel free to suggest improvements!