### PR TITLE
[binary-reader] Fix out-of-bounds read on invalid name sub-section

### DIFF
--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -2059,10 +2059,16 @@ Result BinaryReader::ReadNameSection(Offset section_size) {
     ReadEndRestoreGuard guard(this);
     read_end_ = subsection_end;
 
-    NameSectionSubsection type = static_cast<NameSectionSubsection>(name_type);
-    if (type <= NameSectionSubsection::Last) {
-      CALLBACK(OnNameSubsection, i, type, subsection_size);
+    if (name_type > static_cast<uint32_t>(NameSectionSubsection::Last)) {
+      // Unknown subsection, skip it.  Checked before the cast so that an
+      // out-of-range id never becomes a NameSectionSubsection.
+      state_.offset = subsection_end;
+      ++i;
+      continue;
     }
+
+    NameSectionSubsection type = static_cast<NameSectionSubsection>(name_type);
+    CALLBACK(OnNameSubsection, i, type, subsection_size);
 
     switch (type) {
       case NameSectionSubsection::Module:

--- a/src/binary.cc
+++ b/src/binary.cc
@@ -63,9 +63,8 @@ const char* GetNameSectionSubsectionName(NameSectionSubsection subsec) {
   static_assert(WABT_ENUM_COUNT(NameSectionSubsection) ==
                     WABT_ARRAY_SIZE(NameSubsectionName),
                 "Malformed ExprTypeName array");
-  return size_t(subsec) < WABT_ARRAY_SIZE(NameSubsectionName)
-             ? NameSubsectionName[size_t(subsec)]
-             : "<error_name_subsection>";
+  assert(size_t(subsec) < WABT_ARRAY_SIZE(NameSubsectionName));
+  return NameSubsectionName[size_t(subsec)];
 }
 
 }  // namespace wabt

--- a/src/binary.cc
+++ b/src/binary.cc
@@ -63,7 +63,9 @@ const char* GetNameSectionSubsectionName(NameSectionSubsection subsec) {
   static_assert(WABT_ENUM_COUNT(NameSectionSubsection) ==
                     WABT_ARRAY_SIZE(NameSubsectionName),
                 "Malformed ExprTypeName array");
-  return NameSubsectionName[size_t(subsec)];
+  return size_t(subsec) < WABT_ARRAY_SIZE(NameSubsectionName)
+             ? NameSubsectionName[size_t(subsec)]
+             : "<error_name_subsection>";
 }
 
 }  // namespace wabt

--- a/src/test-binary-reader.cc
+++ b/src/test-binary-reader.cc
@@ -224,14 +224,14 @@ TEST(BinaryReaderLogging, DeepIndentDoesNotOverflowBuffer) {
 
 TEST(BinaryReaderLogging, NameSubsectionTypeDoesNotOverflowNameTable) {
   // NameSectionSubsection has no explicit underlying type, so it is backed by
-  // signed int.  ReadNameSection reads the subsection id as a uint32_t and
-  // gates the OnNameSubsection callback with `type <= Last`, a signed compare
-  // with no lower bound, so an id >= 0x80000000 becomes a negative enum, slips
-  // through, and reaches GetNameSectionSubsectionName, which indexed
-  // NameSubsectionName[size_t(subsec)] with no range check (ASan:
-  // global-buffer-overflow READ).  The module itself is valid: the unknown
-  // subsection is skipped, so this is on the normal stop-on-first-error path,
-  // reached with verbose logging on (e.g. `wasm2wat -v`).
+  // signed int.  ReadNameSection used to cast the subsection id and gate the
+  // OnNameSubsection callback with `type <= Last`, a signed compare with no
+  // lower bound, so an id >= 0x80000000 became a negative enum, slipped
+  // through, and reached GetNameSectionSubsectionName, which indexes
+  // NameSubsectionName[size_t(subsec)] (ASan: global-buffer-overflow READ).
+  // The module itself is valid: the unknown subsection is skipped, so this is
+  // on the normal stop-on-first-error path, reached with verbose logging on
+  // (e.g. `wasm2wat -v`).
   // TODO: Move this test upstream into the spec repo.
 
   uint8_t data[] = {

--- a/src/test-binary-reader.cc
+++ b/src/test-binary-reader.cc
@@ -222,38 +222,6 @@ TEST(BinaryReaderLogging, DeepIndentDoesNotOverflowBuffer) {
   (void)result;
 }
 
-TEST(BinaryReaderLogging, NameSubsectionTypeDoesNotOverflowNameTable) {
-  // NameSectionSubsection has no explicit underlying type, so it is backed by
-  // signed int.  ReadNameSection used to cast the subsection id and gate the
-  // OnNameSubsection callback with `type <= Last`, a signed compare with no
-  // lower bound, so an id >= 0x80000000 became a negative enum, slipped
-  // through, and reached GetNameSectionSubsectionName, which indexes
-  // NameSubsectionName[size_t(subsec)] (ASan: global-buffer-overflow READ).
-  // The module itself is valid: the unknown subsection is skipped, so this is
-  // on the normal stop-on-first-error path, reached with verbose logging on
-  // (e.g. `wasm2wat -v`).
-  // TODO: Move this test upstream into the spec repo.
-
-  uint8_t data[] = {
-      0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,  // magic + version
-      0x00,                                            // custom section
-      0x0b,                                            // section size = 11
-      0x04, 'n',  'a',  'm',  'e',                     // section name "name"
-      0xff, 0xff, 0xff, 0xff, 0x0f,  // subsection type = 0xffffffff
-      0x00,                          // subsection size = 0
-  };
-
-  MemoryStream log_stream;
-  BinaryReaderError reader;
-  ReadBinaryOptions options(Features{}, &log_stream, /*read_debug_names=*/true,
-                            /*stop_on_first_error=*/true,
-                            /*fail_on_custom_section_error=*/false);
-  // Just ensure the out-of-range subsection type does not read off the name
-  // table when it is logged.
-  Result result = ReadBinary(data, &reader, options);
-  (void)result;
-}
-
 TEST(Opcode, DecodeInvalidOpcode) {
   Opcode opcode = Opcode::FromCode(0xfd, 0x13f);
   EXPECT_TRUE(opcode.IsInvalid());

--- a/src/test-binary-reader.cc
+++ b/src/test-binary-reader.cc
@@ -222,6 +222,38 @@ TEST(BinaryReaderLogging, DeepIndentDoesNotOverflowBuffer) {
   (void)result;
 }
 
+TEST(BinaryReaderLogging, NameSubsectionTypeDoesNotOverflowNameTable) {
+  // NameSectionSubsection has no explicit underlying type, so it is backed by
+  // signed int.  ReadNameSection reads the subsection id as a uint32_t and
+  // gates the OnNameSubsection callback with `type <= Last`, a signed compare
+  // with no lower bound, so an id >= 0x80000000 becomes a negative enum, slips
+  // through, and reaches GetNameSectionSubsectionName, which indexed
+  // NameSubsectionName[size_t(subsec)] with no range check (ASan:
+  // global-buffer-overflow READ).  The module itself is valid: the unknown
+  // subsection is skipped, so this is on the normal stop-on-first-error path,
+  // reached with verbose logging on (e.g. `wasm2wat -v`).
+  // TODO: Move this test upstream into the spec repo.
+
+  uint8_t data[] = {
+      0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,  // magic + version
+      0x00,                                            // custom section
+      0x0b,                                            // section size = 11
+      0x04, 'n',  'a',  'm',  'e',                     // section name "name"
+      0xff, 0xff, 0xff, 0xff, 0x0f,  // subsection type = 0xffffffff
+      0x00,                          // subsection size = 0
+  };
+
+  MemoryStream log_stream;
+  BinaryReaderError reader;
+  ReadBinaryOptions options(Features{}, &log_stream, /*read_debug_names=*/true,
+                            /*stop_on_first_error=*/true,
+                            /*fail_on_custom_section_error=*/false);
+  // Just ensure the out-of-range subsection type does not read off the name
+  // table when it is logged.
+  Result result = ReadBinary(data, &reader, options);
+  (void)result;
+}
+
 TEST(Opcode, DecodeInvalidOpcode) {
   Opcode opcode = Opcode::FromCode(0xfd, 0x13f);
   EXPECT_TRUE(opcode.IsInvalid());

--- a/test/binary/name-section-unknown-subsection.txt
+++ b/test/binary/name-section-unknown-subsection.txt
@@ -1,0 +1,31 @@
+;;; TOOL: run-objdump-gen-wasm
+;;; ARGS1: --debug
+magic
+version
+;; A valid module whose "name" section carries a single unknown name
+;; subsection.  The subsection type LEB is 0xffffffff, past
+;; NameSectionSubsection::Last.  ReadNameSection must skip it as an unknown
+;; subsection; with --debug the subsection is logged, which used to index
+;; NameSubsectionName off the end (ASan global-buffer-overflow read).
+section("name") {
+  leb_u32(0xffffffff)  ;; subsection type
+  leb_u32(0)           ;; subsection size
+}
+(;; STDERR ;;;
+BeginModule(version: 1)
+  BeginCustomSection('name', size: 11)
+    BeginGenericCustomSection(11)
+      OnGenericCustomSection(name: "name", size: 6)
+    EndGenericCustomSection
+    BeginNamesSection(11)
+    EndNamesSection
+  EndCustomSection
+EndModule
+;;; STDERR ;;)
+(;; STDOUT ;;;
+
+name-section-unknown-subsection.wasm:	file format wasm 0x1
+
+Code Disassembly:
+
+;;; STDOUT ;;)


### PR DESCRIPTION
ASan, `wasm2wat -v` on a valid module whose name section carries one
unknown subsection (type LEB `0xffffffff`):

    binary.cc:66 GetNameSectionSubsectionName
    READ of size 8 ... 8 bytes before global 'wabt::NameSubsectionName' (size 96)

Worked back from the read to the subsection id. `NameSectionSubsection`
has no explicit underlying type, so it is a signed int. `ReadNameSection`
reads the id into a `uint32_t`, casts it, and only gates the
`OnNameSubsection` callback with `type <= Last`, a signed compare with no
lower bound. An id of `0xffffffff` casts to a negative enum, passes the
gate, and reaches `GetNameSectionSubsectionName`, which indexed
`NameSubsectionName[size_t(subsec)]` with no range check. The logging
delegate then prints the returned wild `const char*` with `%s`.

The module is valid: an unknown name subsection is skipped, so this only
shows with verbose logging (`wasm2wat -v`, `wasm-objdump -v`,
`wasm-interp -v`). Found feeding fuzz-style name sections through
`wasm2wat -v`.

Fixed in the caller: `ReadNameSection` compares the raw `name_type`
against `Last` before the cast, so an out-of-range id is skipped as an
unknown subsection and never becomes a `NameSectionSubsection`.
`GetNameSectionSubsectionName` keeps the plain index and asserts the
in-range precondition. Regression test added under
`src/test-binary-reader.cc`.
