### PR TITLE
Fix memory64 offset truncation in the interp istream

### DIFF
--- a/include/wabt/interp/istream.h
+++ b/include/wabt/interp/istream.h
@@ -94,8 +94,8 @@ struct Instr {
     } imm_index_offset;
     struct {
       u32 memidx;
-      u64 offset;
       u8 lane;
+      u64 offset;
     } imm_index_offset_lane;
   };
 };

--- a/include/wabt/interp/istream.h
+++ b/include/wabt/interp/istream.h
@@ -88,6 +88,15 @@ struct Instr {
       u32 fst, snd;
       u8 idx;
     } imm_u32x2_u8;
+    struct {
+      u32 memidx;
+      u64 offset;
+    } imm_index_offset;
+    struct {
+      u32 memidx;
+      u64 offset;
+      u8 lane;
+    } imm_index_offset_lane;
   };
 };
 
@@ -115,6 +124,8 @@ class Istream {
   void Emit(Opcode::Enum, v128);
   void Emit(Opcode::Enum, u32, u32);
   void Emit(Opcode::Enum, u32, u32, u8);
+  void Emit(Opcode::Enum, u32, u64);
+  void Emit(Opcode::Enum, u32, u64, u8);
   void EmitDropKeep(u32 drop, u32 keep);
   void EmitCatchDrop(u32 drop);
 

--- a/src/interp/interp.cc
+++ b/src/interp/interp.cc
@@ -2222,12 +2222,12 @@ RunResult Thread::DoCall(const Func::Ptr& func, Trap::Ptr* out_trap) {
 
 template <typename T>
 RunResult Thread::Load(Instr instr, T* out, Trap::Ptr* out_trap) {
-  Memory::Ptr memory{store_, inst_->memories()[instr.imm_u32x2.fst]};
+  Memory::Ptr memory{store_, inst_->memories()[instr.imm_index_offset.memidx]};
   u64 offset = PopPtr(memory);
-  TRAP_IF(Failed(memory->Load(offset, instr.imm_u32x2.snd, out)),
+  TRAP_IF(Failed(memory->Load(offset, instr.imm_index_offset.offset, out)),
           StringPrintf("out of bounds memory access: access at %" PRIu64
                        "+%" PRIzd " >= max value %" PRIu64,
-                       offset + instr.imm_u32x2.snd, sizeof(T),
+                       offset + instr.imm_index_offset.offset, sizeof(T),
                        memory->ByteSize()));
   return RunResult::Ok;
 }
@@ -2244,13 +2244,13 @@ RunResult Thread::DoLoad(Instr instr, Trap::Ptr* out_trap) {
 
 template <typename T, typename V>
 RunResult Thread::DoStore(Instr instr, Trap::Ptr* out_trap) {
-  Memory::Ptr memory{store_, inst_->memories()[instr.imm_u32x2.fst]};
+  Memory::Ptr memory{store_, inst_->memories()[instr.imm_index_offset.memidx]};
   V val = static_cast<V>(Pop<T>());
   u64 offset = PopPtr(memory);
-  TRAP_IF(Failed(memory->Store(offset, instr.imm_u32x2.snd, val)),
+  TRAP_IF(Failed(memory->Store(offset, instr.imm_index_offset.offset, val)),
           StringPrintf("out of bounds memory access: access at %" PRIu64
                        "+%" PRIzd " >= max value %" PRIu64,
-                       offset + instr.imm_u32x2.snd, sizeof(V),
+                       offset + instr.imm_index_offset.offset, sizeof(V),
                        memory->ByteSize()));
   return RunResult::Ok;
 }
@@ -2581,7 +2581,7 @@ RunResult Thread::DoSimdLoadLane(Instr instr, Trap::Ptr* out_trap) {
   if (Load<T>(instr, &val, out_trap) != RunResult::Ok) {
     return RunResult::Trap;
   }
-  result[instr.imm_u32x2_u8.idx] = val;
+  result[instr.imm_index_offset_lane.lane] = val;
   Push(result);
   return RunResult::Ok;
 }
@@ -2589,15 +2589,17 @@ RunResult Thread::DoSimdLoadLane(Instr instr, Trap::Ptr* out_trap) {
 template <typename S>
 RunResult Thread::DoSimdStoreLane(Instr instr, Trap::Ptr* out_trap) {
   using T = typename S::LaneType;
-  Memory::Ptr memory{store_, inst_->memories()[instr.imm_u32x2_u8.fst]};
+  Memory::Ptr memory{store_,
+                     inst_->memories()[instr.imm_index_offset_lane.memidx]};
   auto result = Pop<S>();
-  T val = result[instr.imm_u32x2_u8.idx];
+  T val = result[instr.imm_index_offset_lane.lane];
   u64 offset = PopPtr(memory);
-  TRAP_IF(Failed(memory->Store(offset, instr.imm_u32x2_u8.snd, val)),
-          StringPrintf("out of bounds memory access: access at %" PRIu64
-                       "+%" PRIzd " >= max value %" PRIu64,
-                       offset + instr.imm_u32x2_u8.snd, sizeof(T),
-                       memory->ByteSize()));
+  TRAP_IF(
+      Failed(memory->Store(offset, instr.imm_index_offset_lane.offset, val)),
+      StringPrintf("out of bounds memory access: access at %" PRIu64 "+%" PRIzd
+                   " >= max value %" PRIu64,
+                   offset + instr.imm_index_offset_lane.offset, sizeof(T),
+                   memory->ByteSize()));
   return RunResult::Ok;
 }
 
@@ -2774,24 +2776,26 @@ RunResult Thread::DoSimdRelaxedNmadd() {
 
 template <typename T, typename V>
 RunResult Thread::DoAtomicLoad(Instr instr, Trap::Ptr* out_trap) {
-  Memory::Ptr memory{store_, inst_->memories()[instr.imm_u32x2.fst]};
+  Memory::Ptr memory{store_, inst_->memories()[instr.imm_index_offset.memidx]};
   u64 offset = PopPtr(memory);
   V val;
-  TRAP_IF(Failed(memory->AtomicLoad(offset, instr.imm_u32x2.snd, &val)),
-          StringPrintf("invalid atomic access at %" PRIaddress "+%u", offset,
-                       instr.imm_u32x2.snd));
+  TRAP_IF(
+      Failed(memory->AtomicLoad(offset, instr.imm_index_offset.offset, &val)),
+      StringPrintf("invalid atomic access at %" PRIaddress "+%" PRIu64, offset,
+                   instr.imm_index_offset.offset));
   Push(static_cast<T>(val));
   return RunResult::Ok;
 }
 
 template <typename T, typename V>
 RunResult Thread::DoAtomicStore(Instr instr, Trap::Ptr* out_trap) {
-  Memory::Ptr memory{store_, inst_->memories()[instr.imm_u32x2.fst]};
+  Memory::Ptr memory{store_, inst_->memories()[instr.imm_index_offset.memidx]};
   V val = static_cast<V>(Pop<T>());
   u64 offset = PopPtr(memory);
-  TRAP_IF(Failed(memory->AtomicStore(offset, instr.imm_u32x2.snd, val)),
-          StringPrintf("invalid atomic access at %" PRIaddress "+%u", offset,
-                       instr.imm_u32x2.snd));
+  TRAP_IF(
+      Failed(memory->AtomicStore(offset, instr.imm_index_offset.offset, val)),
+      StringPrintf("invalid atomic access at %" PRIaddress "+%" PRIu64, offset,
+                   instr.imm_index_offset.offset));
   return RunResult::Ok;
 }
 
@@ -2799,28 +2803,29 @@ template <typename R, typename T>
 RunResult Thread::DoAtomicRmw(BinopFunc<T, T> f,
                               Instr instr,
                               Trap::Ptr* out_trap) {
-  Memory::Ptr memory{store_, inst_->memories()[instr.imm_u32x2.fst]};
+  Memory::Ptr memory{store_, inst_->memories()[instr.imm_index_offset.memidx]};
   T val = static_cast<T>(Pop<R>());
   u64 offset = PopPtr(memory);
   T old;
-  TRAP_IF(Failed(memory->AtomicRmw(offset, instr.imm_u32x2.snd, val, f, &old)),
-          StringPrintf("invalid atomic access at %" PRIaddress "+%u", offset,
-                       instr.imm_u32x2.snd));
+  TRAP_IF(Failed(memory->AtomicRmw(offset, instr.imm_index_offset.offset, val,
+                                   f, &old)),
+          StringPrintf("invalid atomic access at %" PRIaddress "+%" PRIu64,
+                       offset, instr.imm_index_offset.offset));
   Push(static_cast<R>(old));
   return RunResult::Ok;
 }
 
 template <typename T, typename V>
 RunResult Thread::DoAtomicRmwCmpxchg(Instr instr, Trap::Ptr* out_trap) {
-  Memory::Ptr memory{store_, inst_->memories()[instr.imm_u32x2.fst]};
+  Memory::Ptr memory{store_, inst_->memories()[instr.imm_index_offset.memidx]};
   V replace = static_cast<V>(Pop<T>());
   V expect = static_cast<V>(Pop<T>());
   V old;
   u64 offset = PopPtr(memory);
-  TRAP_IF(Failed(memory->AtomicRmwCmpxchg(offset, instr.imm_u32x2.snd, expect,
-                                          replace, &old)),
-          StringPrintf("invalid atomic access at %" PRIaddress "+%u", offset,
-                       instr.imm_u32x2.snd));
+  TRAP_IF(Failed(memory->AtomicRmwCmpxchg(offset, instr.imm_index_offset.offset,
+                                          expect, replace, &old)),
+          StringPrintf("invalid atomic access at %" PRIaddress "+%" PRIu64,
+                       offset, instr.imm_index_offset.offset));
   Push(static_cast<T>(old));
   return RunResult::Ok;
 }

--- a/src/interp/istream.cc
+++ b/src/interp/istream.cc
@@ -76,6 +76,19 @@ void Istream::Emit(Opcode::Enum op, u32 val1, u32 val2, u8 val3) {
   EmitInternal(val3);
 }
 
+void Istream::Emit(Opcode::Enum op, u32 val1, u64 val2) {
+  Emit(op);
+  EmitInternal(val1);
+  EmitInternal(val2);
+}
+
+void Istream::Emit(Opcode::Enum op, u32 val1, u64 val2, u8 val3) {
+  Emit(op);
+  EmitInternal(val1);
+  EmitInternal(val2);
+  EmitInternal(val3);
+}
+
 void Istream::EmitDropKeep(u32 drop, u32 keep) {
   if (drop > 0) {
     if (drop == 1 && keep == 0) {
@@ -623,8 +636,8 @@ Instr Istream::Read(Offset* offset) const {
     case Opcode::V128Load64Zero:
       // Index + memory offset immediates, 1 operand.
       instr.kind = InstrKind::Imm_Index_Offset_Op_1;
-      instr.imm_u32x2.fst = ReadAt<u32>(offset);
-      instr.imm_u32x2.snd = ReadAt<u32>(offset);
+      instr.imm_index_offset.memidx = ReadAt<u32>(offset);
+      instr.imm_index_offset.offset = ReadAt<u64>(offset);
       break;
 
     case Opcode::MemoryAtomicNotify:
@@ -689,8 +702,8 @@ Instr Istream::Read(Offset* offset) const {
     case Opcode::V128Store:
       // Index and memory offset immediates, 2 operands.
       instr.kind = InstrKind::Imm_Index_Offset_Op_2;
-      instr.imm_u32x2.fst = ReadAt<u32>(offset);
-      instr.imm_u32x2.snd = ReadAt<u32>(offset);
+      instr.imm_index_offset.memidx = ReadAt<u32>(offset);
+      instr.imm_index_offset.offset = ReadAt<u64>(offset);
       break;
 
     case Opcode::V128Load8Lane:
@@ -703,9 +716,9 @@ Instr Istream::Read(Offset* offset) const {
     case Opcode::V128Store64Lane:
       // Index, memory offset, lane index immediates, 2 operands.
       instr.kind = InstrKind::Imm_Index_Offset_Lane_Op_2;
-      instr.imm_u32x2_u8.fst = ReadAt<u32>(offset);
-      instr.imm_u32x2_u8.snd = ReadAt<u32>(offset);
-      instr.imm_u32x2_u8.idx = ReadAt<u8>(offset);
+      instr.imm_index_offset_lane.memidx = ReadAt<u32>(offset);
+      instr.imm_index_offset_lane.offset = ReadAt<u64>(offset);
+      instr.imm_index_offset_lane.lane = ReadAt<u8>(offset);
       break;
 
     case Opcode::I32AtomicRmw16CmpxchgU:
@@ -719,8 +732,8 @@ Instr Istream::Read(Offset* offset) const {
     case Opcode::MemoryAtomicWait64:
       // Index and memory offset immediates, 3 operands.
       instr.kind = InstrKind::Imm_Index_Offset_Op_3;
-      instr.imm_u32x2.fst = ReadAt<u32>(offset);
-      instr.imm_u32x2.snd = ReadAt<u32>(offset);
+      instr.imm_index_offset.memidx = ReadAt<u32>(offset);
+      instr.imm_index_offset.offset = ReadAt<u64>(offset);
       break;
 
     case Opcode::AtomicFence:
@@ -916,28 +929,31 @@ Istream::Offset Istream::Trace(Stream* stream,
       break;
 
     case InstrKind::Imm_Index_Offset_Op_1:
-      stream->Writef(" $%u:%s+$%u\n", instr.imm_u32x2.fst,
-                     source->Pick(1, instr).c_str(), instr.imm_u32x2.snd);
+      stream->Writef(" $%u:%s+$%" PRIu64 "\n", instr.imm_index_offset.memidx,
+                     source->Pick(1, instr).c_str(),
+                     instr.imm_index_offset.offset);
       break;
 
     case InstrKind::Imm_Index_Offset_Op_2:
-      stream->Writef(" $%u:%s+$%u, %s\n", instr.imm_u32x2.fst,
-                     source->Pick(2, instr).c_str(), instr.imm_u32x2.snd,
-                     source->Pick(1, instr).c_str());
+      stream->Writef(
+          " $%u:%s+$%" PRIu64 ", %s\n", instr.imm_index_offset.memidx,
+          source->Pick(2, instr).c_str(), instr.imm_index_offset.offset,
+          source->Pick(1, instr).c_str());
       break;
 
     case InstrKind::Imm_Index_Offset_Op_3:
-      stream->Writef(" $%u:%s+$%u, %s, %s\n", instr.imm_u32x2.fst,
-                     source->Pick(3, instr).c_str(), instr.imm_u32x2.snd,
-                     source->Pick(2, instr).c_str(),
-                     source->Pick(1, instr).c_str());
+      stream->Writef(
+          " $%u:%s+$%" PRIu64 ", %s, %s\n", instr.imm_index_offset.memidx,
+          source->Pick(3, instr).c_str(), instr.imm_index_offset.offset,
+          source->Pick(2, instr).c_str(), source->Pick(1, instr).c_str());
       break;
 
     case InstrKind::Imm_Index_Offset_Lane_Op_2:
-      stream->Writef(" $%u:%s+$%u, %s (Lane imm: $%u)\n",
-                     instr.imm_u32x2_u8.fst, source->Pick(2, instr).c_str(),
-                     instr.imm_u32x2_u8.snd, source->Pick(1, instr).c_str(),
-                     instr.imm_u32x2_u8.idx);
+      stream->Writef(
+          " $%u:%s+$%" PRIu64 ", %s (Lane imm: $%u)\n",
+          instr.imm_index_offset_lane.memidx, source->Pick(2, instr).c_str(),
+          instr.imm_index_offset_lane.offset, source->Pick(1, instr).c_str(),
+          instr.imm_index_offset_lane.lane);
       break;
 
     case InstrKind::Imm_I32_Op_0:

--- a/test/interp/memory64-offset-oob.txt
+++ b/test/interp/memory64-offset-oob.txt
@@ -6,8 +6,8 @@
   ;; A static offset >= 2^32 must not be truncated to 32 bits: address 0 with
   ;; offset 2^32 is out of bounds and must trap, not read a wrapped in-range
   ;; address.
-  (func (export "load_offset_wrap") (result i64)
-    (i64.load offset=0x1_0000_0000 (i64.const 0)))
+  (func (export "load_offset_wrap") (result i32)
+    (i32.load offset=0x1_0000_0000 (i64.const 0)))
   (func (export "store_offset_wrap")
     (i64.store offset=0x1_0000_0000 (i64.const 0) (i64.const 1)))
 
@@ -18,7 +18,7 @@
     (i64.load offset=8 (i64.const 0)))
 )
 (;; STDOUT ;;;
-load_offset_wrap() => error: out of bounds memory access: access at 4294967296+8 >= max value 65536
+load_offset_wrap() => error: out of bounds memory access: access at 4294967296+4 >= max value 65536
 store_offset_wrap() => error: out of bounds memory access: access at 4294967296+8 >= max value 65536
 store_ok() =>
 load_ok() => i64:42

--- a/test/interp/memory64-offset-oob.txt
+++ b/test/interp/memory64-offset-oob.txt
@@ -1,0 +1,25 @@
+;;; TOOL: run-interp
+;;; ARGS*: --enable-memory64
+(module
+  (memory i64 1)
+
+  ;; A static offset >= 2^32 must not be truncated to 32 bits: address 0 with
+  ;; offset 2^32 is out of bounds and must trap, not read a wrapped in-range
+  ;; address.
+  (func (export "load_offset_wrap") (result i64)
+    (i64.load offset=0x1_0000_0000 (i64.const 0)))
+  (func (export "store_offset_wrap")
+    (i64.store offset=0x1_0000_0000 (i64.const 0) (i64.const 1)))
+
+  ;; In-range accesses still work.
+  (func (export "store_ok")
+    (i64.store offset=8 (i64.const 0) (i64.const 42)))
+  (func (export "load_ok") (result i64)
+    (i64.load offset=8 (i64.const 0)))
+)
+(;; STDOUT ;;;
+load_offset_wrap() => error: out of bounds memory access: access at 4294967296+8 >= max value 65536
+store_offset_wrap() => error: out of bounds memory access: access at 4294967296+8 >= max value 65536
+store_ok() =>
+load_ok() => i64:42
+;;; STDOUT ;;)


### PR DESCRIPTION
Running a memory64 module under wasm-interp, `i64.load offset=0x1_0000_0000` from address 0 returned 0 instead of trapping. A large dynamic address (5 GiB) does trap, so the static offset was the suspect.

1. OnLoadExpr hands the memarg offset over as an `Address` (u64), but `istream_.Emit(opcode, memidx, offset)` resolved to `Emit(Opcode, u32, u32)` and narrowed it to 32 bits.
2. For an i64-indexed memory a static offset of 2^32 or more is then lost, so an access whose effective address is out of bounds wraps to a small in-range offset and reads or writes a valid location rather than trapping.

Carried the offset as u64 the whole way: added `imm_index_offset`/`imm_index_offset_lane` immediates and `Emit(Opcode, u32, u64)` overloads, widened the four `Imm_Index_Offset_*` decode groups, the load/store/atomic/simd-lane handlers and the disassembler. 32-bit memories are untouched since the offset always fits u32. Regression test added under test/interp.
