### PR TITLE
[interp] Pop memory.copy/table.copy length using the minimum index type

### DIFF
--- a/src/interp/interp.cc
+++ b/src/interp/interp.cc
@@ -2326,7 +2326,11 @@ RunResult Thread::DoDataDrop(Instr instr) {
 RunResult Thread::DoMemoryCopy(Instr instr, Trap::Ptr* out_trap) {
   Memory::Ptr mem_dst{store_, inst_->memories()[instr.imm_u32x2.fst]};
   Memory::Ptr mem_src{store_, inst_->memories()[instr.imm_u32x2.snd]};
-  u64 size = PopPtr(mem_src);
+  // The size operand's type is the minimum of the two memory index types, so it
+  // is only 64-bit when both memories are (see TypeChecker::OnMemoryCopy).
+  bool size_is_64 =
+      mem_dst->type().limits.is_64 && mem_src->type().limits.is_64;
+  u64 size = size_is_64 ? Pop<u64>() : Pop<u32>();
   u64 src = PopPtr(mem_src);
   u64 dst = PopPtr(mem_dst);
   // TODO: change to "out of bounds"
@@ -2364,7 +2368,11 @@ RunResult Thread::DoElemDrop(Instr instr) {
 RunResult Thread::DoTableCopy(Instr instr, Trap::Ptr* out_trap) {
   Table::Ptr table_dst{store_, inst_->tables()[instr.imm_u32x2.fst]};
   Table::Ptr table_src{store_, inst_->tables()[instr.imm_u32x2.snd]};
-  u64 size = PopPtr(table_src);
+  // The size operand's type is the minimum of the two table index types, so it
+  // is only 64-bit when both tables are (see TypeChecker::OnTableCopy).
+  bool size_is_64 =
+      table_dst->type().limits.is_64 && table_src->type().limits.is_64;
+  u64 size = size_is_64 ? Pop<u64>() : Pop<u32>();
   u64 src = PopPtr(table_src);
   u64 dst = PopPtr(table_dst);
   TRAP_IF(Failed(Table::Copy(store_, *table_dst, dst, *table_src, src, size)),

--- a/test/interp/bulk-copy-mixed64.txt
+++ b/test/interp/bulk-copy-mixed64.txt
@@ -1,0 +1,36 @@
+;;; TOOL: run-interp
+;;; ARGS*: --enable-memory64 --enable-multi-memory
+(module
+  (memory $m32 1 1)
+  (memory $m64 i64 1 1)
+  (data (memory $m64) (i64.const 0) "\11\22\33\44")
+
+  (table $t32 10 funcref)
+  (table $t64 i64 10 funcref)
+  (elem (table $t64) (i64.const 1) func $a $b)
+  (type $r (func (result i32)))
+  (func $a (result i32) (i32.const 111))
+  (func $b (result i32) (i32.const 222))
+
+  ;; memory.copy/table.copy from a 64-bit source into a 32-bit destination: the
+  ;; length operand's type is the minimum of the two index types (i32 here), so
+  ;; the interpreter must pop it as i32, not as the source's i64.
+  (func (export "mem_copy_64to32")
+    (memory.copy $m32 $m64 (i32.const 0) (i64.const 0) (i32.const 4)))
+  (func (export "mem_read0") (result i32) (i32.load8_u $m32 (i32.const 0)))
+  (func (export "mem_read3") (result i32) (i32.load8_u $m32 (i32.const 3)))
+
+  (func (export "tbl_copy_64to32")
+    (table.copy $t32 $t64 (i32.const 5) (i64.const 1) (i32.const 2)))
+  (func (export "tbl_call5") (result i32)
+    (call_indirect $t32 (type $r) (i32.const 5)))
+  (func (export "tbl_call6") (result i32)
+    (call_indirect $t32 (type $r) (i32.const 6))))
+(;; STDOUT ;;;
+mem_copy_64to32() =>
+mem_read0() => i32:17
+mem_read3() => i32:68
+tbl_copy_64to32() =>
+tbl_call5() => i32:111
+tbl_call6() => i32:222
+;;; STDOUT ;;)


### PR DESCRIPTION
A valid module doing a mixed-width `table.copy` aborts wasm-interp in a debug build:

    $ wasm-interp --enable-memory64 --enable-multi-memory --run-all-exports t.wasm
    Assertion failed: (t == type || type == ValueType::Any), function CheckType, file interp.h, line 596.

The module copies from an i64-indexed table into an i32-indexed one (`table.copy $t32 $t64`). Found it running the memory64 tests under `--run-all-exports`.

`DoTableCopy`/`DoMemoryCopy` pop the length operand with the source's index type (`PopPtr(table_src)`/`PopPtr(mem_src)`). But the length's type is the minimum of the two index types, not the source's, so for a 64-bit source into a 32-bit destination the length is i32 while the interpreter reads it as i64. `TypeChecker::OnMemoryCopy`/`OnTableCopy` already spell out the min rule; the runtime side just didn't follow it.

Debug builds trip the type assertion. In release the read only gives the right answer because the `Value` union happens to be zero-initialised.

Pop the length as u64 only when both memories/tables are 64-bit. Same-width copies are byte-identical. Regression test added under test/interp.