### PR TITLE
Fix WABT_PRINTF_TYPE_CODE to correctly handle INT_MIN

### DIFF
--- a/include/wabt/string-format.h
+++ b/include/wabt/string-format.h
@@ -29,7 +29,7 @@
 #define WABT_PRINTF_STRING_VIEW_ARG(x) \
   static_cast<int>((x).length()), (x).data()
 
-#define PRItypecode "%s%" PRIx64
+#define PRItypecode "%s%#" PRIx64
 #define WABT_PRINTF_TYPE_CODE(x) \
   (static_cast<int32_t>(x) < 0 ? "-" : ""), std::abs(static_cast<int64_t>(x))
 

--- a/include/wabt/string-format.h
+++ b/include/wabt/string-format.h
@@ -17,6 +17,8 @@
 #ifndef WABT_STRING_FORMAT_H_
 #define WABT_STRING_FORMAT_H_
 
+#include <inttypes.h>
+
 #include <cstdarg>
 #include <string>
 #include <vector>
@@ -27,7 +29,7 @@
 #define WABT_PRINTF_STRING_VIEW_ARG(x) \
   static_cast<int>((x).length()), (x).data()
 
-#define PRItypecode "%s%#lx"
+#define PRItypecode "%s%" PRIx64
 #define WABT_PRINTF_TYPE_CODE(x) \
   (static_cast<int32_t>(x) < 0 ? "-" : ""), std::abs(static_cast<int64_t>(x))
 

--- a/include/wabt/string-format.h
+++ b/include/wabt/string-format.h
@@ -27,11 +27,9 @@
 #define WABT_PRINTF_STRING_VIEW_ARG(x) \
   static_cast<int>((x).length()), (x).data()
 
-#define PRItypecode "%s%#x"
-#define WABT_PRINTF_TYPE_CODE(x)                                     \
-  (static_cast<int32_t>(x) < 0 ? "-" : ""),                          \
-      (static_cast<int32_t>(x) < 0 ? (0u - static_cast<uint32_t>(x)) \
-                                   : static_cast<uint32_t>(x))
+#define PRItypecode "%s%#lx"
+#define WABT_PRINTF_TYPE_CODE(x) \
+  (static_cast<int32_t>(x) < 0 ? "-" : ""), std::abs(static_cast<int64_t>(x))
 
 #define WABT_DEFAULT_SNPRINTF_ALLOCA_BUFSIZE 128
 #define WABT_SNPRINTF_ALLOCA(buffer, len, format)                          \

--- a/include/wabt/string-format.h
+++ b/include/wabt/string-format.h
@@ -28,8 +28,10 @@
   static_cast<int>((x).length()), (x).data()
 
 #define PRItypecode "%s%#x"
-#define WABT_PRINTF_TYPE_CODE(x) \
-  (static_cast<int32_t>(x) < 0 ? "-" : ""), std::abs(static_cast<int32_t>(x))
+#define WABT_PRINTF_TYPE_CODE(x)                                     \
+  (static_cast<int32_t>(x) < 0 ? "-" : ""),                          \
+      (static_cast<int32_t>(x) < 0 ? (0u - static_cast<uint32_t>(x)) \
+                                   : static_cast<uint32_t>(x))
 
 #define WABT_DEFAULT_SNPRINTF_ALLOCA_BUFSIZE 128
 #define WABT_SNPRINTF_ALLOCA(buffer, len, format)                          \


### PR DESCRIPTION
This fixes a fuzzer-discovered edge case: the result of std::abs(INT_MIN) is undefined behavior.