### PR TITLE
Avoid out-of-bounds imports read in wasm_instance_new

### DIFF
--- a/src/interp/interp-wasm-c-api.cc
+++ b/src/interp/interp-wasm-c-api.cc
@@ -742,7 +742,11 @@ own wasm_instance_t* wasm_instance_new(wasm_store_t* store,
   assert(store);
 
   RefVec import_refs;
-  for (size_t i = 0; i < module->As<Module>()->import_types().size(); i++) {
+  // Bound the read by imports->size so a module that declares more imports
+  // than the caller supplied cannot walk off the end of the imports array;
+  // the short list is then rejected by Instance::Instantiate below.
+  size_t import_count = module->As<Module>()->import_types().size();
+  for (size_t i = 0; i < import_count && i < imports->size; i++) {
     import_refs.push_back(imports->data[i]->I->self());
   }
 

--- a/src/interp/interp-wasm-c-api.cc
+++ b/src/interp/interp-wasm-c-api.cc
@@ -741,12 +741,17 @@ own wasm_instance_t* wasm_instance_new(wasm_store_t* store,
   assert(module);
   assert(store);
 
-  RefVec import_refs;
-  // Bound the read by imports->size so a module that declares more imports
-  // than the caller supplied cannot walk off the end of the imports array;
-  // the short list is then rejected by Instance::Instantiate below.
+  // The caller must supply exactly as many imports as the module declares;
+  // reading imports->data[i] beyond imports->size would be out of bounds.
   size_t import_count = module->As<Module>()->import_types().size();
-  for (size_t i = 0; i < import_count && i < imports->size; i++) {
+  if (imports->size != import_count) {
+    *trap_out = new wasm_trap_t{
+        Trap::New(store->I, "wrong number of imports provided")};
+    return nullptr;
+  }
+
+  RefVec import_refs;
+  for (size_t i = 0; i < import_count; i++) {
     import_refs.push_back(imports->data[i]->I->self());
   }
 


### PR DESCRIPTION
ASan, instantiating a 2-import module through the wasm C API with a 1-element imports vector:

    ==ERROR: AddressSanitizer: heap-buffer-overflow
    READ of size 8 ... in wasm_instance_new interp-wasm-c-api.cc:746
    0 bytes after 8-byte region [...] (the caller's imports array)

Spotted while running modules through libwasm with a fixed imports list. `wasm_instance_new` copies the imports into a `RefVec` by looping `i` over the module's declared import count and reading `imports->data[i]`. Nothing checks the caller actually supplied that many, so a module whose import section declares more imports than the embedder passes reads past the end of the imports array and then derefs the wild pointer through `->I->self()`.

`Instance::Instantiate` already rejects a short list with a "not enough imports!" trap, but it runs after this loop, so the over-read happens first. Bounding the loop by `imports->size` lets the short case fall through to that existing trap instead. Valid and over-supplied lists build the same `RefVec` as before.
