### PR TITLE
Fix out-of-bounds type stack read after rethrow in c-writer

### DIFF
--- a/src/c-writer.cc
+++ b/src/c-writer.cc
@@ -4187,7 +4187,9 @@ void CWriter::Write(const ExprList& exprs) {
         Write("wasm_rt_load_exception(", ex, "_tag, ", ex, "_size, ", ex, ");",
               Newline());
         WriteThrow();
-      } break;
+        // Stop processing this ExprList, since the following are unreachable.
+        return;
+      }
 
       case ExprType::Try: {
         const TryExpr& tryexpr = *cast<TryExpr>(&expr);

--- a/src/test-c-writer.cc
+++ b/src/test-c-writer.cc
@@ -45,13 +45,15 @@ const uint8_t s_float_globals[] = {
     0x03, 0x00, 0x05, 0x67, 0x5f, 0x66, 0x33, 0x32, 0x03, 0x01,
 };
 
-std::string WriteCSource(const uint8_t* data, size_t size) {
+std::string WriteCSource(const uint8_t* data,
+                         size_t size,
+                         const Features& features = Features{}) {
   Errors errors;
   Module module;
   ReadBinaryOptions read_options;
+  read_options.features = features;
   EXPECT_EQ(Result::Ok,
             ReadBinaryIr("test", data, size, read_options, &errors, &module));
-  Features features;
   ValidateOptions validate_options(features);
   EXPECT_EQ(Result::Ok, ValidateModule(&module, &errors, validate_options));
   EXPECT_EQ(Result::Ok, GenerateNames(&module));
@@ -100,4 +102,34 @@ TEST(CWriter, FloatConstLocaleIndependent) {
   EXPECT_NE(source.find("0.5"), std::string::npos);
   EXPECT_EQ(source.find("1,5"), std::string::npos);
   EXPECT_EQ(source.find("0,5"), std::string::npos);
+}
+
+// rethrow transfers control unconditionally, so the validator marks the rest
+// of the block unreachable and accepts instructions there against a
+// polymorphic stack. The generator must stop emitting the block at such a
+// terminator; walking into the unreachable tail pops operands that do not
+// exist and reads past the end of the type stack (StackVar underflow).
+// Translating this valid module must not fault.
+TEST(CWriter, RethrowFollowedByUnreachableCode) {
+  // (module
+  //   (memory 1)
+  //   (func try nop catch_all rethrow 0 i32.store end))
+  const uint8_t data[] = {
+      0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,  // magic + version
+      0x01, 0x04, 0x01, 0x60, 0x00, 0x00,              // type: () -> ()
+      0x03, 0x02, 0x01, 0x00,                          // func: type 0
+      0x05, 0x03, 0x01, 0x00, 0x01,                    // memory: min 1
+      0x0a, 0x0e, 0x01, 0x0c, 0x00,                    // code: 1 body, size 12
+      0x06, 0x40,                                      // try (void)
+      0x01,                                            // nop
+      0x19,                                            // catch_all
+      0x09, 0x00,                                      // rethrow 0
+      0x36, 0x02, 0x00,  // i32.store (unreachable)
+      0x0b,              // end try
+      0x0b,              // end func
+  };
+
+  Features features;
+  features.enable_exceptions();
+  WriteCSource(data, sizeof(data), features);
 }

--- a/src/test-c-writer.cc
+++ b/src/test-c-writer.cc
@@ -45,15 +45,13 @@ const uint8_t s_float_globals[] = {
     0x03, 0x00, 0x05, 0x67, 0x5f, 0x66, 0x33, 0x32, 0x03, 0x01,
 };
 
-std::string WriteCSource(const uint8_t* data,
-                         size_t size,
-                         const Features& features = Features{}) {
+std::string WriteCSource(const uint8_t* data, size_t size) {
   Errors errors;
   Module module;
   ReadBinaryOptions read_options;
-  read_options.features = features;
   EXPECT_EQ(Result::Ok,
             ReadBinaryIr("test", data, size, read_options, &errors, &module));
+  Features features;
   ValidateOptions validate_options(features);
   EXPECT_EQ(Result::Ok, ValidateModule(&module, &errors, validate_options));
   EXPECT_EQ(Result::Ok, GenerateNames(&module));
@@ -102,34 +100,4 @@ TEST(CWriter, FloatConstLocaleIndependent) {
   EXPECT_NE(source.find("0.5"), std::string::npos);
   EXPECT_EQ(source.find("1,5"), std::string::npos);
   EXPECT_EQ(source.find("0,5"), std::string::npos);
-}
-
-// rethrow transfers control unconditionally, so the validator marks the rest
-// of the block unreachable and accepts instructions there against a
-// polymorphic stack. The generator must stop emitting the block at such a
-// terminator; walking into the unreachable tail pops operands that do not
-// exist and reads past the end of the type stack (StackVar underflow).
-// Translating this valid module must not fault.
-TEST(CWriter, RethrowFollowedByUnreachableCode) {
-  // (module
-  //   (memory 1)
-  //   (func try nop catch_all rethrow 0 i32.store end))
-  const uint8_t data[] = {
-      0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,  // magic + version
-      0x01, 0x04, 0x01, 0x60, 0x00, 0x00,              // type: () -> ()
-      0x03, 0x02, 0x01, 0x00,                          // func: type 0
-      0x05, 0x03, 0x01, 0x00, 0x01,                    // memory: min 1
-      0x0a, 0x0e, 0x01, 0x0c, 0x00,                    // code: 1 body, size 12
-      0x06, 0x40,                                      // try (void)
-      0x01,                                            // nop
-      0x19,                                            // catch_all
-      0x09, 0x00,                                      // rethrow 0
-      0x36, 0x02, 0x00,  // i32.store (unreachable)
-      0x0b,              // end try
-      0x0b,              // end func
-  };
-
-  Features features;
-  features.enable_exceptions();
-  WriteCSource(data, sizeof(data), features);
 }

--- a/test/wasm2c/unreachable-after-rethrow.txt
+++ b/test/wasm2c/unreachable-after-rethrow.txt
@@ -1,0 +1,15 @@
+;;; TOOL: run-spec-wasm2c
+;;; ARGS*: --enable-exceptions
+(module
+  (memory 1)
+  (func (export "test")
+    try
+      nop
+    catch_all
+      rethrow 0
+      i32.store
+    end))
+(assert_return (invoke "test"))
+(;; STDOUT ;;;
+1/1 tests passed.
+;;; STDOUT ;;)


### PR DESCRIPTION
wasm2c on a valid exceptions module, ASan/debug build:

    Assertion failed: (index < type_stack_.size()), function Write, file c-writer.cc, line 1246.

Worked backwards from the StackVar read. The rethrow case in `Write(const ExprList&)` ends in `break`, so the loop carries on and emits the instructions after it. The validator has already marked those unreachable (`OnRethrow` makes the stack polymorphic), so a valid module can put operations there that pop operands which are not really on the stack. StackVar then underflows `type_stack_` and reads off the end. Release builds drop the assert and take the out-of-bounds read; `DropTypes` does an out-of-bounds erase on the same tail.

br, br_table, return, unreachable, throw, throw_ref and the return_call family all return here to stop walking the list. rethrow was the one that fell through, so it now does the same.

Repro: `(func try nop catch_all rethrow 0 i32.store end)` assembled with `--enable-exceptions`, then run through wasm2c.
