### PR TITLE
Fix out-of-bounds read when tracing global.set and table ops

### DIFF
--- a/src/interp/interp.cc
+++ b/src/interp/interp.cc
@@ -3019,11 +3019,15 @@ ValueType Thread::TraceSource::GetLocalType(Index stack_slot) {
 }
 
 ValueType Thread::TraceSource::GetGlobalType(Index index) {
-  return thread_->mod_->desc().globals[index].type.type;
+  // The immediate counts imported globals, so resolve it against the
+  // instance's globals rather than the module's defined-only descriptions.
+  Global::Ptr global{thread_->store_, thread_->inst_->globals()[index]};
+  return global->type().type;
 }
 
 ValueType Thread::TraceSource::GetTableElementType(Index index) {
-  return thread_->mod_->desc().tables[index].type.element;
+  Table::Ptr table{thread_->store_, thread_->inst_->tables()[index]};
+  return table->type().element;
 }
 
 }  // namespace interp

--- a/test/interp/tracing-imported-index.txt
+++ b/test/interp/tracing-imported-index.txt
@@ -1,0 +1,36 @@
+;;; TOOL: run-interp-spec
+;;; ARGS: --trace
+(module
+  ;; The global.set/table.* immediates count imported globals and tables, so
+  ;; tracing them has to resolve the index against the instance rather than the
+  ;; module's defined-only descriptions.
+  (import "spectest" "global_i32" (global i32))
+  (import "spectest" "table" (table 10 20 funcref))
+  (global $g (mut i64) (i64.const 0))
+  (table $t 1 2 funcref)
+
+  (func (export "set_global") (global.set $g (i64.const 7)))
+  (func (export "grow_table") (drop (table.grow $t (ref.null func) (i32.const 1))))
+  (func (export "fill_table") (table.fill $t (i32.const 0) (ref.null func) (i32.const 1))))
+(invoke "set_global")
+(invoke "grow_table")
+(invoke "fill_table")
+(;; STDOUT ;;;
+#0.   16: V:0  | i64.const 7
+#0.   28: V:1  | global.set $1, 7
+#0.   36: V:0  | return
+set_global() =>
+#0.   40: V:0  | ref.null
+#0.   44: V:1  | i32.const 1
+#0.   52: V:2  | table.grow $1, funcref:0, 1
+#0.   60: V:1  | drop
+#0.   64: V:0  | return
+grow_table() =>
+#0.   68: V:0  | i32.const 0
+#0.   76: V:1  | ref.null
+#0.   80: V:2  | i32.const 1
+#0.   88: V:3  | table.fill $1, 0, funcref:0, 1
+#0.   96: V:0  | return
+fill_table() =>
+4/4 tests passed.
+;;; STDOUT ;;)


### PR DESCRIPTION
ASan, `spectest-interp --trace` on a module that imports a global and also defines one:

    ==73766==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x60e0000002a4
    READ of size 8 at 0x60e0000002a4 thread T0
        #1 Thread::TraceSource::GetGlobalType(unsigned int) interp.cc:3022
        #2 Thread::TraceSource::Pick(unsigned int, Instr) interp.cc:2954
        #3 Istream::Trace(...) istream.cc:887
    0x60e0000002a4 is located 12 bytes after 152-byte region [0x60e000000200,0x60e000000298)

Noticed it while reading the trace helpers. `ModuleDesc::globals` and `ModuleDesc::tables` hold only the defined entries, imports live in `ModuleDesc::imports`. But the `global.set`/`table.*` immediate is the module-level index, which counts imports first. One imported global plus one defined global is already enough to run off the end. `GetTableElementType` has the same shape at interp.cc:3026, reached from `table.grow` and `table.fill`.

The garbage `ValueType` that comes back then decides how the operand `Value` is read, so a debug build aborts on the `CheckType` assert in interp.h and a release build prints an arbitrary reference index.

Both immediates now resolve against the instance, which is what the `GlobalSet`, `DoTableGrow` and `DoTableFill` handlers already do. Regression test added under test/interp.
