### PR TITLE
Allow initializer expressions to reference defined immutable globals

### DIFF
--- a/include/wabt/shared-validator.h
+++ b/include/wabt/shared-validator.h
@@ -367,7 +367,6 @@ class SharedValidator {
   std::vector<TagType> tags_;         // Includes imported and defined.
   std::vector<ElemType> elems_;
   Index starts_ = 0;
-  Index num_imported_globals_ = 0;
   Index data_segments_ = 0;
 
   // Includes parameters, since this is only used for validating

--- a/include/wabt/shared-validator.h
+++ b/include/wabt/shared-validator.h
@@ -85,7 +85,8 @@ class SharedValidator {
   Result OnTable(const Location&, Type elem_type, const Limits&, TableImportStatus import_status, TableInitExprStatus init_provided);
   Result OnMemory(const Location&, const Limits&, uint32_t page_size);
   Result OnGlobalImport(const Location&, Type type, bool mutable_);
-  Result OnGlobal(const Location&, Type type, bool mutable_);
+  Result OnGlobalType(const Location&, Type type);
+  Result OnGlobal(Type type, bool mutable_);
   Result OnTag(const Location&, Var sig_var);
 
   Result OnExport(const Location&,

--- a/src/interp/binary-reader-interp.cc
+++ b/src/interp/binary-reader-interp.cc
@@ -359,6 +359,14 @@ class BinaryReaderInterp : public BinaryReaderNop {
   std::vector<GlobalType> global_types_;  // Includes imported and defined.
   std::vector<TagType> tag_types_;        // Includes imported and defined.
 
+  // The defined global whose initializer is currently being validated. It is
+  // published to the validator only after its initializer has been validated,
+  // so it is visible to later globals but not to itself.
+  bool has_pending_global_ = false;
+  Type pending_global_type_ = Type::Void;
+  bool pending_global_mutable_ = false;
+  Location pending_global_loc_;
+
   std::string_view filename_;
 };
 
@@ -683,11 +691,18 @@ Result BinaryReaderInterp::OnGlobalCount(Index count) {
 }
 
 Result BinaryReaderInterp::BeginGlobal(Index index, Type type, bool mutable_) {
-  CHECK_RESULT(validator_.OnGlobal(GetLocation(), type, mutable_));
   GlobalType global_type{type, ToMutability(mutable_)};
   FuncDesc init_func{FuncType{{}, {type}}, {}, Istream::kInvalidOffset, {}};
   module_.globals.push_back(GlobalDesc{global_type, init_func});
   global_types_.push_back(global_type);
+
+  // Defer publishing the global to the validator until after its initializer
+  // has been validated (see EndGlobalInitExpr), so it is visible to later
+  // globals but not to itself.
+  has_pending_global_ = true;
+  pending_global_type_ = type;
+  pending_global_mutable_ = mutable_;
+  pending_global_loc_ = GetLocation();
   return Result::Ok;
 }
 
@@ -716,7 +731,13 @@ Result BinaryReaderInterp::BeginInitExpr(FuncDesc* func) {
 }
 
 Result BinaryReaderInterp::EndGlobalInitExpr(Index index) {
-  return EndInitExpr();
+  Result result = EndInitExpr();
+  if (has_pending_global_) {
+    result |= validator_.OnGlobal(pending_global_loc_, pending_global_type_,
+                                  pending_global_mutable_);
+    has_pending_global_ = false;
+  }
+  return result;
 }
 
 Result BinaryReaderInterp::OnTagCount(Index count) {

--- a/src/interp/binary-reader-interp.cc
+++ b/src/interp/binary-reader-interp.cc
@@ -363,9 +363,9 @@ class BinaryReaderInterp : public BinaryReaderNop {
   // published to the validator only after its initializer has been validated,
   // so it is visible to later globals but not to itself.
   bool has_pending_global_ = false;
+  bool pending_global_type_valid_ = false;
   Type pending_global_type_ = Type::Void;
   bool pending_global_mutable_ = false;
-  Location pending_global_loc_;
 
   std::string_view filename_;
 };
@@ -700,10 +700,11 @@ Result BinaryReaderInterp::BeginGlobal(Index index, Type type, bool mutable_) {
   // has been validated (see EndGlobalInitExpr), so it is visible to later
   // globals but not to itself.
   has_pending_global_ = true;
+  Result global_type_result = validator_.OnGlobalType(GetLocation(), type);
+  pending_global_type_valid_ = Succeeded(global_type_result);
   pending_global_type_ = type;
   pending_global_mutable_ = mutable_;
-  pending_global_loc_ = GetLocation();
-  return Result::Ok;
+  return global_type_result;
 }
 
 Result BinaryReaderInterp::BeginGlobalInitExpr(Index index) {
@@ -733,8 +734,10 @@ Result BinaryReaderInterp::BeginInitExpr(FuncDesc* func) {
 Result BinaryReaderInterp::EndGlobalInitExpr(Index index) {
   Result result = EndInitExpr();
   if (has_pending_global_) {
-    result |= validator_.OnGlobal(pending_global_loc_, pending_global_type_,
-                                  pending_global_mutable_);
+    if (pending_global_type_valid_) {
+      result |=
+          validator_.OnGlobal(pending_global_type_, pending_global_mutable_);
+    }
     has_pending_global_ = false;
   }
   return result;

--- a/src/shared-validator.cc
+++ b/src/shared-validator.cc
@@ -212,7 +212,6 @@ Result SharedValidator::OnGlobalImport(const Location& loc,
     result |= Result::Error;
   }
   globals_.push_back(GlobalType{type, mutable_});
-  ++num_imported_globals_;
   return result;
 }
 
@@ -985,12 +984,6 @@ Result SharedValidator::OnGlobalGet(const Location& loc, Var global_var) {
   result |= CheckGlobalIndex(global_var, &global_type);
   result |= typechecker_.OnGlobalGet(global_type.type);
   if (Succeeded(result) && in_init_expr_) {
-    if (global_var.index() >= num_imported_globals_) {
-      PrintError(
-          global_var.loc,
-          "initializer expression can only reference an imported global");
-      result |= Result::Error;
-    }
     if (global_type.mutable_) {
       PrintError(loc,
                  "initializer expression cannot reference a mutable global");

--- a/src/shared-validator.cc
+++ b/src/shared-validator.cc
@@ -215,10 +215,11 @@ Result SharedValidator::OnGlobalImport(const Location& loc,
   return result;
 }
 
-Result SharedValidator::OnGlobal(const Location& loc,
-                                 Type type,
-                                 bool mutable_) {
-  CHECK_RESULT(CheckReferenceType(loc, type, "globals"));
+Result SharedValidator::OnGlobalType(const Location& loc, Type type) {
+  return CheckReferenceType(loc, type, "globals");
+}
+
+Result SharedValidator::OnGlobal(Type type, bool mutable_) {
   globals_.push_back(GlobalType{type, mutable_});
   return Result::Ok;
 }

--- a/src/validator.cc
+++ b/src/validator.cc
@@ -885,6 +885,10 @@ Result Validator::CheckModule() {
   // Global section.
   for (const ModuleField& field : module->fields) {
     if (auto* f = dyn_cast<GlobalModuleField>(&field)) {
+      Result global_type_result =
+          validator_.OnGlobalType(field.loc, f->global.type);
+      result_ |= global_type_result;
+
       // Validate the initializer expression before publishing the global so
       // that it is only visible to later globals, and not to itself.
       result_ |= validator_.BeginInitExpr(field.loc, f->global.type);
@@ -892,8 +896,9 @@ Result Validator::CheckModule() {
       result_ |=
           visitor.VisitExprList(const_cast<ExprList&>(f->global.init_expr));
       result_ |= validator_.EndInitExpr();
-      result_ |=
-          validator_.OnGlobal(field.loc, f->global.type, f->global.mutable_);
+      if (Succeeded(global_type_result)) {
+        result_ |= validator_.OnGlobal(f->global.type, f->global.mutable_);
+      }
     }
   }
 

--- a/src/validator.cc
+++ b/src/validator.cc
@@ -885,15 +885,15 @@ Result Validator::CheckModule() {
   // Global section.
   for (const ModuleField& field : module->fields) {
     if (auto* f = dyn_cast<GlobalModuleField>(&field)) {
-      result_ |=
-          validator_.OnGlobal(field.loc, f->global.type, f->global.mutable_);
-
-      // Init expr.
+      // Validate the initializer expression before publishing the global so
+      // that it is only visible to later globals, and not to itself.
       result_ |= validator_.BeginInitExpr(field.loc, f->global.type);
       ExprVisitor visitor(this);
       result_ |=
           visitor.VisitExprList(const_cast<ExprList&>(f->global.init_expr));
       result_ |= validator_.EndInitExpr();
+      result_ |=
+          validator_.OnGlobal(field.loc, f->global.type, f->global.mutable_);
     }
   }
 

--- a/test/old-spec/data.wast
+++ b/test/old-spec/data.wast
@@ -1,6 +1,6 @@
 ;; Vendored copy of data.wast from the pinned testsuite, patched with the
-;; 2025-09 spec change that allows global.get of defined immutable globals
-;; in initializer expressions (ref: WebAssembly/testsuite@4b24564c84).
+;; spec change that allows global.get of defined immutable globals in
+;; data segment offsets (ref: WebAssembly/testsuite@4b24564c84).
 ;; Test the data section
 
 ;; Syntax

--- a/test/old-spec/data.wast
+++ b/test/old-spec/data.wast
@@ -1,0 +1,495 @@
+;; Vendored copy of data.wast from the pinned testsuite, patched with the
+;; 2025-09 spec change that allows global.get of defined immutable globals
+;; in initializer expressions (ref: WebAssembly/testsuite@4b24564c84).
+;; Test the data section
+
+;; Syntax
+
+(module
+  (memory $m 1)
+  (data (i32.const 0))
+  (data (i32.const 1) "a" "" "bcd")
+  (data (offset (i32.const 0)))
+  (data (offset (i32.const 0)) "" "a" "bc" "")
+  (data (memory 0) (i32.const 0))
+  (data (memory 0x0) (i32.const 1) "a" "" "bcd")
+  (data (memory 0x000) (offset (i32.const 0)))
+  (data (memory 0) (offset (i32.const 0)) "" "a" "bc" "")
+  (data (memory $m) (i32.const 0))
+  (data (memory $m) (i32.const 1) "a" "" "bcd")
+  (data (memory $m) (offset (i32.const 0)))
+  (data (memory $m) (offset (i32.const 0)) "" "a" "bc" "")
+  (data $d1 (i32.const 0))
+  (data $d2 (i32.const 1) "a" "" "bcd")
+  (data $d3 (offset (i32.const 0)))
+  (data $d4 (offset (i32.const 0)) "" "a" "bc" "")
+  (data $d5 (memory 0) (i32.const 0))
+  (data $d6 (memory 0x0) (i32.const 1) "a" "" "bcd")
+  (data $d7 (memory 0x000) (offset (i32.const 0)))
+  (data $d8 (memory 0) (offset (i32.const 0)) "" "a" "bc" "")
+  (data $d9 (memory $m) (i32.const 0))
+  (data $d10 (memory $m) (i32.const 1) "a" "" "bcd")
+  (data $d11 (memory $m) (offset (i32.const 0)))
+  (data $d12 (memory $m) (offset (i32.const 0)) "" "a" "bc" "")
+)
+
+;; Basic use
+
+(module
+  (memory 1)
+  (data (i32.const 0) "a")
+)
+(module
+  (import "spectest" "memory" (memory 1))
+  (data (i32.const 0) "a")
+)
+
+(module
+  (memory 1)
+  (data (i32.const 0) "a")
+  (data (i32.const 3) "b")
+  (data (i32.const 100) "cde")
+  (data (i32.const 5) "x")
+  (data (i32.const 3) "c")
+)
+(module
+  (import "spectest" "memory" (memory 1))
+  (data (i32.const 0) "a")
+  (data (i32.const 1) "b")
+  (data (i32.const 2) "cde")
+  (data (i32.const 3) "f")
+  (data (i32.const 2) "g")
+  (data (i32.const 1) "h")
+)
+
+(module
+  (global (import "spectest" "global_i32") i32)
+  (memory 1)
+  (data (global.get 0) "a")
+)
+(module
+  (global (import "spectest" "global_i32") i32)
+  (import "spectest" "memory" (memory 1))
+  (data (global.get 0) "a")
+)
+
+(module
+  (global $g (import "spectest" "global_i32") i32)
+  (memory 1)
+  (data (global.get $g) "a")
+)
+(module
+  (global $g (import "spectest" "global_i32") i32)
+  (import "spectest" "memory" (memory 1))
+  (data (global.get $g) "a")
+)
+
+(module (memory 1) (global i32 (i32.const 0)) (data (global.get 0) "a"))
+(module (memory 1) (global $g i32 (i32.const 0)) (data (global.get $g) "a"))
+
+
+;; Corner cases
+
+(module
+  (memory 1)
+  (data (i32.const 0) "a")
+  (data (i32.const 0xffff) "b")
+)
+(module
+  (import "spectest" "memory" (memory 1))
+  (data (i32.const 0) "a")
+  (data (i32.const 0xffff) "b")
+)
+
+(module
+  (memory 2)
+  (data (i32.const 0x1_ffff) "a")
+)
+
+(module
+  (memory 0)
+  (data (i32.const 0))
+)
+(module
+  (import "spectest" "memory" (memory 0))
+  (data (i32.const 0))
+)
+
+(module
+  (memory 0 0)
+  (data (i32.const 0))
+)
+
+(module
+  (memory 1)
+  (data (i32.const 0x1_0000) "")
+)
+
+(module
+  (memory 0)
+  (data (i32.const 0) "" "")
+)
+(module
+  (import "spectest" "memory" (memory 0))
+  (data (i32.const 0) "" "")
+)
+
+(module
+  (memory 0 0)
+  (data (i32.const 0) "" "")
+)
+
+(module
+  (import "spectest" "memory" (memory 0))
+  (data (i32.const 0) "a")
+)
+
+(module
+  (import "spectest" "memory" (memory 0 3))
+  (data (i32.const 0) "a")
+)
+
+(module
+  (global (import "spectest" "global_i32") i32)
+  (import "spectest" "memory" (memory 0))
+  (data (global.get 0) "a")
+)
+
+(module
+  (global (import "spectest" "global_i32") i32)
+  (import "spectest" "memory" (memory 0 3))
+  (data (global.get 0) "a")
+)
+
+(module
+  (import "spectest" "memory" (memory 0))
+  (data (i32.const 1) "a")
+)
+
+(module
+  (import "spectest" "memory" (memory 0 3))
+  (data (i32.const 1) "a")
+)
+
+;; Invalid bounds for data
+
+(assert_trap
+  (module
+    (memory 0)
+    (data (i32.const 0) "a")
+  )
+  "out of bounds memory access"
+)
+
+(assert_trap
+  (module
+    (memory 0 0)
+    (data (i32.const 0) "a")
+  )
+  "out of bounds memory access"
+)
+
+(assert_trap
+  (module
+    (memory 0 1)
+    (data (i32.const 0) "a")
+  )
+  "out of bounds memory access"
+)
+(assert_trap
+  (module
+    (memory 0)
+    (data (i32.const 1))
+  )
+  "out of bounds memory access"
+)
+(assert_trap
+  (module
+    (memory 0 1)
+    (data (i32.const 1))
+  )
+  "out of bounds memory access"
+)
+
+;; This seems to cause a time-out on Travis.
+(;assert_unlinkable
+  (module
+    (memory 0x10000)
+    (data (i32.const 0xffffffff) "ab")
+  )
+  ""  ;; either out of memory or out of bounds
+;)
+
+(assert_trap
+  (module
+    (global (import "spectest" "global_i32") i32)
+    (memory 0)
+    (data (global.get 0) "a")
+  )
+  "out of bounds memory access"
+)
+
+(assert_trap
+  (module
+    (memory 1 2)
+    (data (i32.const 0x1_0000) "a")
+  )
+  "out of bounds memory access"
+)
+(assert_trap
+  (module
+    (import "spectest" "memory" (memory 1))
+    (data (i32.const 0x1_0000) "a")
+  )
+  "out of bounds memory access"
+)
+
+(assert_trap
+  (module
+    (memory 2)
+    (data (i32.const 0x2_0000) "a")
+  )
+  "out of bounds memory access"
+)
+
+(assert_trap
+  (module
+    (memory 2 3)
+    (data (i32.const 0x2_0000) "a")
+  )
+  "out of bounds memory access"
+)
+
+(assert_trap
+  (module
+    (memory 1)
+    (data (i32.const -1) "a")
+  )
+  "out of bounds memory access"
+)
+(assert_trap
+  (module
+    (import "spectest" "memory" (memory 1))
+    (data (i32.const -1) "a")
+  )
+  "out of bounds memory access"
+)
+
+(assert_trap
+  (module
+    (memory 2)
+    (data (i32.const -100) "a")
+  )
+  "out of bounds memory access"
+)
+(assert_trap
+  (module
+    (import "spectest" "memory" (memory 1))
+    (data (i32.const -100) "a")
+  )
+  "out of bounds memory access"
+)
+
+;; Data without memory
+
+(assert_invalid
+  (module
+    (data (i32.const 0) "")
+  )
+  "unknown memory"
+)
+
+;; Data segment with memory index 1 (only memory 0 available)
+(assert_invalid
+  (module binary
+    "\00asm" "\01\00\00\00"
+    "\05\03\01"                             ;; memory section
+    "\00\00"                                ;; memory 0
+    "\0b\07\01"                             ;; data section
+    "\02\01\41\00\0b"                       ;; active data segment 0 for memory 1
+    "\00"                                   ;; empty vec(byte)
+  )
+  "unknown memory 1"
+)
+
+;; Data segment with memory index 0 (no memory section)
+(assert_invalid
+  (module binary
+    "\00asm" "\01\00\00\00"
+    "\0b\06\01"                             ;; data section
+    "\00\41\00\0b"                          ;; active data segment 0 for memory 0
+    "\00"                                   ;; empty vec(byte)
+  )
+  "unknown memory 0"
+)
+
+;; Data segment with memory index 1 (no memory section)
+(assert_invalid
+  (module binary
+    "\00asm" "\01\00\00\00"
+    "\0b\07\01"                             ;; data section
+    "\02\01\41\00\0b"                       ;; active data segment 0 for memory 1
+    "\00"                                   ;; empty vec(byte)
+  )
+  "unknown memory 1"
+)
+
+;; Data segment with memory index 1 and vec(byte) as above,
+;; only memory 0 available.
+(assert_invalid
+  (module binary
+    "\00asm" "\01\00\00\00"
+    "\05\03\01"                             ;; memory section
+    "\00\00"                                ;; memory 0
+    "\0b\45\01"                             ;; data section
+    "\02"                                   ;; active segment
+    "\01"                                   ;; memory index
+    "\41\00\0b"                             ;; offset constant expression
+    "\3e"                                   ;; vec(byte) length
+    "\00\01\02\03\04\05\06\07\08\09\0a\0b\0c\0d\0e\0f"
+    "\10\11\12\13\14\15\16\17\18\19\1a\1b\1c\1d\1e\1f"
+    "\20\21\22\23\24\25\26\27\28\29\2a\2b\2c\2d\2e\2f"
+    "\30\31\32\33\34\35\36\37\38\39\3a\3b\3c\3d"
+  )
+  "unknown memory 1"
+)
+
+;; Data segment with memory index 1 and specially crafted vec(byte) after.
+;; This is to detect incorrect validation where memory index is interpreted
+;; as a flag followed by "\41" interpreted as the size of vec(byte)
+;; with the expected number of bytes following.
+(assert_invalid
+  (module binary
+    "\00asm" "\01\00\00\00"
+    "\0b\45\01"                             ;; data section
+    "\02"                                   ;; active segment
+    "\01"                                   ;; memory index
+    "\41\00\0b"                             ;; offset constant expression
+    "\3e"                                   ;; vec(byte) length
+    "\00\01\02\03\04\05\06\07\08\09\0a\0b\0c\0d\0e\0f"
+    "\10\11\12\13\14\15\16\17\18\19\1a\1b\1c\1d\1e\1f"
+    "\20\21\22\23\24\25\26\27\28\29\2a\2b\2c\2d\2e\2f"
+    "\30\31\32\33\34\35\36\37\38\39\3a\3b\3c\3d"
+  )
+  "unknown memory 1"
+)
+
+
+;; Invalid offsets
+
+(assert_invalid
+  (module
+    (memory 1)
+    (data (i64.const 0))
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+  (module
+    (memory 1)
+    (data (ref.null func))
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+  (module 
+    (memory 1)
+    (data (offset (;empty instruction sequence;)))
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+  (module
+    (memory 1)
+    (data (offset (i32.const 0) (i32.const 0)))
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+  (module
+    (global (import "test" "global-i32") i32)
+    (memory 1)
+    (data (offset (global.get 0) (global.get 0)))
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+  (module
+    (global (import "test" "global-i32") i32)
+    (memory 1)
+    (data (offset (global.get 0) (i32.const 0)))
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+  (module
+    (memory 1)
+    (data (i32.ctz (i32.const 0)))
+  )
+  "constant expression required"
+)
+
+(assert_invalid
+  (module
+    (memory 1)
+    (data (nop))
+  )
+  "constant expression required"
+)
+
+(assert_invalid
+  (module
+    (memory 1)
+    (data (offset (nop) (i32.const 0)))
+  )
+  "constant expression required"
+)
+
+(assert_invalid
+  (module
+    (memory 1)
+    (data (offset (i32.const 0) (nop)))
+  )
+  "constant expression required"
+)
+
+(assert_invalid
+  (module
+    (global $g (import "test" "g") (mut i32))
+    (memory 1)
+    (data (global.get $g))
+  )
+  "constant expression required"
+)
+
+(assert_invalid
+   (module 
+     (memory 1)
+     (data (global.get 0))
+   )
+   "unknown global 0"
+)
+
+(assert_invalid
+   (module
+     (global (import "test" "global-i32") i32)
+     (memory 1)
+     (data (global.get 1))
+   )
+   "unknown global 1"
+)
+
+(assert_invalid
+   (module 
+     (global (import "test" "global-mut-i32") (mut i32))
+     (memory 1)
+     (data (global.get 0))
+   )
+   "constant expression required"
+)

--- a/test/old-spec/elem.wast
+++ b/test/old-spec/elem.wast
@@ -1,6 +1,6 @@
 ;; Vendored copy of elem.wast from the pinned testsuite, patched with the
-;; 2025-09 spec change that allows global.get of defined immutable globals
-;; in initializer expressions (ref: WebAssembly/testsuite@4b24564c84).
+;; spec change that allows global.get of defined immutable globals in
+;; element segment offsets (ref: WebAssembly/testsuite@4b24564c84).
 ;; Test the element section
 
 ;; Syntax

--- a/test/old-spec/elem.wast
+++ b/test/old-spec/elem.wast
@@ -1,0 +1,695 @@
+;; Vendored copy of elem.wast from the pinned testsuite, patched with the
+;; 2025-09 spec change that allows global.get of defined immutable globals
+;; in initializer expressions (ref: WebAssembly/testsuite@4b24564c84).
+;; Test the element section
+
+;; Syntax
+(module
+  (table $t 10 funcref)
+  (func $f)
+  (func $g)
+
+  ;; Passive
+  (elem funcref)
+  (elem funcref (ref.func $f) (item ref.func $f) (item (ref.null func)) (ref.func $g))
+  (elem func)
+  (elem func $f $f $g $g)
+
+  (elem $p1 funcref)
+  (elem $p2 funcref (ref.func $f) (ref.func $f) (ref.null func) (ref.func $g))
+  (elem $p3 func)
+  (elem $p4 func $f $f $g $g)
+
+  ;; Active
+  (elem (table $t) (i32.const 0) funcref)
+  (elem (table $t) (i32.const 0) funcref (ref.func $f) (ref.null func))
+  (elem (table $t) (i32.const 0) func)
+  (elem (table $t) (i32.const 0) func $f $g)
+  (elem (table $t) (offset (i32.const 0)) funcref)
+  (elem (table $t) (offset (i32.const 0)) func $f $g)
+  (elem (table 0) (i32.const 0) func)
+  (elem (table 0x0) (i32.const 0) func $f $f)
+  (elem (table 0x000) (offset (i32.const 0)) func)
+  (elem (table 0) (offset (i32.const 0)) func $f $f)
+  (elem (table $t) (i32.const 0) func)
+  (elem (table $t) (i32.const 0) func $f $f)
+  (elem (table $t) (offset (i32.const 0)) func)
+  (elem (table $t) (offset (i32.const 0)) func $f $f)
+  (elem (offset (i32.const 0)))
+  (elem (offset (i32.const 0)) funcref (ref.func $f) (ref.null func))
+  (elem (offset (i32.const 0)) func $f $f)
+  (elem (offset (i32.const 0)) $f $f)
+  (elem (i32.const 0))
+  (elem (i32.const 0) funcref (ref.func $f) (ref.null func))
+  (elem (i32.const 0) func $f $f)
+  (elem (i32.const 0) $f $f)
+  (elem (i32.const 0) funcref (item (ref.func $f)) (item (ref.null func)))
+
+  (elem $a1 (table $t) (i32.const 0) funcref)
+  (elem $a2 (table $t) (i32.const 0) funcref (ref.func $f) (ref.null func))
+  (elem $a3 (table $t) (i32.const 0) func)
+  (elem $a4 (table $t) (i32.const 0) func $f $g)
+  (elem $a9 (table $t) (offset (i32.const 0)) funcref)
+  (elem $a10 (table $t) (offset (i32.const 0)) func $f $g)
+  (elem $a11 (table 0) (i32.const 0) func)
+  (elem $a12 (table 0x0) (i32.const 0) func $f $f)
+  (elem $a13 (table 0x000) (offset (i32.const 0)) func)
+  (elem $a14 (table 0) (offset (i32.const 0)) func $f $f)
+  (elem $a15 (table $t) (i32.const 0) func)
+  (elem $a16 (table $t) (i32.const 0) func $f $f)
+  (elem $a17 (table $t) (offset (i32.const 0)) func)
+  (elem $a18 (table $t) (offset (i32.const 0)) func $f $f)
+  (elem $a19 (offset (i32.const 0)))
+  (elem $a20 (offset (i32.const 0)) funcref (ref.func $f) (ref.null func))
+  (elem $a21 (offset (i32.const 0)) func $f $f)
+  (elem $a22 (offset (i32.const 0)) $f $f)
+  (elem $a23 (i32.const 0))
+  (elem $a24 (i32.const 0) funcref (ref.func $f) (ref.null func))
+  (elem $a25 (i32.const 0) func $f $f)
+  (elem $a26 (i32.const 0) $f $f)
+
+  ;; Declarative
+  (elem declare funcref)
+  (elem declare funcref (ref.func $f) (ref.func $f) (ref.null func) (ref.func $g))
+  (elem declare func)
+  (elem declare func $f $f $g $g)
+
+  (elem $d1 declare funcref)
+  (elem $d2 declare funcref (ref.func $f) (ref.func $f) (ref.null func) (ref.func $g))
+  (elem $d3 declare func)
+  (elem $d4 declare func $f $f $g $g)
+)
+
+(module
+  (func $f)
+  (func $g)
+
+  (table $t funcref (elem (ref.func $f) (ref.null func) (ref.func $g)))
+)
+
+
+;; Basic use
+
+(module
+  (table 10 funcref)
+  (func $f)
+  (elem (i32.const 0) $f)
+)
+(module
+  (import "spectest" "table" (table 10 funcref))
+  (func $f)
+  (elem (i32.const 0) $f)
+)
+
+(module
+  (table 10 funcref)
+  (func $f)
+  (elem (i32.const 0) $f)
+  (elem (i32.const 3) $f)
+  (elem (i32.const 7) $f)
+  (elem (i32.const 5) $f)
+  (elem (i32.const 3) $f)
+)
+(module
+  (import "spectest" "table" (table 10 funcref))
+  (func $f)
+  (elem (i32.const 9) $f)
+  (elem (i32.const 3) $f)
+  (elem (i32.const 7) $f)
+  (elem (i32.const 3) $f)
+  (elem (i32.const 5) $f)
+)
+
+(module
+  (global (import "spectest" "global_i32") i32)
+  (table 1000 funcref)
+  (func $f)
+  (elem (global.get 0) $f)
+)
+
+(module
+  (global $g (import "spectest" "global_i32") i32)
+  (table 1000 funcref)
+  (func $f)
+  (elem (global.get $g) $f)
+)
+
+(module
+  (type $out-i32 (func (result i32)))
+  (table 10 funcref)
+  (elem (i32.const 7) $const-i32-a)
+  (elem (i32.const 9) $const-i32-b)
+  (func $const-i32-a (type $out-i32) (i32.const 65))
+  (func $const-i32-b (type $out-i32) (i32.const 66))
+  (func (export "call-7") (type $out-i32)
+    (call_indirect (type $out-i32) (i32.const 7))
+  )
+  (func (export "call-9") (type $out-i32)
+    (call_indirect (type $out-i32) (i32.const 9))
+  )
+)
+(assert_return (invoke "call-7") (i32.const 65))
+(assert_return (invoke "call-9") (i32.const 66))
+
+;; Same as the above, but use ref.null to ensure the elements use exprs.
+;; Note: some tools like wast2json avoid using exprs when possible.
+(module
+  (type $out-i32 (func (result i32)))
+  (table 11 funcref)
+  (elem (i32.const 6) funcref (ref.null func) (ref.func $const-i32-a))
+  (elem (i32.const 9) funcref (ref.func $const-i32-b) (ref.null func))
+  (func $const-i32-a (type $out-i32) (i32.const 65))
+  (func $const-i32-b (type $out-i32) (i32.const 66))
+  (func (export "call-7") (type $out-i32)
+    (call_indirect (type $out-i32) (i32.const 7))
+  )
+  (func (export "call-9") (type $out-i32)
+    (call_indirect (type $out-i32) (i32.const 9))
+  )
+)
+(assert_return (invoke "call-7") (i32.const 65))
+(assert_return (invoke "call-9") (i32.const 66))
+
+(module
+  (global i32 (i32.const 0))
+  (table 1 funcref) (elem (global.get 0) $f) (func $f)
+)
+(module
+  (global $g i32 (i32.const 0))
+  (table 1 funcref) (elem (global.get $g) $f) (func $f)
+)
+
+
+;; Corner cases
+
+(module
+  (table 10 funcref)
+  (func $f)
+  (elem (i32.const 9) $f)
+)
+(module
+  (import "spectest" "table" (table 10 funcref))
+  (func $f)
+  (elem (i32.const 9) $f)
+)
+
+(module
+  (table 0 funcref)
+  (elem (i32.const 0))
+)
+(module
+  (import "spectest" "table" (table 0 funcref))
+  (elem (i32.const 0))
+)
+
+(module
+  (table 0 0 funcref)
+  (elem (i32.const 0))
+)
+
+(module
+  (table 20 funcref)
+  (elem (i32.const 20))
+)
+
+(module
+  (import "spectest" "table" (table 0 funcref))
+  (func $f)
+  (elem (i32.const 0) $f)
+)
+
+(module
+  (import "spectest" "table" (table 0 100 funcref))
+  (func $f)
+  (elem (i32.const 0) $f)
+)
+
+(module
+  (import "spectest" "table" (table 0 funcref))
+  (func $f)
+  (elem (i32.const 1) $f)
+)
+
+(module
+  (import "spectest" "table" (table 0 30 funcref))
+  (func $f)
+  (elem (i32.const 1) $f)
+)
+
+;; Invalid bounds for elements
+
+(assert_trap
+  (module
+    (table 0 funcref)
+    (func $f)
+    (elem (i32.const 0) $f)
+  )
+  "out of bounds table access"
+)
+
+(assert_trap
+  (module
+    (table 0 0 funcref)
+    (func $f)
+    (elem (i32.const 0) $f)
+  )
+  "out of bounds table access"
+)
+
+(assert_trap
+  (module
+    (table 0 1 funcref)
+    (func $f)
+    (elem (i32.const 0) $f)
+  )
+  "out of bounds table access"
+)
+
+(assert_trap
+  (module
+    (table 0 funcref)
+    (elem (i32.const 1))
+  )
+  "out of bounds table access"
+)
+(assert_trap
+  (module
+    (table 10 funcref)
+    (func $f)
+    (elem (i32.const 10) $f)
+  )
+  "out of bounds table access"
+)
+(assert_trap
+  (module
+    (import "spectest" "table" (table 10 funcref))
+    (func $f)
+    (elem (i32.const 10) $f)
+  )
+  "out of bounds table access"
+)
+
+(assert_trap
+  (module
+    (table 10 20 funcref)
+    (func $f)
+    (elem (i32.const 10) $f)
+  )
+  "out of bounds table access"
+)
+(assert_trap
+  (module
+    (import "spectest" "table" (table 10 funcref))
+    (func $f)
+    (elem (i32.const 10) $f)
+  )
+  "out of bounds table access"
+)
+
+(assert_trap
+  (module
+    (table 10 funcref)
+    (func $f)
+    (elem (i32.const -1) $f)
+  )
+  "out of bounds table access"
+)
+(assert_trap
+  (module
+    (import "spectest" "table" (table 10 funcref))
+    (func $f)
+    (elem (i32.const -1) $f)
+  )
+  "out of bounds table access"
+)
+
+(assert_trap
+  (module
+    (table 10 funcref)
+    (func $f)
+    (elem (i32.const -10) $f)
+  )
+  "out of bounds table access"
+)
+(assert_trap
+  (module
+    (import "spectest" "table" (table 10 funcref))
+    (func $f)
+    (elem (i32.const -10) $f)
+  )
+  "out of bounds table access"
+)
+
+;; Implicitly dropped elements
+
+(module
+  (table 10 funcref)
+  (elem $e (i32.const 0) func $f)
+  (func $f)
+  (func (export "init")
+    (table.init $e (i32.const 0) (i32.const 0) (i32.const 1))
+  )
+)
+(assert_trap (invoke "init") "out of bounds table access")
+
+(module
+  (table 10 funcref)
+  (elem $e declare func $f)
+  (func $f)
+  (func (export "init")
+    (table.init $e (i32.const 0) (i32.const 0) (i32.const 1))
+  )
+)
+(assert_trap (invoke "init") "out of bounds table access")
+
+;; Element without table
+
+(assert_invalid
+  (module
+    (func $f)
+    (elem (i32.const 0) $f)
+  )
+  "unknown table"
+)
+
+;; Invalid offsets
+
+(assert_invalid
+  (module
+    (table 1 funcref)
+    (elem (i64.const 0))
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+  (module
+    (table 1 funcref)
+    (elem (ref.null func))
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+  (module 
+    (table 1 funcref)
+    (elem (offset (;empty instruction sequence;)))
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+  (module
+    (table 1 funcref)
+    (elem (offset (i32.const 0) (i32.const 0)))
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+  (module
+    (global (import "test" "global-i32") i32)
+    (table 1 funcref)
+    (elem (offset (global.get 0) (global.get 0)))
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+  (module
+    (global (import "test" "global-i32") i32)
+    (table 1 funcref)
+    (elem (offset (global.get 0) (i32.const 0)))
+  )
+  "type mismatch"
+)
+
+
+(assert_invalid
+  (module
+    (table 1 funcref)
+    (elem (i32.ctz (i32.const 0)))
+  )
+  "constant expression required"
+)
+
+(assert_invalid
+  (module
+    (table 1 funcref)
+    (elem (nop))
+  )
+  "constant expression required"
+)
+
+(assert_invalid
+  (module
+    (table 1 funcref)
+    (elem (offset (nop) (i32.const 0)))
+  )
+  "constant expression required"
+)
+
+(assert_invalid
+  (module
+    (table 1 funcref)
+    (elem (offset (i32.const 0) (nop)))
+  )
+  "constant expression required"
+)
+
+(assert_invalid
+  (module
+    (global $g (import "test" "g") (mut i32))
+    (table 1 funcref)
+    (elem (global.get $g))
+  )
+  "constant expression required"
+)
+
+(assert_invalid
+   (module 
+     (table 1 funcref)
+     (elem (global.get 0))
+   )
+   "unknown global 0"
+)
+
+(assert_invalid
+   (module
+     (global (import "test" "global-i32") i32)
+     (table 1 funcref)
+     (elem (global.get 1))
+   )
+   "unknown global 1"
+)
+
+(assert_invalid
+   (module 
+     (global (import "test" "global-mut-i32") (mut i32))
+     (table 1 funcref)
+     (elem (global.get 0))
+   )
+   "constant expression required"
+)
+
+;; Invalid elements
+
+(assert_invalid
+  (module
+    (table 1 funcref)
+    (elem (i32.const 0) funcref (ref.null extern))
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+  (module
+    (table 1 funcref)
+    (elem (i32.const 0) funcref (item (ref.null func) (ref.null func)))
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+  (module
+    (table 1 funcref)
+    (elem (i32.const 0) funcref (i32.const 0))
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+  (module
+    (table 1 funcref)
+    (elem (i32.const 0) funcref (item (i32.const 0)))
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+  (module
+    (table 1 funcref)
+    (elem (i32.const 0) funcref (item (call $f)))
+    (func $f (result funcref) (ref.null func))
+  )
+  "constant expression required"
+)
+
+;; Two elements target the same slot
+
+(module
+  (type $out-i32 (func (result i32)))
+  (table 10 funcref)
+  (elem (i32.const 9) $const-i32-a)
+  (elem (i32.const 9) $const-i32-b)
+  (func $const-i32-a (type $out-i32) (i32.const 65))
+  (func $const-i32-b (type $out-i32) (i32.const 66))
+  (func (export "call-overwritten") (type $out-i32)
+    (call_indirect (type $out-i32) (i32.const 9))
+  )
+)
+(assert_return (invoke "call-overwritten") (i32.const 66))
+
+(module
+  (type $out-i32 (func (result i32)))
+  (import "spectest" "table" (table 10 funcref))
+  (elem (i32.const 9) $const-i32-a)
+  (elem (i32.const 9) $const-i32-b)
+  (func $const-i32-a (type $out-i32) (i32.const 65))
+  (func $const-i32-b (type $out-i32) (i32.const 66))
+  (func (export "call-overwritten-element") (type $out-i32)
+    (call_indirect (type $out-i32) (i32.const 9))
+  )
+)
+(assert_return (invoke "call-overwritten-element") (i32.const 66))
+
+;; Element sections across multiple modules change the same table
+
+(module $module1
+  (type $out-i32 (func (result i32)))
+  (table (export "shared-table") 10 funcref)
+  (elem (i32.const 8) $const-i32-a)
+  (elem (i32.const 9) $const-i32-b)
+  (func $const-i32-a (type $out-i32) (i32.const 65))
+  (func $const-i32-b (type $out-i32) (i32.const 66))
+  (func (export "call-7") (type $out-i32)
+    (call_indirect (type $out-i32) (i32.const 7))
+  )
+  (func (export "call-8") (type $out-i32)
+    (call_indirect (type $out-i32) (i32.const 8))
+  )
+  (func (export "call-9") (type $out-i32)
+    (call_indirect (type $out-i32) (i32.const 9))
+  )
+)
+
+(register "module1" $module1)
+
+(assert_trap (invoke $module1 "call-7") "uninitialized element")
+(assert_return (invoke $module1 "call-8") (i32.const 65))
+(assert_return (invoke $module1 "call-9") (i32.const 66))
+
+(module $module2
+  (type $out-i32 (func (result i32)))
+  (import "module1" "shared-table" (table 10 funcref))
+  (elem (i32.const 7) $const-i32-c)
+  (elem (i32.const 8) $const-i32-d)
+  (func $const-i32-c (type $out-i32) (i32.const 67))
+  (func $const-i32-d (type $out-i32) (i32.const 68))
+)
+
+(assert_return (invoke $module1 "call-7") (i32.const 67))
+(assert_return (invoke $module1 "call-8") (i32.const 68))
+(assert_return (invoke $module1 "call-9") (i32.const 66))
+
+(module $module3
+  (type $out-i32 (func (result i32)))
+  (import "module1" "shared-table" (table 10 funcref))
+  (elem (i32.const 8) $const-i32-e)
+  (elem (i32.const 9) $const-i32-f)
+  (func $const-i32-e (type $out-i32) (i32.const 69))
+  (func $const-i32-f (type $out-i32) (i32.const 70))
+)
+
+(assert_return (invoke $module1 "call-7") (i32.const 67))
+(assert_return (invoke $module1 "call-8") (i32.const 69))
+(assert_return (invoke $module1 "call-9") (i32.const 70))
+
+;; Element segments must match element type of table
+
+(assert_invalid
+  (module (func $f) (table 1 externref) (elem (i32.const 0) $f))
+  "type mismatch"
+)
+
+(assert_invalid
+  (module (table 1 funcref) (elem (i32.const 0) externref (ref.null extern)))
+  "type mismatch"
+)
+
+(assert_invalid
+  (module
+    (func $f)
+    (table $t 1 externref)
+    (elem $e funcref (ref.func $f))
+    (func (table.init $t $e (i32.const 0) (i32.const 0) (i32.const 1))))
+  "type mismatch"
+)
+
+(assert_invalid
+  (module
+    (table $t 1 funcref)
+    (elem $e externref (ref.null extern))
+    (func (table.init $t $e (i32.const 0) (i32.const 0) (i32.const 1))))
+  "type mismatch"
+)
+
+;; Initializing a table with an externref-type element segment
+
+(module $m
+  (table $t (export "table") 2 externref)
+  (func (export "get") (param $i i32) (result externref)
+        (table.get $t (local.get $i)))
+  (func (export "set") (param $i i32) (param $x externref)
+        (table.set $t (local.get $i) (local.get $x))))
+
+(register "exporter" $m)
+
+(assert_return (invoke $m "get" (i32.const 0)) (ref.null extern))
+(assert_return (invoke $m "get" (i32.const 1)) (ref.null extern))
+
+(assert_return (invoke $m "set" (i32.const 0) (ref.extern 42)))
+(assert_return (invoke $m "set" (i32.const 1) (ref.extern 137)))
+
+(assert_return (invoke $m "get" (i32.const 0)) (ref.extern 42))
+(assert_return (invoke $m "get" (i32.const 1)) (ref.extern 137))
+
+(module
+  (import "exporter" "table" (table $t 2 externref))
+  (elem (i32.const 0) externref (ref.null extern)))
+
+(assert_return (invoke $m "get" (i32.const 0)) (ref.null extern))
+(assert_return (invoke $m "get" (i32.const 1)) (ref.extern 137))
+
+;; Initializing a table with imported funcref global
+
+(module $module4
+  (func (result i32)
+    i32.const 42
+  )
+  (global (export "f") funcref (ref.func 0))
+)
+
+(register "module4" $module4)
+
+(module
+  (import "module4" "f" (global funcref))
+  (type $out-i32 (func (result i32)))
+  (table 10 funcref)
+  (elem (offset (i32.const 0)) funcref (global.get 0))
+  (func (export "call_imported_elem") (type $out-i32)
+    (call_indirect (type $out-i32) (i32.const 0))
+  )
+)
+
+(assert_return (invoke "call_imported_elem") (i32.const 42))

--- a/test/old-spec/global.wast
+++ b/test/old-spec/global.wast
@@ -351,6 +351,9 @@
   "unknown global"
 )
 
+(module (global i32 (i32.const 0)) (global i32 (global.get 0)))
+(module (global $g i32 (i32.const 0)) (global i32 (global.get $g)))
+
 (assert_invalid
   (module (global i32 (global.get 1)) (global i32 (i32.const 0)))
   "unknown global"
@@ -360,9 +363,6 @@
   (module (global (import "test" "global-i32") i32) (global i32 (global.get 2)))
   "unknown global"
 )
-
-(module (global i32 (i32.const 0)) (global i32 (global.get 0)))
-(module (global $g i32 (i32.const 0)) (global i32 (global.get $g)))
 
 (assert_invalid
   (module (global (import "test" "global-mut-i32") (mut i32)) (global i32 (global.get 0)))

--- a/test/old-spec/global.wast
+++ b/test/old-spec/global.wast
@@ -1,0 +1,630 @@
+;; Vendored copy of global.wast from the pinned testsuite, patched with the
+;; 2025-09 spec change that allows global.get of defined immutable globals
+;; in initializer expressions (ref: WebAssembly/testsuite@4b24564c84).
+;; Test globals
+
+(module
+  (global (import "spectest" "global_i32") i32)
+  (global (import "spectest" "global_i64") i64)
+
+  (global $a i32 (i32.const -2))
+  (global (;3;) f32 (f32.const -3))
+  (global (;4;) f64 (f64.const -4))
+  (global $b i64 (i64.const -5))
+
+  (global $x (mut i32) (i32.const -12))
+  (global (;7;) (mut f32) (f32.const -13))
+  (global (;8;) (mut f64) (f64.const -14))
+  (global $y (mut i64) (i64.const -15))
+
+  (global $z1 i32 (global.get 0))
+  (global $z2 i64 (global.get 1))
+
+  (global $r externref (ref.null extern))
+  (global $mr (mut externref) (ref.null extern))
+  (global funcref (ref.null func))
+
+  (func (export "get-a") (result i32) (global.get $a))
+  (func (export "get-b") (result i64) (global.get $b))
+  (func (export "get-r") (result externref) (global.get $r))
+  (func (export "get-mr") (result externref) (global.get $mr))
+  (func (export "get-x") (result i32) (global.get $x))
+  (func (export "get-y") (result i64) (global.get $y))
+  (func (export "get-z1") (result i32) (global.get $z1))
+  (func (export "get-z2") (result i64) (global.get $z2))
+  (func (export "set-x") (param i32) (global.set $x (local.get 0)))
+  (func (export "set-y") (param i64) (global.set $y (local.get 0)))
+  (func (export "set-mr") (param externref) (global.set $mr (local.get 0)))
+
+  (func (export "get-3") (result f32) (global.get 3))
+  (func (export "get-4") (result f64) (global.get 4))
+  (func (export "get-7") (result f32) (global.get 7))
+  (func (export "get-8") (result f64) (global.get 8))
+  (func (export "set-7") (param f32) (global.set 7 (local.get 0)))
+  (func (export "set-8") (param f64) (global.set 8 (local.get 0)))
+
+  ;; As the argument of control constructs and instructions
+
+  (memory 1)
+
+  (func $dummy)
+
+  (func (export "as-select-first") (result i32)
+    (select (global.get $x) (i32.const 2) (i32.const 3))
+  )
+  (func (export "as-select-mid") (result i32)
+    (select (i32.const 2) (global.get $x) (i32.const 3))
+  )
+  (func (export "as-select-last") (result i32)
+    (select (i32.const 2) (i32.const 3) (global.get $x))
+  )
+
+  (func (export "as-loop-first") (result i32)
+    (loop (result i32)
+      (global.get $x) (call $dummy) (call $dummy)
+    )
+  )
+  (func (export "as-loop-mid") (result i32)
+    (loop (result i32)
+      (call $dummy) (global.get $x) (call $dummy)
+    )
+  )
+  (func (export "as-loop-last") (result i32)
+    (loop (result i32)
+      (call $dummy) (call $dummy) (global.get $x)
+    )
+  )
+
+  (func (export "as-if-condition") (result i32)
+    (if (result i32) (global.get $x)
+      (then (call $dummy) (i32.const 2))
+      (else (call $dummy) (i32.const 3))
+    )
+  )
+  (func (export "as-if-then") (result i32)
+    (if (result i32) (i32.const 1)
+      (then (global.get $x)) (else (i32.const 2))
+    )
+  )
+  (func (export "as-if-else") (result i32)
+    (if (result i32) (i32.const 0)
+      (then (i32.const 2)) (else (global.get $x))
+    )
+  )
+
+  (func (export "as-br_if-first") (result i32)
+    (block (result i32)
+      (br_if 0 (global.get $x) (i32.const 2))
+      (return (i32.const 3))
+    )
+  )
+  (func (export "as-br_if-last") (result i32)
+    (block (result i32)
+      (br_if 0 (i32.const 2) (global.get $x))
+      (return (i32.const 3))
+    )
+  )
+
+  (func (export "as-br_table-first") (result i32)
+    (block (result i32)
+      (global.get $x) (i32.const 2) (br_table 0 0)
+    )
+  )
+  (func (export "as-br_table-last") (result i32)
+    (block (result i32)
+      (i32.const 2) (global.get $x) (br_table 0 0)
+    )
+  )
+
+  (func $func (param i32 i32) (result i32) (local.get 0))
+  (type $check (func (param i32 i32) (result i32)))
+  (table funcref (elem $func))
+  (func (export "as-call_indirect-first") (result i32)
+    (block (result i32)
+      (call_indirect (type $check)
+        (global.get $x) (i32.const 2) (i32.const 0)
+      )
+    )
+  )
+  (func (export "as-call_indirect-mid") (result i32)
+    (block (result i32)
+      (call_indirect (type $check)
+        (i32.const 2) (global.get $x) (i32.const 0)
+      )
+    )
+  )
+ (func (export "as-call_indirect-last") (result i32)
+    (block (result i32)
+      (call_indirect (type $check)
+        (i32.const 2) (i32.const 0) (global.get $x)
+      )
+    )
+  )
+
+  (func (export "as-store-first")
+    (global.get $x) (i32.const 1) (i32.store)
+  )
+  (func (export "as-store-last")
+    (i32.const 0) (global.get $x) (i32.store)
+  )
+  (func (export "as-load-operand") (result i32)
+    (i32.load (global.get $x))
+  )
+  (func (export "as-memory.grow-value") (result i32)
+    (memory.grow (global.get $x))
+  )
+
+  (func $f (param i32) (result i32) (local.get 0))
+  (func (export "as-call-value") (result i32)
+    (call $f (global.get $x))
+  )
+
+  (func (export "as-return-value") (result i32)
+    (global.get $x) (return)
+  )
+  (func (export "as-drop-operand")
+    (drop (global.get $x))
+  )
+  (func (export "as-br-value") (result i32)
+    (block (result i32) (br 0 (global.get $x)))
+  )
+
+  (func (export "as-local.set-value") (param i32) (result i32)
+    (local.set 0 (global.get $x))
+    (local.get 0)
+  )
+  (func (export "as-local.tee-value") (param i32) (result i32)
+    (local.tee 0 (global.get $x))
+  )
+  (func (export "as-global.set-value") (result i32)
+    (global.set $x (global.get $x))
+    (global.get $x)
+  )
+
+  (func (export "as-unary-operand") (result i32)
+    (i32.eqz (global.get $x))
+  )
+  (func (export "as-binary-operand") (result i32)
+    (i32.mul
+      (global.get $x) (global.get $x)
+    )
+  )
+  (func (export "as-compare-operand") (result i32)
+    (i32.gt_u
+      (global.get 0) (i32.const 1)
+    )
+  )
+)
+
+(assert_return (invoke "get-a") (i32.const -2))
+(assert_return (invoke "get-b") (i64.const -5))
+(assert_return (invoke "get-r") (ref.null extern))
+(assert_return (invoke "get-mr") (ref.null extern))
+(assert_return (invoke "get-x") (i32.const -12))
+(assert_return (invoke "get-y") (i64.const -15))
+(assert_return (invoke "get-z1") (i32.const 666))
+(assert_return (invoke "get-z2") (i64.const 666))
+
+(assert_return (invoke "get-3") (f32.const -3))
+(assert_return (invoke "get-4") (f64.const -4))
+(assert_return (invoke "get-7") (f32.const -13))
+(assert_return (invoke "get-8") (f64.const -14))
+
+(assert_return (invoke "set-x" (i32.const 6)))
+(assert_return (invoke "set-y" (i64.const 7)))
+
+(assert_return (invoke "set-7" (f32.const 8)))
+(assert_return (invoke "set-8" (f64.const 9)))
+
+(assert_return (invoke "get-x") (i32.const 6))
+(assert_return (invoke "get-y") (i64.const 7))
+(assert_return (invoke "get-7") (f32.const 8))
+(assert_return (invoke "get-8") (f64.const 9))
+
+(assert_return (invoke "set-7" (f32.const 8)))
+(assert_return (invoke "set-8" (f64.const 9)))
+(assert_return (invoke "set-mr" (ref.extern 10)))
+
+(assert_return (invoke "get-x") (i32.const 6))
+(assert_return (invoke "get-y") (i64.const 7))
+(assert_return (invoke "get-7") (f32.const 8))
+(assert_return (invoke "get-8") (f64.const 9))
+(assert_return (invoke "get-mr") (ref.extern 10))
+
+(assert_return (invoke "as-select-first") (i32.const 6))
+(assert_return (invoke "as-select-mid") (i32.const 2))
+(assert_return (invoke "as-select-last") (i32.const 2))
+
+(assert_return (invoke "as-loop-first") (i32.const 6))
+(assert_return (invoke "as-loop-mid") (i32.const 6))
+(assert_return (invoke "as-loop-last") (i32.const 6))
+
+(assert_return (invoke "as-if-condition") (i32.const 2))
+(assert_return (invoke "as-if-then") (i32.const 6))
+(assert_return (invoke "as-if-else") (i32.const 6))
+
+(assert_return (invoke "as-br_if-first") (i32.const 6))
+(assert_return (invoke "as-br_if-last") (i32.const 2))
+
+(assert_return (invoke "as-br_table-first") (i32.const 6))
+(assert_return (invoke "as-br_table-last") (i32.const 2))
+
+(assert_return (invoke "as-call_indirect-first") (i32.const 6))
+(assert_return (invoke "as-call_indirect-mid") (i32.const 2))
+(assert_trap (invoke "as-call_indirect-last") "undefined element")
+
+(assert_return (invoke "as-store-first"))
+(assert_return (invoke "as-store-last"))
+(assert_return (invoke "as-load-operand") (i32.const 1))
+(assert_return (invoke "as-memory.grow-value") (i32.const 1))
+
+(assert_return (invoke "as-call-value") (i32.const 6))
+
+(assert_return (invoke "as-return-value") (i32.const 6))
+(assert_return (invoke "as-drop-operand"))
+(assert_return (invoke "as-br-value") (i32.const 6))
+
+(assert_return (invoke "as-local.set-value" (i32.const 1)) (i32.const 6))
+(assert_return (invoke "as-local.tee-value" (i32.const 1)) (i32.const 6))
+(assert_return (invoke "as-global.set-value") (i32.const 6))
+
+(assert_return (invoke "as-unary-operand") (i32.const 0))
+(assert_return (invoke "as-binary-operand") (i32.const 36))
+(assert_return (invoke "as-compare-operand") (i32.const 1))
+
+(assert_invalid
+  (module (global f32 (f32.const 0)) (func (global.set 0 (f32.const 1))))
+  "global is immutable"
+)
+
+(assert_invalid
+  (module (import "spectest" "global_i32" (global i32)) (func (global.set 0 (i32.const 1))))
+  "global is immutable"
+)
+
+;; mutable globals can be exported
+(module (global (mut f32) (f32.const 0)) (export "a" (global 0)))
+(module (global (export "a") (mut f32) (f32.const 0)))
+
+(assert_invalid
+  (module (global f32 (f32.neg (f32.const 0))))
+  "constant expression required"
+)
+
+(assert_invalid
+  (module (global f32 (local.get 0)))
+  "constant expression required"
+)
+
+(assert_invalid
+  (module (global f32 (f32.neg (f32.const 1))))
+  "constant expression required"
+)
+
+(assert_invalid
+  (module (global i32 (i32.const 0) (nop)))
+  "constant expression required"
+)
+
+(assert_invalid
+  (module (global i32 (i32.ctz (i32.const 0))))
+  "constant expression required"
+)
+
+(assert_invalid
+  (module (global i32 (nop)))
+  "constant expression required"
+)
+
+(assert_invalid
+  (module (global i32 (f32.const 0)))
+  "type mismatch"
+)
+
+(assert_invalid
+  (module (global i32 (i32.const 0) (i32.const 0)))
+  "type mismatch"
+)
+
+(assert_invalid
+  (module (global i32 (;empty instruction sequence;)))
+  "type mismatch"
+)
+
+(assert_invalid
+  (module (global (import "" "") externref) (global funcref (global.get 0)))
+  "type mismatch"
+)
+
+(assert_invalid
+  (module (global (import "test" "global-i32") i32) (global i32 (global.get 0) (global.get 0)))
+  "type mismatch"
+)
+
+(assert_invalid
+  (module (global (import "test" "global-i32") i32) (global i32 (i32.const 0) (global.get 0)))
+  "type mismatch"
+)
+
+(assert_invalid
+  (module (global i32 (global.get 0)))
+  "unknown global"
+)
+
+(assert_invalid
+  (module (global i32 (global.get 1)) (global i32 (i32.const 0)))
+  "unknown global"
+)
+
+(assert_invalid
+  (module (global (import "test" "global-i32") i32) (global i32 (global.get 2)))
+  "unknown global"
+)
+
+(module (global i32 (i32.const 0)) (global i32 (global.get 0)))
+(module (global $g i32 (i32.const 0)) (global i32 (global.get $g)))
+
+(assert_invalid
+  (module (global (import "test" "global-mut-i32") (mut i32)) (global i32 (global.get 0)))
+  "constant expression required"
+)
+
+(module
+  (import "spectest" "global_i32" (global i32))
+)
+(assert_malformed
+  (module binary
+    "\00asm" "\01\00\00\00"
+    "\02\98\80\80\80\00"             ;; import section
+      "\01"                          ;; length 1
+      "\08\73\70\65\63\74\65\73\74"  ;; "spectest"
+      "\0a\67\6c\6f\62\61\6c\5f\69\33\32" ;; "global_i32"
+      "\03"                          ;; GlobalImport
+      "\7f"                          ;; i32
+      "\02"                          ;; malformed mutability
+  )
+  "malformed mutability"
+)
+(assert_malformed
+  (module binary
+    "\00asm" "\01\00\00\00"
+    "\02\98\80\80\80\00"             ;; import section
+      "\01"                          ;; length 1
+      "\08\73\70\65\63\74\65\73\74"  ;; "spectest"
+      "\0a\67\6c\6f\62\61\6c\5f\69\33\32" ;; "global_i32"
+      "\03"                          ;; GlobalImport
+      "\7f"                          ;; i32
+      "\ff"                          ;; malformed mutability
+  )
+  "malformed mutability"
+)
+
+(module
+  (global i32 (i32.const 0))
+)
+(assert_malformed
+  (module binary
+    "\00asm" "\01\00\00\00"
+    "\06\86\80\80\80\00"  ;; global section
+      "\01"               ;; length 1
+      "\7f"               ;; i32
+      "\02"               ;; malformed mutability
+      "\41\00"            ;; i32.const 0
+      "\0b"               ;; end
+  )
+  "malformed mutability"
+)
+(assert_malformed
+  (module binary
+    "\00asm" "\01\00\00\00"
+    "\06\86\80\80\80\00"  ;; global section
+      "\01"               ;; length 1
+      "\7f"               ;; i32
+      "\ff"               ;; malformed mutability
+      "\41\00"            ;; i32.const 0
+      "\0b"               ;; end
+  )
+  "malformed mutability"
+)
+
+;; global.get with invalid index
+(assert_invalid
+  (module (func (result i32) (global.get 0)))
+  "unknown global"
+)
+
+(assert_invalid
+  (module
+    (global i32 (i32.const 0))
+    (func (result i32) (global.get 1))
+  )
+  "unknown global"
+)
+
+(assert_invalid
+  (module
+    (import "spectest" "global_i32" (global i32))
+    (func (result i32) (global.get 1))
+  )
+  "unknown global"
+)
+
+(assert_invalid
+  (module
+    (import "spectest" "global_i32" (global i32))
+    (global i32 (i32.const 0))
+    (func (result i32) (global.get 2))
+  )
+  "unknown global"
+)
+
+;; global.set with invalid index
+(assert_invalid
+  (module (func (i32.const 0) (global.set 0)))
+  "unknown global"
+)
+
+(assert_invalid
+  (module
+    (global i32 (i32.const 0))
+    (func (i32.const 0) (global.set 1))
+  )
+  "unknown global"
+)
+
+(assert_invalid
+  (module
+    (import "spectest" "global_i32" (global i32))
+    (func (i32.const 0) (global.set 1))
+  )
+  "unknown global"
+)
+
+(assert_invalid
+  (module
+    (import "spectest" "global_i32" (global i32))
+    (global i32 (i32.const 0))
+    (func (i32.const 0) (global.set 2))
+  )
+  "unknown global"
+)
+
+
+(assert_invalid
+  (module
+    (global $x (mut i32) (i32.const 0))
+    (func $type-global.set-value-empty
+      (global.set $x)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (global $x (mut i32) (i32.const 0))
+    (func $type-global.set-value-empty-in-block
+      (i32.const 0)
+      (block (global.set $x))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (global $x (mut i32) (i32.const 0))
+    (func $type-global.set-value-empty-in-loop
+      (i32.const 0)
+      (loop (global.set $x))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (global $x (mut i32) (i32.const 0))
+    (func $type-global.set-value-empty-in-then
+      (i32.const 0) (i32.const 0)
+      (if (then (global.set $x)))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (global $x (mut i32) (i32.const 0))
+    (func $type-global.set-value-empty-in-else
+      (i32.const 0) (i32.const 0)
+      (if (result i32) (then (i32.const 0)) (else (global.set $x)))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (global $x (mut i32) (i32.const 0))
+    (func $type-global.set-value-empty-in-br
+      (i32.const 0)
+      (block (br 0 (global.set $x)))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (global $x (mut i32) (i32.const 0))
+    (func $type-global.set-value-empty-in-br_if
+      (i32.const 0)
+      (block (br_if 0 (global.set $x)))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (global $x (mut i32) (i32.const 0))
+    (func $type-global.set-value-empty-in-br_table
+      (i32.const 0)
+      (block (br_table 0 (global.set $x)))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (global $x (mut i32) (i32.const 0))
+    (func $type-global.set-value-empty-in-return
+      (return (global.set $x))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (global $x (mut i32) (i32.const 0))
+    (func $type-global.set-value-empty-in-select
+      (select (global.set $x) (i32.const 1) (i32.const 2))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (global $x (mut i32) (i32.const 0))
+    (func $type-global.set-value-empty-in-call
+      (call 1 (global.set $x))
+    )
+    (func (param i32) (result i32) (local.get 0))
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (global $x (mut i32) (i32.const 0))
+    (func $f (param i32) (result i32) (local.get 0))
+    (type $sig (func (param i32) (result i32)))
+    (table funcref (elem $f))
+    (func $type-global.set-value-empty-in-call_indirect
+      (block (result i32)
+        (call_indirect (type $sig)
+          (global.set $x) (i32.const 0)
+        )
+      )
+    )
+  )
+  "type mismatch"
+)
+
+;; Duplicate identifier errors
+
+(assert_malformed (module quote
+  "(global $foo i32 (i32.const 0))"
+  "(global $foo i32 (i32.const 0))")
+  "duplicate global")
+(assert_malformed (module quote
+  "(import \"\" \"\" (global $foo i32))"
+  "(global $foo i32 (i32.const 0))")
+  "duplicate global")
+(assert_malformed (module quote
+  "(import \"\" \"\" (global $foo i32))"
+  "(import \"\" \"\" (global $foo i32))")
+  "duplicate global")

--- a/test/old-spec/proposals/extended-const/data.wast
+++ b/test/old-spec/proposals/extended-const/data.wast
@@ -1,0 +1,527 @@
+;; Vendored copy of proposals/extended-const/data.wast from the pinned testsuite, patched with the
+;; 2025-09 spec change that allows global.get of defined immutable globals
+;; in initializer expressions (ref: WebAssembly/testsuite@4b24564c84).
+;; Test the data section
+
+;; Syntax
+
+(module
+  (memory $m 1)
+  (data (i32.const 0))
+  (data (i32.const 1) "a" "" "bcd")
+  (data (offset (i32.const 0)))
+  (data (offset (i32.const 0)) "" "a" "bc" "")
+  (data (memory 0) (i32.const 0))
+  (data (memory 0x0) (i32.const 1) "a" "" "bcd")
+  (data (memory 0x000) (offset (i32.const 0)))
+  (data (memory 0) (offset (i32.const 0)) "" "a" "bc" "")
+  (data (memory $m) (i32.const 0))
+  (data (memory $m) (i32.const 1) "a" "" "bcd")
+  (data (memory $m) (offset (i32.const 0)))
+  (data (memory $m) (offset (i32.const 0)) "" "a" "bc" "")
+  (data $d1 (i32.const 0))
+  (data $d2 (i32.const 1) "a" "" "bcd")
+  (data $d3 (offset (i32.const 0)))
+  (data $d4 (offset (i32.const 0)) "" "a" "bc" "")
+  (data $d5 (memory 0) (i32.const 0))
+  (data $d6 (memory 0x0) (i32.const 1) "a" "" "bcd")
+  (data $d7 (memory 0x000) (offset (i32.const 0)))
+  (data $d8 (memory 0) (offset (i32.const 0)) "" "a" "bc" "")
+  (data $d9 (memory $m) (i32.const 0))
+  (data $d10 (memory $m) (i32.const 1) "a" "" "bcd")
+  (data $d11 (memory $m) (offset (i32.const 0)))
+  (data $d12 (memory $m) (offset (i32.const 0)) "" "a" "bc" "")
+)
+
+;; Basic use
+
+(module
+  (memory 1)
+  (data (i32.const 0) "a")
+)
+(module
+  (import "spectest" "memory" (memory 1))
+  (data (i32.const 0) "a")
+)
+
+(module
+  (memory 1)
+  (data (i32.const 0) "a")
+  (data (i32.const 3) "b")
+  (data (i32.const 100) "cde")
+  (data (i32.const 5) "x")
+  (data (i32.const 3) "c")
+)
+(module
+  (import "spectest" "memory" (memory 1))
+  (data (i32.const 0) "a")
+  (data (i32.const 1) "b")
+  (data (i32.const 2) "cde")
+  (data (i32.const 3) "f")
+  (data (i32.const 2) "g")
+  (data (i32.const 1) "h")
+)
+
+(module
+  (global (import "spectest" "global_i32") i32)
+  (memory 1)
+  (data (global.get 0) "a")
+)
+(module
+  (global (import "spectest" "global_i32") i32)
+  (import "spectest" "memory" (memory 1))
+  (data (global.get 0) "a")
+)
+
+(module
+  (global $g (import "spectest" "global_i32") i32)
+  (memory 1)
+  (data (global.get $g) "a")
+)
+(module
+  (global $g (import "spectest" "global_i32") i32)
+  (import "spectest" "memory" (memory 1))
+  (data (global.get $g) "a")
+)
+
+(module (memory 1) (global i32 (i32.const 0)) (data (global.get 0) "a"))
+(module (memory 1) (global $g i32 (i32.const 0)) (data (global.get $g) "a"))
+
+
+;; Corner cases
+
+(module
+  (memory 1)
+  (data (i32.const 0) "a")
+  (data (i32.const 0xffff) "b")
+)
+(module
+  (import "spectest" "memory" (memory 1))
+  (data (i32.const 0) "a")
+  (data (i32.const 0xffff) "b")
+)
+
+(module
+  (memory 2)
+  (data (i32.const 0x1_ffff) "a")
+)
+
+(module
+  (memory 0)
+  (data (i32.const 0))
+)
+(module
+  (import "spectest" "memory" (memory 0))
+  (data (i32.const 0))
+)
+
+(module
+  (memory 0 0)
+  (data (i32.const 0))
+)
+
+(module
+  (memory 1)
+  (data (i32.const 0x1_0000) "")
+)
+
+(module
+  (memory 0)
+  (data (i32.const 0) "" "")
+)
+(module
+  (import "spectest" "memory" (memory 0))
+  (data (i32.const 0) "" "")
+)
+
+(module
+  (memory 0 0)
+  (data (i32.const 0) "" "")
+)
+
+(module
+  (import "spectest" "memory" (memory 0))
+  (data (i32.const 0) "a")
+)
+
+(module
+  (import "spectest" "memory" (memory 0 3))
+  (data (i32.const 0) "a")
+)
+
+(module
+  (global (import "spectest" "global_i32") i32)
+  (import "spectest" "memory" (memory 0))
+  (data (global.get 0) "a")
+)
+
+(module
+  (global (import "spectest" "global_i32") i32)
+  (import "spectest" "memory" (memory 0 3))
+  (data (global.get 0) "a")
+)
+
+(module
+  (import "spectest" "memory" (memory 0))
+  (data (i32.const 1) "a")
+)
+
+(module
+  (import "spectest" "memory" (memory 0 3))
+  (data (i32.const 1) "a")
+)
+
+;; Extended contant expressions
+
+(module
+  (memory 1)
+  (data (i32.add (i32.const 0) (i32.const 42)))
+)
+
+(module
+  (memory 1)
+  (data (i32.sub (i32.const 42) (i32.const 0)))
+)
+
+(module
+  (memory 1)
+  (data (i32.mul (i32.const 1) (i32.const 2)))
+)
+
+;; Combining add, sub, mul and global.get
+
+(module
+  (global (import "spectest" "global_i32") i32)
+  (memory 1)
+  (data (i32.mul
+          (i32.const 2)
+          (i32.add
+            (i32.sub (global.get 0) (i32.const 1))
+            (i32.const 2)
+          )
+        )
+  )
+)
+
+;; Invalid bounds for data
+
+(assert_trap
+  (module
+    (memory 0)
+    (data (i32.const 0) "a")
+  )
+  "out of bounds memory access"
+)
+
+(assert_trap
+  (module
+    (memory 0 0)
+    (data (i32.const 0) "a")
+  )
+  "out of bounds memory access"
+)
+
+(assert_trap
+  (module
+    (memory 0 1)
+    (data (i32.const 0) "a")
+  )
+  "out of bounds memory access"
+)
+(assert_trap
+  (module
+    (memory 0)
+    (data (i32.const 1))
+  )
+  "out of bounds memory access"
+)
+(assert_trap
+  (module
+    (memory 0 1)
+    (data (i32.const 1))
+  )
+  "out of bounds memory access"
+)
+
+;; This seems to cause a time-out on Travis.
+(;assert_unlinkable
+  (module
+    (memory 0x10000)
+    (data (i32.const 0xffffffff) "ab")
+  )
+  ""  ;; either out of memory or out of bounds
+;)
+
+(assert_trap
+  (module
+    (global (import "spectest" "global_i32") i32)
+    (memory 0)
+    (data (global.get 0) "a")
+  )
+  "out of bounds memory access"
+)
+
+(assert_trap
+  (module
+    (memory 1 2)
+    (data (i32.const 0x1_0000) "a")
+  )
+  "out of bounds memory access"
+)
+(assert_trap
+  (module
+    (import "spectest" "memory" (memory 1))
+    (data (i32.const 0x1_0000) "a")
+  )
+  "out of bounds memory access"
+)
+
+(assert_trap
+  (module
+    (memory 2)
+    (data (i32.const 0x2_0000) "a")
+  )
+  "out of bounds memory access"
+)
+
+(assert_trap
+  (module
+    (memory 2 3)
+    (data (i32.const 0x2_0000) "a")
+  )
+  "out of bounds memory access"
+)
+
+(assert_trap
+  (module
+    (memory 1)
+    (data (i32.const -1) "a")
+  )
+  "out of bounds memory access"
+)
+(assert_trap
+  (module
+    (import "spectest" "memory" (memory 1))
+    (data (i32.const -1) "a")
+  )
+  "out of bounds memory access"
+)
+
+(assert_trap
+  (module
+    (memory 2)
+    (data (i32.const -100) "a")
+  )
+  "out of bounds memory access"
+)
+(assert_trap
+  (module
+    (import "spectest" "memory" (memory 1))
+    (data (i32.const -100) "a")
+  )
+  "out of bounds memory access"
+)
+
+;; Data without memory
+
+(assert_invalid
+  (module
+    (data (i32.const 0) "")
+  )
+  "unknown memory"
+)
+
+;; Data segment with memory index 1 (only memory 0 available)
+(assert_invalid
+  (module binary
+    "\00asm" "\01\00\00\00"
+    "\05\03\01"                             ;; memory section
+    "\00\00"                                ;; memory 0
+    "\0b\07\01"                             ;; data section
+    "\02\01\41\00\0b"                       ;; active data segment 0 for memory 1
+    "\00"                                   ;; empty vec(byte)
+  )
+  "unknown memory 1"
+)
+
+;; Data segment with memory index 0 (no memory section)
+(assert_invalid
+  (module binary
+    "\00asm" "\01\00\00\00"
+    "\0b\06\01"                             ;; data section
+    "\00\41\00\0b"                          ;; active data segment 0 for memory 0
+    "\00"                                   ;; empty vec(byte)
+  )
+  "unknown memory 0"
+)
+
+;; Data segment with memory index 1 (no memory section)
+(assert_invalid
+  (module binary
+    "\00asm" "\01\00\00\00"
+    "\0b\07\01"                             ;; data section
+    "\02\01\41\00\0b"                       ;; active data segment 0 for memory 1
+    "\00"                                   ;; empty vec(byte)
+  )
+  "unknown memory 1"
+)
+
+;; Data segment with memory index 1 and vec(byte) as above,
+;; only memory 0 available.
+(assert_invalid
+  (module binary
+    "\00asm" "\01\00\00\00"
+    "\05\03\01"                             ;; memory section
+    "\00\00"                                ;; memory 0
+    "\0b\45\01"                             ;; data section
+    "\02"                                   ;; active segment
+    "\01"                                   ;; memory index
+    "\41\00\0b"                             ;; offset constant expression
+    "\3e"                                   ;; vec(byte) length
+    "\00\01\02\03\04\05\06\07\08\09\0a\0b\0c\0d\0e\0f"
+    "\10\11\12\13\14\15\16\17\18\19\1a\1b\1c\1d\1e\1f"
+    "\20\21\22\23\24\25\26\27\28\29\2a\2b\2c\2d\2e\2f"
+    "\30\31\32\33\34\35\36\37\38\39\3a\3b\3c\3d"
+  )
+  "unknown memory 1"
+)
+
+;; Data segment with memory index 1 and specially crafted vec(byte) after.
+;; This is to detect incorrect validation where memory index is interpreted
+;; as a flag followed by "\41" interpreted as the size of vec(byte)
+;; with the expected number of bytes following.
+(assert_invalid
+  (module binary
+    "\00asm" "\01\00\00\00"
+    "\0b\45\01"                             ;; data section
+    "\02"                                   ;; active segment
+    "\01"                                   ;; memory index
+    "\41\00\0b"                             ;; offset constant expression
+    "\3e"                                   ;; vec(byte) length
+    "\00\01\02\03\04\05\06\07\08\09\0a\0b\0c\0d\0e\0f"
+    "\10\11\12\13\14\15\16\17\18\19\1a\1b\1c\1d\1e\1f"
+    "\20\21\22\23\24\25\26\27\28\29\2a\2b\2c\2d\2e\2f"
+    "\30\31\32\33\34\35\36\37\38\39\3a\3b\3c\3d"
+  )
+  "unknown memory 1"
+)
+
+
+;; Invalid offsets
+
+(assert_invalid
+  (module
+    (memory 1)
+    (data (i64.const 0))
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+  (module
+    (memory 1)
+    (data (ref.null func))
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+  (module 
+    (memory 1)
+    (data (offset (;empty instruction sequence;)))
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+  (module
+    (memory 1)
+    (data (offset (i32.const 0) (i32.const 0)))
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+  (module
+    (global (import "test" "global-i32") i32)
+    (memory 1)
+    (data (offset (global.get 0) (global.get 0)))
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+  (module
+    (global (import "test" "global-i32") i32)
+    (memory 1)
+    (data (offset (global.get 0) (i32.const 0)))
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+  (module
+    (memory 1)
+    (data (i32.ctz (i32.const 0)))
+  )
+  "constant expression required"
+)
+
+(assert_invalid
+  (module
+    (memory 1)
+    (data (nop))
+  )
+  "constant expression required"
+)
+
+(assert_invalid
+  (module
+    (memory 1)
+    (data (offset (nop) (i32.const 0)))
+  )
+  "constant expression required"
+)
+
+(assert_invalid
+  (module
+    (memory 1)
+    (data (offset (i32.const 0) (nop)))
+  )
+  "constant expression required"
+)
+
+(assert_invalid
+  (module
+    (global $g (import "test" "g") (mut i32))
+    (memory 1)
+    (data (global.get $g))
+  )
+  "constant expression required"
+)
+
+(assert_invalid
+   (module 
+     (memory 1)
+     (data (global.get 0))
+   )
+   "unknown global 0"
+)
+
+(assert_invalid
+   (module
+     (global (import "test" "global-i32") i32)
+     (memory 1)
+     (data (global.get 1))
+   )
+   "unknown global 1"
+)
+
+(assert_invalid
+   (module 
+     (global (import "test" "global-mut-i32") (mut i32))
+     (memory 1)
+     (data (global.get 0))
+   )
+   "constant expression required"
+)

--- a/test/old-spec/proposals/extended-const/elem.wast
+++ b/test/old-spec/proposals/extended-const/elem.wast
@@ -1,0 +1,761 @@
+;; Vendored copy of proposals/extended-const/elem.wast from the pinned testsuite, patched with the
+;; 2025-09 spec change that allows global.get of defined immutable globals
+;; in initializer expressions (ref: WebAssembly/testsuite@4b24564c84).
+;; Test the element section
+
+;; Syntax
+(module
+  (table $t 10 funcref)
+  (func $f)
+  (func $g)
+
+  ;; Passive
+  (elem funcref)
+  (elem funcref (ref.func $f) (item ref.func $f) (item (ref.null func)) (ref.func $g))
+  (elem func)
+  (elem func $f $f $g $g)
+
+  (elem $p1 funcref)
+  (elem $p2 funcref (ref.func $f) (ref.func $f) (ref.null func) (ref.func $g))
+  (elem $p3 func)
+  (elem $p4 func $f $f $g $g)
+
+  ;; Active
+  (elem (table $t) (i32.const 0) funcref)
+  (elem (table $t) (i32.const 0) funcref (ref.func $f) (ref.null func))
+  (elem (table $t) (i32.const 0) func)
+  (elem (table $t) (i32.const 0) func $f $g)
+  (elem (table $t) (offset (i32.const 0)) funcref)
+  (elem (table $t) (offset (i32.const 0)) func $f $g)
+  (elem (table 0) (i32.const 0) func)
+  (elem (table 0x0) (i32.const 0) func $f $f)
+  (elem (table 0x000) (offset (i32.const 0)) func)
+  (elem (table 0) (offset (i32.const 0)) func $f $f)
+  (elem (table $t) (i32.const 0) func)
+  (elem (table $t) (i32.const 0) func $f $f)
+  (elem (table $t) (offset (i32.const 0)) func)
+  (elem (table $t) (offset (i32.const 0)) func $f $f)
+  (elem (offset (i32.const 0)))
+  (elem (offset (i32.const 0)) funcref (ref.func $f) (ref.null func))
+  (elem (offset (i32.const 0)) func $f $f)
+  (elem (offset (i32.const 0)) $f $f)
+  (elem (i32.const 0))
+  (elem (i32.const 0) funcref (ref.func $f) (ref.null func))
+  (elem (i32.const 0) func $f $f)
+  (elem (i32.const 0) $f $f)
+  (elem (i32.const 0) funcref (item (ref.func $f)) (item (ref.null func)))
+
+  (elem $a1 (table $t) (i32.const 0) funcref)
+  (elem $a2 (table $t) (i32.const 0) funcref (ref.func $f) (ref.null func))
+  (elem $a3 (table $t) (i32.const 0) func)
+  (elem $a4 (table $t) (i32.const 0) func $f $g)
+  (elem $a9 (table $t) (offset (i32.const 0)) funcref)
+  (elem $a10 (table $t) (offset (i32.const 0)) func $f $g)
+  (elem $a11 (table 0) (i32.const 0) func)
+  (elem $a12 (table 0x0) (i32.const 0) func $f $f)
+  (elem $a13 (table 0x000) (offset (i32.const 0)) func)
+  (elem $a14 (table 0) (offset (i32.const 0)) func $f $f)
+  (elem $a15 (table $t) (i32.const 0) func)
+  (elem $a16 (table $t) (i32.const 0) func $f $f)
+  (elem $a17 (table $t) (offset (i32.const 0)) func)
+  (elem $a18 (table $t) (offset (i32.const 0)) func $f $f)
+  (elem $a19 (offset (i32.const 0)))
+  (elem $a20 (offset (i32.const 0)) funcref (ref.func $f) (ref.null func))
+  (elem $a21 (offset (i32.const 0)) func $f $f)
+  (elem $a22 (offset (i32.const 0)) $f $f)
+  (elem $a23 (i32.const 0))
+  (elem $a24 (i32.const 0) funcref (ref.func $f) (ref.null func))
+  (elem $a25 (i32.const 0) func $f $f)
+  (elem $a26 (i32.const 0) $f $f)
+
+  ;; Declarative
+  (elem declare funcref)
+  (elem declare funcref (ref.func $f) (ref.func $f) (ref.null func) (ref.func $g))
+  (elem declare func)
+  (elem declare func $f $f $g $g)
+
+  (elem $d1 declare funcref)
+  (elem $d2 declare funcref (ref.func $f) (ref.func $f) (ref.null func) (ref.func $g))
+  (elem $d3 declare func)
+  (elem $d4 declare func $f $f $g $g)
+)
+
+(module
+  (func $f)
+  (func $g)
+
+  (table $t funcref (elem (ref.func $f) (ref.null func) (ref.func $g)))
+)
+
+
+;; Basic use
+
+(module
+  (table 10 funcref)
+  (func $f)
+  (elem (i32.const 0) $f)
+)
+(module
+  (import "spectest" "table" (table 10 funcref))
+  (func $f)
+  (elem (i32.const 0) $f)
+)
+
+(module
+  (table 10 funcref)
+  (func $f)
+  (elem (i32.const 0) $f)
+  (elem (i32.const 3) $f)
+  (elem (i32.const 7) $f)
+  (elem (i32.const 5) $f)
+  (elem (i32.const 3) $f)
+)
+(module
+  (import "spectest" "table" (table 10 funcref))
+  (func $f)
+  (elem (i32.const 9) $f)
+  (elem (i32.const 3) $f)
+  (elem (i32.const 7) $f)
+  (elem (i32.const 3) $f)
+  (elem (i32.const 5) $f)
+)
+
+(module
+  (global (import "spectest" "global_i32") i32)
+  (table 1000 funcref)
+  (func $f)
+  (elem (global.get 0) $f)
+)
+
+(module
+  (global $g (import "spectest" "global_i32") i32)
+  (table 1000 funcref)
+  (func $f)
+  (elem (global.get $g) $f)
+)
+
+(module
+  (type $out-i32 (func (result i32)))
+  (table 10 funcref)
+  (elem (i32.const 7) $const-i32-a)
+  (elem (i32.const 9) $const-i32-b)
+  (func $const-i32-a (type $out-i32) (i32.const 65))
+  (func $const-i32-b (type $out-i32) (i32.const 66))
+  (func (export "call-7") (type $out-i32)
+    (call_indirect (type $out-i32) (i32.const 7))
+  )
+  (func (export "call-9") (type $out-i32)
+    (call_indirect (type $out-i32) (i32.const 9))
+  )
+)
+(assert_return (invoke "call-7") (i32.const 65))
+(assert_return (invoke "call-9") (i32.const 66))
+
+;; Same as the above, but use ref.null to ensure the elements use exprs.
+;; Note: some tools like wast2json avoid using exprs when possible.
+(module
+  (type $out-i32 (func (result i32)))
+  (table 11 funcref)
+  (elem (i32.const 6) funcref (ref.null func) (ref.func $const-i32-a))
+  (elem (i32.const 9) funcref (ref.func $const-i32-b) (ref.null func))
+  (func $const-i32-a (type $out-i32) (i32.const 65))
+  (func $const-i32-b (type $out-i32) (i32.const 66))
+  (func (export "call-7") (type $out-i32)
+    (call_indirect (type $out-i32) (i32.const 7))
+  )
+  (func (export "call-9") (type $out-i32)
+    (call_indirect (type $out-i32) (i32.const 9))
+  )
+)
+(assert_return (invoke "call-7") (i32.const 65))
+(assert_return (invoke "call-9") (i32.const 66))
+
+(module
+  (global i32 (i32.const 0))
+  (table 1 funcref) (elem (global.get 0) $f) (func $f)
+)
+(module
+  (global $g i32 (i32.const 0))
+  (table 1 funcref) (elem (global.get $g) $f) (func $f)
+)
+
+
+;; Corner cases
+
+(module
+  (table 10 funcref)
+  (func $f)
+  (elem (i32.const 9) $f)
+)
+(module
+  (import "spectest" "table" (table 10 funcref))
+  (func $f)
+  (elem (i32.const 9) $f)
+)
+
+(module
+  (table 0 funcref)
+  (elem (i32.const 0))
+)
+(module
+  (import "spectest" "table" (table 0 funcref))
+  (elem (i32.const 0))
+)
+
+(module
+  (table 0 0 funcref)
+  (elem (i32.const 0))
+)
+
+(module
+  (table 20 funcref)
+  (elem (i32.const 20))
+)
+
+(module
+  (import "spectest" "table" (table 0 funcref))
+  (func $f)
+  (elem (i32.const 0) $f)
+)
+
+(module
+  (import "spectest" "table" (table 0 100 funcref))
+  (func $f)
+  (elem (i32.const 0) $f)
+)
+
+(module
+  (import "spectest" "table" (table 0 funcref))
+  (func $f)
+  (elem (i32.const 1) $f)
+)
+
+(module
+  (import "spectest" "table" (table 0 30 funcref))
+  (func $f)
+  (elem (i32.const 1) $f)
+)
+
+;; Invalid bounds for elements
+
+(assert_trap
+  (module
+    (table 0 funcref)
+    (func $f)
+    (elem (i32.const 0) $f)
+  )
+  "out of bounds table access"
+)
+
+(assert_trap
+  (module
+    (table 0 0 funcref)
+    (func $f)
+    (elem (i32.const 0) $f)
+  )
+  "out of bounds table access"
+)
+
+(assert_trap
+  (module
+    (table 0 1 funcref)
+    (func $f)
+    (elem (i32.const 0) $f)
+  )
+  "out of bounds table access"
+)
+
+(assert_trap
+  (module
+    (table 0 funcref)
+    (elem (i32.const 1))
+  )
+  "out of bounds table access"
+)
+(assert_trap
+  (module
+    (table 10 funcref)
+    (func $f)
+    (elem (i32.const 10) $f)
+  )
+  "out of bounds table access"
+)
+(assert_trap
+  (module
+    (import "spectest" "table" (table 10 funcref))
+    (func $f)
+    (elem (i32.const 10) $f)
+  )
+  "out of bounds table access"
+)
+
+(assert_trap
+  (module
+    (table 10 20 funcref)
+    (func $f)
+    (elem (i32.const 10) $f)
+  )
+  "out of bounds table access"
+)
+(assert_trap
+  (module
+    (import "spectest" "table" (table 10 funcref))
+    (func $f)
+    (elem (i32.const 10) $f)
+  )
+  "out of bounds table access"
+)
+
+(assert_trap
+  (module
+    (table 10 funcref)
+    (func $f)
+    (elem (i32.const -1) $f)
+  )
+  "out of bounds table access"
+)
+(assert_trap
+  (module
+    (import "spectest" "table" (table 10 funcref))
+    (func $f)
+    (elem (i32.const -1) $f)
+  )
+  "out of bounds table access"
+)
+
+(assert_trap
+  (module
+    (table 10 funcref)
+    (func $f)
+    (elem (i32.const -10) $f)
+  )
+  "out of bounds table access"
+)
+(assert_trap
+  (module
+    (import "spectest" "table" (table 10 funcref))
+    (func $f)
+    (elem (i32.const -10) $f)
+  )
+  "out of bounds table access"
+)
+
+;; Implicitly dropped elements
+
+(module
+  (table 10 funcref)
+  (elem $e (i32.const 0) func $f)
+  (func $f)
+  (func (export "init")
+    (table.init $e (i32.const 0) (i32.const 0) (i32.const 1))
+  )
+)
+(assert_trap (invoke "init") "out of bounds table access")
+
+(module
+  (table 10 funcref)
+  (elem $e declare func $f)
+  (func $f)
+  (func (export "init")
+    (table.init $e (i32.const 0) (i32.const 0) (i32.const 1))
+  )
+)
+(assert_trap (invoke "init") "out of bounds table access")
+
+;; Element without table
+
+(assert_invalid
+  (module
+    (func $f)
+    (elem (i32.const 0) $f)
+  )
+  "unknown table"
+)
+
+;; Invalid offsets
+
+(assert_invalid
+  (module
+    (table 1 funcref)
+    (elem (i64.const 0))
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+  (module
+    (table 1 funcref)
+    (elem (ref.null func))
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+  (module 
+    (table 1 funcref)
+    (elem (offset (;empty instruction sequence;)))
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+  (module
+    (table 1 funcref)
+    (elem (offset (i32.const 0) (i32.const 0)))
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+  (module
+    (global (import "test" "global-i32") i32)
+    (table 1 funcref)
+    (elem (offset (global.get 0) (global.get 0)))
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+  (module
+    (global (import "test" "global-i32") i32)
+    (table 1 funcref)
+    (elem (offset (global.get 0) (i32.const 0)))
+  )
+  "type mismatch"
+)
+
+
+(assert_invalid
+  (module
+    (table 1 funcref)
+    (elem (i32.ctz (i32.const 0)))
+  )
+  "constant expression required"
+)
+
+(assert_invalid
+  (module
+    (table 1 funcref)
+    (elem (nop))
+  )
+  "constant expression required"
+)
+
+(assert_invalid
+  (module
+    (table 1 funcref)
+    (elem (offset (nop) (i32.const 0)))
+  )
+  "constant expression required"
+)
+
+(assert_invalid
+  (module
+    (table 1 funcref)
+    (elem (offset (i32.const 0) (nop)))
+  )
+  "constant expression required"
+)
+
+(assert_invalid
+  (module
+    (global $g (import "test" "g") (mut i32))
+    (table 1 funcref)
+    (elem (global.get $g))
+  )
+  "constant expression required"
+)
+
+(assert_invalid
+   (module 
+     (table 1 funcref)
+     (elem (global.get 0))
+   )
+   "unknown global 0"
+)
+
+(assert_invalid
+   (module
+     (global (import "test" "global-i32") i32)
+     (table 1 funcref)
+     (elem (global.get 1))
+   )
+   "unknown global 1"
+)
+
+(assert_invalid
+   (module 
+     (global (import "test" "global-mut-i32") (mut i32))
+     (table 1 funcref)
+     (elem (global.get 0))
+   )
+   "constant expression required"
+)
+
+;; Invalid elements
+
+(assert_invalid
+  (module
+    (table 1 funcref)
+    (elem (i32.const 0) funcref (ref.null extern))
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+  (module
+    (table 1 funcref)
+    (elem (i32.const 0) funcref (item (ref.null func) (ref.null func)))
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+  (module
+    (table 1 funcref)
+    (elem (i32.const 0) funcref (i32.const 0))
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+  (module
+    (table 1 funcref)
+    (elem (i32.const 0) funcref (item (i32.const 0)))
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+  (module
+    (table 1 funcref)
+    (elem (i32.const 0) funcref (item (call $f)))
+    (func $f (result funcref) (ref.null func))
+  )
+  "constant expression required"
+)
+
+(assert_invalid
+  (module
+    (func $f (result i32) (i32.const 9))
+    (table 1 funcref)
+    (elem (i32.const 0) funcref (item (call $f)))
+  )
+  "constant expression required"
+)
+
+;; Two elements target the same slot
+
+(module
+  (type $out-i32 (func (result i32)))
+  (table 10 funcref)
+  (elem (i32.const 9) $const-i32-a)
+  (elem (i32.const 9) $const-i32-b)
+  (func $const-i32-a (type $out-i32) (i32.const 65))
+  (func $const-i32-b (type $out-i32) (i32.const 66))
+  (func (export "call-overwritten") (type $out-i32)
+    (call_indirect (type $out-i32) (i32.const 9))
+  )
+)
+(assert_return (invoke "call-overwritten") (i32.const 66))
+
+(module
+  (type $out-i32 (func (result i32)))
+  (import "spectest" "table" (table 10 funcref))
+  (elem (i32.const 9) $const-i32-a)
+  (elem (i32.const 9) $const-i32-b)
+  (func $const-i32-a (type $out-i32) (i32.const 65))
+  (func $const-i32-b (type $out-i32) (i32.const 66))
+  (func (export "call-overwritten-element") (type $out-i32)
+    (call_indirect (type $out-i32) (i32.const 9))
+  )
+)
+(assert_return (invoke "call-overwritten-element") (i32.const 66))
+
+;; Element sections across multiple modules change the same table
+
+(module $module1
+  (type $out-i32 (func (result i32)))
+  (table (export "shared-table") 10 funcref)
+  (elem (i32.const 8) $const-i32-a)
+  (elem (i32.const 9) $const-i32-b)
+  (func $const-i32-a (type $out-i32) (i32.const 65))
+  (func $const-i32-b (type $out-i32) (i32.const 66))
+  (func (export "call-7") (type $out-i32)
+    (call_indirect (type $out-i32) (i32.const 7))
+  )
+  (func (export "call-8") (type $out-i32)
+    (call_indirect (type $out-i32) (i32.const 8))
+  )
+  (func (export "call-9") (type $out-i32)
+    (call_indirect (type $out-i32) (i32.const 9))
+  )
+)
+
+(register "module1" $module1)
+
+(assert_trap (invoke $module1 "call-7") "uninitialized element")
+(assert_return (invoke $module1 "call-8") (i32.const 65))
+(assert_return (invoke $module1 "call-9") (i32.const 66))
+
+(module $module2
+  (type $out-i32 (func (result i32)))
+  (import "module1" "shared-table" (table 10 funcref))
+  (elem (i32.const 7) $const-i32-c)
+  (elem (i32.const 8) $const-i32-d)
+  (func $const-i32-c (type $out-i32) (i32.const 67))
+  (func $const-i32-d (type $out-i32) (i32.const 68))
+)
+
+(assert_return (invoke $module1 "call-7") (i32.const 67))
+(assert_return (invoke $module1 "call-8") (i32.const 68))
+(assert_return (invoke $module1 "call-9") (i32.const 66))
+
+(module $module3
+  (type $out-i32 (func (result i32)))
+  (import "module1" "shared-table" (table 10 funcref))
+  (elem (i32.const 8) $const-i32-e)
+  (elem (i32.const 9) $const-i32-f)
+  (func $const-i32-e (type $out-i32) (i32.const 69))
+  (func $const-i32-f (type $out-i32) (i32.const 70))
+)
+
+(assert_return (invoke $module1 "call-7") (i32.const 67))
+(assert_return (invoke $module1 "call-8") (i32.const 69))
+(assert_return (invoke $module1 "call-9") (i32.const 70))
+
+;; Element segments must match element type of table
+
+(assert_invalid
+  (module (func $f) (table 1 externref) (elem (i32.const 0) $f))
+  "type mismatch"
+)
+
+(assert_invalid
+  (module (table 1 funcref) (elem (i32.const 0) externref (ref.null extern)))
+  "type mismatch"
+)
+
+(assert_invalid
+  (module
+    (func $f)
+    (table $t 1 externref)
+    (elem $e funcref (ref.func $f))
+    (func (table.init $t $e (i32.const 0) (i32.const 0) (i32.const 1))))
+  "type mismatch"
+)
+
+(assert_invalid
+  (module
+    (table $t 1 funcref)
+    (elem $e externref (ref.null extern))
+    (func (table.init $t $e (i32.const 0) (i32.const 0) (i32.const 1))))
+  "type mismatch"
+)
+
+;; Initializing a table with an externref-type element segment
+
+(module $m
+	(table $t (export "table") 2 externref)
+	(func (export "get") (param $i i32) (result externref)
+	      (table.get $t (local.get $i)))
+	(func (export "set") (param $i i32) (param $x externref)
+	      (table.set $t (local.get $i) (local.get $x))))
+
+(register "exporter" $m)
+
+(assert_return (invoke $m "get" (i32.const 0)) (ref.null extern))
+(assert_return (invoke $m "get" (i32.const 1)) (ref.null extern))
+
+(assert_return (invoke $m "set" (i32.const 0) (ref.extern 42)))
+(assert_return (invoke $m "set" (i32.const 1) (ref.extern 137)))
+
+(assert_return (invoke $m "get" (i32.const 0)) (ref.extern 42))
+(assert_return (invoke $m "get" (i32.const 1)) (ref.extern 137))
+
+(module
+  (import "exporter" "table" (table $t 2 externref))
+  (elem (i32.const 0) externref (ref.null extern)))
+
+(assert_return (invoke $m "get" (i32.const 0)) (ref.null extern))
+(assert_return (invoke $m "get" (i32.const 1)) (ref.extern 137))
+
+;; Initializing a table with imported funcref global
+
+(module $module4
+  (func (result i32)
+    i32.const 42
+  )
+  (global (export "f") funcref (ref.func 0))
+)
+
+(register "module4" $module4)
+
+(module
+  (import "module4" "f" (global funcref))
+  (type $out-i32 (func (result i32)))
+  (table 10 funcref)
+  (elem (offset (i32.const 0)) funcref (global.get 0))
+  (func (export "call_imported_elem") (type $out-i32)
+    (call_indirect (type $out-i32) (i32.const 0))
+  )
+)
+
+(assert_return (invoke "call_imported_elem") (i32.const 42))
+
+;; Extended contant expressions
+
+(module
+  (table 10 funcref)
+  (func (result i32) (i32.const 42))
+  (func (export "call_in_table") (param i32) (result i32)
+    (call_indirect (type 0) (local.get 0)))
+  (elem (table 0) (offset (i32.add (i32.const 1) (i32.const 2))) funcref (ref.func 0))
+)
+
+(assert_return (invoke "call_in_table" (i32.const 3)) (i32.const 42))
+(assert_trap (invoke "call_in_table" (i32.const 0)) "uninitialized element")
+
+(module
+  (table 10 funcref)
+  (func (result i32) (i32.const 42))
+  (func (export "call_in_table") (param i32) (result i32)
+    (call_indirect (type 0) (local.get 0)))
+  (elem (table 0) (offset (i32.sub (i32.const 2) (i32.const 1))) funcref (ref.func 0))
+)
+
+(assert_return (invoke "call_in_table" (i32.const 1)) (i32.const 42))
+(assert_trap (invoke "call_in_table" (i32.const 0)) "uninitialized element")
+
+(module
+  (table 10 funcref)
+  (func (result i32) (i32.const 42))
+  (func (export "call_in_table") (param i32) (result i32)
+    (call_indirect (type 0) (local.get 0)))
+  (elem (table 0) (offset (i32.mul (i32.const 2) (i32.const 2))) funcref (ref.func 0))
+)
+
+(assert_return (invoke "call_in_table" (i32.const 4)) (i32.const 42))
+(assert_trap (invoke "call_in_table" (i32.const 0)) "uninitialized element")
+
+;; Combining add, sub, mul and global.get
+
+(module
+  (global (import "spectest" "global_i32") i32)
+  (table 10 funcref)
+  (func (result i32) (i32.const 42))
+  (func (export "call_in_table") (param i32) (result i32)
+    (call_indirect (type 0) (local.get 0)))
+  (elem (table 0)
+        (offset
+          (i32.mul
+            (i32.const 2)
+            (i32.add
+              (i32.sub (global.get 0) (i32.const 665))
+              (i32.const 2))))
+        funcref
+        (ref.func 0))
+)
+
+(assert_return (invoke "call_in_table" (i32.const 6)) (i32.const 42))
+(assert_trap (invoke "call_in_table" (i32.const 0)) "uninitialized element")

--- a/test/old-spec/proposals/extended-const/global.wast
+++ b/test/old-spec/proposals/extended-const/global.wast
@@ -1,0 +1,642 @@
+;; Vendored copy of proposals/extended-const/global.wast from the pinned testsuite, patched with the
+;; 2025-09 spec change that allows global.get of defined immutable globals
+;; in initializer expressions (ref: WebAssembly/testsuite@4b24564c84).
+;; Test globals
+
+(module
+  (global (import "spectest" "global_i32") i32)
+  (global (import "spectest" "global_i64") i64)
+
+  (global $a i32 (i32.const -2))
+  (global (;3;) f32 (f32.const -3))
+  (global (;4;) f64 (f64.const -4))
+  (global $b i64 (i64.const -5))
+
+  (global $x (mut i32) (i32.const -12))
+  (global (;7;) (mut f32) (f32.const -13))
+  (global (;8;) (mut f64) (f64.const -14))
+  (global $y (mut i64) (i64.const -15))
+
+  (global $z1 i32 (global.get 0))
+  (global $z2 i64 (global.get 1))
+  (global $z3 i32 (i32.add (i32.sub (i32.mul (i32.const 20) (i32.const 2)) (i32.const 2)) (i32.const 4)))
+  (global $z4 i64 (i64.add (i64.sub (i64.mul (i64.const 20) (i64.const 2)) (i64.const 2)) (i64.const 5)))
+  (global $z5 i32 (i32.add (global.get 0) (i32.const 42)))
+  (global $z6 i64 (i64.add (global.get 1) (i64.const 42)))
+
+  (global $r externref (ref.null extern))
+  (global $mr (mut externref) (ref.null extern))
+  (global funcref (ref.null func))
+
+  (func (export "get-a") (result i32) (global.get $a))
+  (func (export "get-b") (result i64) (global.get $b))
+  (func (export "get-r") (result externref) (global.get $r))
+  (func (export "get-mr") (result externref) (global.get $mr))
+  (func (export "get-x") (result i32) (global.get $x))
+  (func (export "get-y") (result i64) (global.get $y))
+  (func (export "get-z1") (result i32) (global.get $z1))
+  (func (export "get-z2") (result i64) (global.get $z2))
+  (func (export "get-z3") (result i32) (global.get $z3))
+  (func (export "get-z4") (result i64) (global.get $z4))
+  (func (export "get-z5") (result i32) (global.get $z5))
+  (func (export "get-z6") (result i64) (global.get $z6))
+  (func (export "set-x") (param i32) (global.set $x (local.get 0)))
+  (func (export "set-y") (param i64) (global.set $y (local.get 0)))
+  (func (export "set-mr") (param externref) (global.set $mr (local.get 0)))
+
+  (func (export "get-3") (result f32) (global.get 3))
+  (func (export "get-4") (result f64) (global.get 4))
+  (func (export "get-7") (result f32) (global.get 7))
+  (func (export "get-8") (result f64) (global.get 8))
+  (func (export "set-7") (param f32) (global.set 7 (local.get 0)))
+  (func (export "set-8") (param f64) (global.set 8 (local.get 0)))
+
+  ;; As the argument of control constructs and instructions
+
+  (memory 1)
+
+  (func $dummy)
+
+  (func (export "as-select-first") (result i32)
+    (select (global.get $x) (i32.const 2) (i32.const 3))
+  )
+  (func (export "as-select-mid") (result i32)
+    (select (i32.const 2) (global.get $x) (i32.const 3))
+  )
+  (func (export "as-select-last") (result i32)
+    (select (i32.const 2) (i32.const 3) (global.get $x))
+  )
+
+  (func (export "as-loop-first") (result i32)
+    (loop (result i32)
+      (global.get $x) (call $dummy) (call $dummy)
+    )
+  )
+  (func (export "as-loop-mid") (result i32)
+    (loop (result i32)
+      (call $dummy) (global.get $x) (call $dummy)
+    )
+  )
+  (func (export "as-loop-last") (result i32)
+    (loop (result i32)
+      (call $dummy) (call $dummy) (global.get $x)
+    )
+  )
+
+  (func (export "as-if-condition") (result i32)
+    (if (result i32) (global.get $x)
+      (then (call $dummy) (i32.const 2))
+      (else (call $dummy) (i32.const 3))
+    )
+  )
+  (func (export "as-if-then") (result i32)
+    (if (result i32) (i32.const 1)
+      (then (global.get $x)) (else (i32.const 2))
+    )
+  )
+  (func (export "as-if-else") (result i32)
+    (if (result i32) (i32.const 0)
+      (then (i32.const 2)) (else (global.get $x))
+    )
+  )
+
+  (func (export "as-br_if-first") (result i32)
+    (block (result i32)
+      (br_if 0 (global.get $x) (i32.const 2))
+      (return (i32.const 3))
+    )
+  )
+  (func (export "as-br_if-last") (result i32)
+    (block (result i32)
+      (br_if 0 (i32.const 2) (global.get $x))
+      (return (i32.const 3))
+    )
+  )
+
+  (func (export "as-br_table-first") (result i32)
+    (block (result i32)
+      (global.get $x) (i32.const 2) (br_table 0 0)
+    )
+  )
+  (func (export "as-br_table-last") (result i32)
+    (block (result i32)
+      (i32.const 2) (global.get $x) (br_table 0 0)
+    )
+  )
+
+  (func $func (param i32 i32) (result i32) (local.get 0))
+  (type $check (func (param i32 i32) (result i32)))
+  (table funcref (elem $func))
+  (func (export "as-call_indirect-first") (result i32)
+    (block (result i32)
+      (call_indirect (type $check)
+        (global.get $x) (i32.const 2) (i32.const 0)
+      )
+    )
+  )
+  (func (export "as-call_indirect-mid") (result i32)
+    (block (result i32)
+      (call_indirect (type $check)
+        (i32.const 2) (global.get $x) (i32.const 0)
+      )
+    )
+  )
+ (func (export "as-call_indirect-last") (result i32)
+    (block (result i32)
+      (call_indirect (type $check)
+        (i32.const 2) (i32.const 0) (global.get $x)
+      )
+    )
+  )
+
+  (func (export "as-store-first")
+    (global.get $x) (i32.const 1) (i32.store)
+  )
+  (func (export "as-store-last")
+    (i32.const 0) (global.get $x) (i32.store)
+  )
+  (func (export "as-load-operand") (result i32)
+    (i32.load (global.get $x))
+  )
+  (func (export "as-memory.grow-value") (result i32)
+    (memory.grow (global.get $x))
+  )
+
+  (func $f (param i32) (result i32) (local.get 0))
+  (func (export "as-call-value") (result i32)
+    (call $f (global.get $x))
+  )
+
+  (func (export "as-return-value") (result i32)
+    (global.get $x) (return)
+  )
+  (func (export "as-drop-operand")
+    (drop (global.get $x))
+  )
+  (func (export "as-br-value") (result i32)
+    (block (result i32) (br 0 (global.get $x)))
+  )
+
+  (func (export "as-local.set-value") (param i32) (result i32)
+    (local.set 0 (global.get $x))
+    (local.get 0)
+  )
+  (func (export "as-local.tee-value") (param i32) (result i32)
+    (local.tee 0 (global.get $x))
+  )
+  (func (export "as-global.set-value") (result i32)
+    (global.set $x (global.get $x))
+    (global.get $x)
+  )
+
+  (func (export "as-unary-operand") (result i32)
+    (i32.eqz (global.get $x))
+  )
+  (func (export "as-binary-operand") (result i32)
+    (i32.mul
+      (global.get $x) (global.get $x)
+    )
+  )
+  (func (export "as-compare-operand") (result i32)
+    (i32.gt_u
+      (global.get 0) (i32.const 1)
+    )
+  )
+)
+
+(assert_return (invoke "get-a") (i32.const -2))
+(assert_return (invoke "get-b") (i64.const -5))
+(assert_return (invoke "get-r") (ref.null extern))
+(assert_return (invoke "get-mr") (ref.null extern))
+(assert_return (invoke "get-x") (i32.const -12))
+(assert_return (invoke "get-y") (i64.const -15))
+(assert_return (invoke "get-z1") (i32.const 666))
+(assert_return (invoke "get-z2") (i64.const 666))
+(assert_return (invoke "get-z3") (i32.const 42))
+(assert_return (invoke "get-z4") (i64.const 43))
+(assert_return (invoke "get-z5") (i32.const 708))
+(assert_return (invoke "get-z6") (i64.const 708))
+
+(assert_return (invoke "get-3") (f32.const -3))
+(assert_return (invoke "get-4") (f64.const -4))
+(assert_return (invoke "get-7") (f32.const -13))
+(assert_return (invoke "get-8") (f64.const -14))
+
+(assert_return (invoke "set-x" (i32.const 6)))
+(assert_return (invoke "set-y" (i64.const 7)))
+
+(assert_return (invoke "set-7" (f32.const 8)))
+(assert_return (invoke "set-8" (f64.const 9)))
+
+(assert_return (invoke "get-x") (i32.const 6))
+(assert_return (invoke "get-y") (i64.const 7))
+(assert_return (invoke "get-7") (f32.const 8))
+(assert_return (invoke "get-8") (f64.const 9))
+
+(assert_return (invoke "set-7" (f32.const 8)))
+(assert_return (invoke "set-8" (f64.const 9)))
+(assert_return (invoke "set-mr" (ref.extern 10)))
+
+(assert_return (invoke "get-x") (i32.const 6))
+(assert_return (invoke "get-y") (i64.const 7))
+(assert_return (invoke "get-7") (f32.const 8))
+(assert_return (invoke "get-8") (f64.const 9))
+(assert_return (invoke "get-mr") (ref.extern 10))
+
+(assert_return (invoke "as-select-first") (i32.const 6))
+(assert_return (invoke "as-select-mid") (i32.const 2))
+(assert_return (invoke "as-select-last") (i32.const 2))
+
+(assert_return (invoke "as-loop-first") (i32.const 6))
+(assert_return (invoke "as-loop-mid") (i32.const 6))
+(assert_return (invoke "as-loop-last") (i32.const 6))
+
+(assert_return (invoke "as-if-condition") (i32.const 2))
+(assert_return (invoke "as-if-then") (i32.const 6))
+(assert_return (invoke "as-if-else") (i32.const 6))
+
+(assert_return (invoke "as-br_if-first") (i32.const 6))
+(assert_return (invoke "as-br_if-last") (i32.const 2))
+
+(assert_return (invoke "as-br_table-first") (i32.const 6))
+(assert_return (invoke "as-br_table-last") (i32.const 2))
+
+(assert_return (invoke "as-call_indirect-first") (i32.const 6))
+(assert_return (invoke "as-call_indirect-mid") (i32.const 2))
+(assert_trap (invoke "as-call_indirect-last") "undefined element")
+
+(assert_return (invoke "as-store-first"))
+(assert_return (invoke "as-store-last"))
+(assert_return (invoke "as-load-operand") (i32.const 1))
+(assert_return (invoke "as-memory.grow-value") (i32.const 1))
+
+(assert_return (invoke "as-call-value") (i32.const 6))
+
+(assert_return (invoke "as-return-value") (i32.const 6))
+(assert_return (invoke "as-drop-operand"))
+(assert_return (invoke "as-br-value") (i32.const 6))
+
+(assert_return (invoke "as-local.set-value" (i32.const 1)) (i32.const 6))
+(assert_return (invoke "as-local.tee-value" (i32.const 1)) (i32.const 6))
+(assert_return (invoke "as-global.set-value") (i32.const 6))
+
+(assert_return (invoke "as-unary-operand") (i32.const 0))
+(assert_return (invoke "as-binary-operand") (i32.const 36))
+(assert_return (invoke "as-compare-operand") (i32.const 1))
+
+(assert_invalid
+  (module (global f32 (f32.const 0)) (func (global.set 0 (f32.const 1))))
+  "global is immutable"
+)
+
+(assert_invalid
+  (module (import "spectest" "global_i32" (global i32)) (func (global.set 0 (i32.const 1))))
+  "global is immutable"
+)
+
+;; mutable globals can be exported
+(module (global (mut f32) (f32.const 0)) (export "a" (global 0)))
+(module (global (export "a") (mut f32) (f32.const 0)))
+
+(assert_invalid
+  (module (global f32 (f32.neg (f32.const 0))))
+  "constant expression required"
+)
+
+(assert_invalid
+  (module (global f32 (local.get 0)))
+  "constant expression required"
+)
+
+(assert_invalid
+  (module (global f32 (f32.neg (f32.const 1))))
+  "constant expression required"
+)
+
+(assert_invalid
+  (module (global i32 (i32.const 0) (nop)))
+  "constant expression required"
+)
+
+(assert_invalid
+  (module (global i32 (i32.ctz (i32.const 0))))
+  "constant expression required"
+)
+
+(assert_invalid
+  (module (global i32 (nop)))
+  "constant expression required"
+)
+
+(assert_invalid
+  (module (global i32 (f32.const 0)))
+  "type mismatch"
+)
+
+(assert_invalid
+  (module (global i32 (i32.const 0) (i32.const 0)))
+  "type mismatch"
+)
+
+(assert_invalid
+  (module (global i32 (;empty instruction sequence;)))
+  "type mismatch"
+)
+
+(assert_invalid
+  (module (global (import "" "") externref) (global funcref (global.get 0)))
+  "type mismatch"
+)
+
+(assert_invalid
+  (module (global (import "test" "global-i32") i32) (global i32 (global.get 0) (global.get 0)))
+  "type mismatch"
+)
+
+(assert_invalid
+  (module (global (import "test" "global-i32") i32) (global i32 (i32.const 0) (global.get 0)))
+  "type mismatch"
+)
+
+(assert_invalid
+  (module (global i32 (global.get 0)))
+  "unknown global"
+)
+
+(assert_invalid
+  (module (global i32 (global.get 1)) (global i32 (i32.const 0)))
+  "unknown global"
+)
+
+(assert_invalid
+  (module (global (import "test" "global-i32") i32) (global i32 (global.get 2)))
+  "unknown global"
+)
+
+(module (global i32 (i32.const 0)) (global i32 (global.get 0)))
+(module (global $g i32 (i32.const 0)) (global i32 (global.get $g)))
+
+(assert_invalid
+  (module (global (import "test" "global-mut-i32") (mut i32)) (global i32 (global.get 0)))
+  "constant expression required"
+)
+
+(module
+  (import "spectest" "global_i32" (global i32))
+)
+(assert_malformed
+  (module binary
+    "\00asm" "\01\00\00\00"
+    "\02\98\80\80\80\00"             ;; import section
+      "\01"                          ;; length 1
+      "\08\73\70\65\63\74\65\73\74"  ;; "spectest"
+      "\0a\67\6c\6f\62\61\6c\5f\69\33\32" ;; "global_i32"
+      "\03"                          ;; GlobalImport
+      "\7f"                          ;; i32
+      "\02"                          ;; malformed mutability
+  )
+  "malformed mutability"
+)
+(assert_malformed
+  (module binary
+    "\00asm" "\01\00\00\00"
+    "\02\98\80\80\80\00"             ;; import section
+      "\01"                          ;; length 1
+      "\08\73\70\65\63\74\65\73\74"  ;; "spectest"
+      "\0a\67\6c\6f\62\61\6c\5f\69\33\32" ;; "global_i32"
+      "\03"                          ;; GlobalImport
+      "\7f"                          ;; i32
+      "\ff"                          ;; malformed mutability
+  )
+  "malformed mutability"
+)
+
+(module
+  (global i32 (i32.const 0))
+)
+(assert_malformed
+  (module binary
+    "\00asm" "\01\00\00\00"
+    "\06\86\80\80\80\00"  ;; global section
+      "\01"               ;; length 1
+      "\7f"               ;; i32
+      "\02"               ;; malformed mutability
+      "\41\00"            ;; i32.const 0
+      "\0b"               ;; end
+  )
+  "malformed mutability"
+)
+(assert_malformed
+  (module binary
+    "\00asm" "\01\00\00\00"
+    "\06\86\80\80\80\00"  ;; global section
+      "\01"               ;; length 1
+      "\7f"               ;; i32
+      "\ff"               ;; malformed mutability
+      "\41\00"            ;; i32.const 0
+      "\0b"               ;; end
+  )
+  "malformed mutability"
+)
+
+;; global.get with invalid index
+(assert_invalid
+  (module (func (result i32) (global.get 0)))
+  "unknown global"
+)
+
+(assert_invalid
+  (module
+    (global i32 (i32.const 0))
+    (func (result i32) (global.get 1))
+  )
+  "unknown global"
+)
+
+(assert_invalid
+  (module
+    (import "spectest" "global_i32" (global i32))
+    (func (result i32) (global.get 1))
+  )
+  "unknown global"
+)
+
+(assert_invalid
+  (module
+    (import "spectest" "global_i32" (global i32))
+    (global i32 (i32.const 0))
+    (func (result i32) (global.get 2))
+  )
+  "unknown global"
+)
+
+;; global.set with invalid index
+(assert_invalid
+  (module (func (i32.const 0) (global.set 0)))
+  "unknown global"
+)
+
+(assert_invalid
+  (module
+    (global i32 (i32.const 0))
+    (func (i32.const 0) (global.set 1))
+  )
+  "unknown global"
+)
+
+(assert_invalid
+  (module
+    (import "spectest" "global_i32" (global i32))
+    (func (i32.const 0) (global.set 1))
+  )
+  "unknown global"
+)
+
+(assert_invalid
+  (module
+    (import "spectest" "global_i32" (global i32))
+    (global i32 (i32.const 0))
+    (func (i32.const 0) (global.set 2))
+  )
+  "unknown global"
+)
+
+
+(assert_invalid
+  (module
+    (global $x (mut i32) (i32.const 0))
+    (func $type-global.set-value-empty
+      (global.set $x)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (global $x (mut i32) (i32.const 0))
+    (func $type-global.set-value-empty-in-block
+      (i32.const 0)
+      (block (global.set $x))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (global $x (mut i32) (i32.const 0))
+    (func $type-global.set-value-empty-in-loop
+      (i32.const 0)
+      (loop (global.set $x))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (global $x (mut i32) (i32.const 0))
+    (func $type-global.set-value-empty-in-then
+      (i32.const 0) (i32.const 0)
+      (if (then (global.set $x)))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (global $x (mut i32) (i32.const 0))
+    (func $type-global.set-value-empty-in-else
+      (i32.const 0) (i32.const 0)
+      (if (result i32) (then (i32.const 0)) (else (global.set $x)))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (global $x (mut i32) (i32.const 0))
+    (func $type-global.set-value-empty-in-br
+      (i32.const 0)
+      (block (br 0 (global.set $x)))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (global $x (mut i32) (i32.const 0))
+    (func $type-global.set-value-empty-in-br_if
+      (i32.const 0)
+      (block (br_if 0 (global.set $x)))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (global $x (mut i32) (i32.const 0))
+    (func $type-global.set-value-empty-in-br_table
+      (i32.const 0)
+      (block (br_table 0 (global.set $x)))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (global $x (mut i32) (i32.const 0))
+    (func $type-global.set-value-empty-in-return
+      (return (global.set $x))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (global $x (mut i32) (i32.const 0))
+    (func $type-global.set-value-empty-in-select
+      (select (global.set $x) (i32.const 1) (i32.const 2))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (global $x (mut i32) (i32.const 0))
+    (func $type-global.set-value-empty-in-call
+      (call 1 (global.set $x))
+    )
+    (func (param i32) (result i32) (local.get 0))
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (global $x (mut i32) (i32.const 0))
+    (func $f (param i32) (result i32) (local.get 0))
+    (type $sig (func (param i32) (result i32)))
+    (table funcref (elem $f))
+    (func $type-global.set-value-empty-in-call_indirect
+      (block (result i32)
+        (call_indirect (type $sig)
+          (global.set $x) (i32.const 0)
+        )
+      )
+    )
+  )
+  "type mismatch"
+)
+
+;; Duplicate identifier errors
+
+(assert_malformed (module quote
+  "(global $foo i32 (i32.const 0))"
+  "(global $foo i32 (i32.const 0))")
+  "duplicate global")
+(assert_malformed (module quote
+  "(import \"\" \"\" (global $foo i32))"
+  "(global $foo i32 (i32.const 0))")
+  "duplicate global")
+(assert_malformed (module quote
+  "(import \"\" \"\" (global $foo i32))"
+  "(import \"\" \"\" (global $foo i32))")
+  "duplicate global")

--- a/test/old-spec/proposals/multi-memory/data.wast
+++ b/test/old-spec/proposals/multi-memory/data.wast
@@ -1,0 +1,496 @@
+;; Vendored copy of proposals/multi-memory/data.wast from the pinned testsuite, patched with the
+;; 2025-09 spec change that allows global.get of defined immutable globals
+;; in initializer expressions (ref: WebAssembly/testsuite@4b24564c84).
+;; Test the data section
+
+;; Syntax
+
+(module
+  (memory $m 1)
+  (data (i32.const 0))
+  (data (i32.const 1) "a" "" "bcd")
+  (data (offset (i32.const 0)))
+  (data (offset (i32.const 0)) "" "a" "bc" "")
+  (data (memory 0) (i32.const 0))
+  (data (memory 0x0) (i32.const 1) "a" "" "bcd")
+  (data (memory 0x000) (offset (i32.const 0)))
+  (data (memory 0) (offset (i32.const 0)) "" "a" "bc" "")
+  (data (memory $m) (i32.const 0))
+  (data (memory $m) (i32.const 1) "a" "" "bcd")
+  (data (memory $m) (offset (i32.const 0)))
+  (data (memory $m) (offset (i32.const 0)) "" "a" "bc" "")
+
+  (data $d1 (i32.const 0))
+  (data $d2 (i32.const 1) "a" "" "bcd")
+  (data $d3 (offset (i32.const 0)))
+  (data $d4 (offset (i32.const 0)) "" "a" "bc" "")
+  (data $d5 (memory 0) (i32.const 0))
+  (data $d6 (memory 0x0) (i32.const 1) "a" "" "bcd")
+  (data $d7 (memory 0x000) (offset (i32.const 0)))
+  (data $d8 (memory 0) (offset (i32.const 0)) "" "a" "bc" "")
+  (data $d9 (memory $m) (i32.const 0))
+  (data $d10 (memory $m) (i32.const 1) "a" "" "bcd")
+  (data $d11 (memory $m) (offset (i32.const 0)))
+  (data $d12 (memory $m) (offset (i32.const 0)) "" "a" "bc" "")
+)
+
+;; Basic use
+
+(module
+  (memory 1)
+  (data (i32.const 0) "a")
+)
+(module
+  (import "spectest" "memory" (memory 1))
+  (data (i32.const 0) "a")
+)
+
+(module
+  (memory 1)
+  (data (i32.const 0) "a")
+  (data (i32.const 3) "b")
+  (data (i32.const 100) "cde")
+  (data (i32.const 5) "x")
+  (data (i32.const 3) "c")
+)
+(module
+  (import "spectest" "memory" (memory 1))
+  (data (i32.const 0) "a")
+  (data (i32.const 1) "b")
+  (data (i32.const 2) "cde")
+  (data (i32.const 3) "f")
+  (data (i32.const 2) "g")
+  (data (i32.const 1) "h")
+)
+
+(module
+  (global (import "spectest" "global_i32") i32)
+  (memory 1)
+  (data (global.get 0) "a")
+)
+(module
+  (global (import "spectest" "global_i32") i32)
+  (import "spectest" "memory" (memory 1))
+  (data (global.get 0) "a")
+)
+
+(module
+  (global $g (import "spectest" "global_i32") i32)
+  (memory 1)
+  (data (global.get $g) "a")
+)
+(module
+  (global $g (import "spectest" "global_i32") i32)
+  (import "spectest" "memory" (memory 1))
+  (data (global.get $g) "a")
+)
+
+(module (memory 1) (global i32 (i32.const 0)) (data (global.get 0) "a"))
+(module (memory 1) (global $g i32 (i32.const 0)) (data (global.get $g) "a"))
+
+
+;; Corner cases
+
+(module
+  (memory 1)
+  (data (i32.const 0) "a")
+  (data (i32.const 0xffff) "b")
+)
+(module
+  (import "spectest" "memory" (memory 1))
+  (data (i32.const 0) "a")
+  (data (i32.const 0xffff) "b")
+)
+
+(module
+  (memory 2)
+  (data (i32.const 0x1_ffff) "a")
+)
+
+(module
+  (memory 0)
+  (data (i32.const 0))
+)
+(module
+  (import "spectest" "memory" (memory 0))
+  (data (i32.const 0))
+)
+
+(module
+  (memory 0 0)
+  (data (i32.const 0))
+)
+
+(module
+  (memory 1)
+  (data (i32.const 0x1_0000) "")
+)
+
+(module
+  (memory 0)
+  (data (i32.const 0) "" "")
+)
+(module
+  (import "spectest" "memory" (memory 0))
+  (data (i32.const 0) "" "")
+)
+
+(module
+  (memory 0 0)
+  (data (i32.const 0) "" "")
+)
+
+(module
+  (import "spectest" "memory" (memory 0))
+  (data (i32.const 0) "a")
+)
+
+(module
+  (import "spectest" "memory" (memory 0 3))
+  (data (i32.const 0) "a")
+)
+
+(module
+  (global (import "spectest" "global_i32") i32)
+  (import "spectest" "memory" (memory 0))
+  (data (global.get 0) "a")
+)
+
+(module
+  (global (import "spectest" "global_i32") i32)
+  (import "spectest" "memory" (memory 0 3))
+  (data (global.get 0) "a")
+)
+
+(module
+  (import "spectest" "memory" (memory 0))
+  (data (i32.const 1) "a")
+)
+
+(module
+  (import "spectest" "memory" (memory 0 3))
+  (data (i32.const 1) "a")
+)
+
+;; Invalid bounds for data
+
+(assert_trap
+  (module
+    (memory 0)
+    (data (i32.const 0) "a")
+  )
+  "out of bounds memory access"
+)
+
+(assert_trap
+  (module
+    (memory 0 0)
+    (data (i32.const 0) "a")
+  )
+  "out of bounds memory access"
+)
+
+(assert_trap
+  (module
+    (memory 0 1)
+    (data (i32.const 0) "a")
+  )
+  "out of bounds memory access"
+)
+(assert_trap
+  (module
+    (memory 0)
+    (data (i32.const 1))
+  )
+  "out of bounds memory access"
+)
+(assert_trap
+  (module
+    (memory 0 1)
+    (data (i32.const 1))
+  )
+  "out of bounds memory access"
+)
+
+;; This seems to cause a time-out on Travis.
+(;assert_unlinkable
+  (module
+    (memory 0x10000)
+    (data (i32.const 0xffffffff) "ab")
+  )
+  ""  ;; either out of memory or out of bounds
+;)
+
+(assert_trap
+  (module
+    (global (import "spectest" "global_i32") i32)
+    (memory 0)
+    (data (global.get 0) "a")
+  )
+  "out of bounds memory access"
+)
+
+(assert_trap
+  (module
+    (memory 1 2)
+    (data (i32.const 0x1_0000) "a")
+  )
+  "out of bounds memory access"
+)
+(assert_trap
+  (module
+    (import "spectest" "memory" (memory 1))
+    (data (i32.const 0x1_0000) "a")
+  )
+  "out of bounds memory access"
+)
+
+(assert_trap
+  (module
+    (memory 2)
+    (data (i32.const 0x2_0000) "a")
+  )
+  "out of bounds memory access"
+)
+
+(assert_trap
+  (module
+    (memory 2 3)
+    (data (i32.const 0x2_0000) "a")
+  )
+  "out of bounds memory access"
+)
+
+(assert_trap
+  (module
+    (memory 1)
+    (data (i32.const -1) "a")
+  )
+  "out of bounds memory access"
+)
+(assert_trap
+  (module
+    (import "spectest" "memory" (memory 1))
+    (data (i32.const -1) "a")
+  )
+  "out of bounds memory access"
+)
+
+(assert_trap
+  (module
+    (memory 2)
+    (data (i32.const -100) "a")
+  )
+  "out of bounds memory access"
+)
+(assert_trap
+  (module
+    (import "spectest" "memory" (memory 1))
+    (data (i32.const -100) "a")
+  )
+  "out of bounds memory access"
+)
+
+;; Data without memory
+
+(assert_invalid
+  (module
+    (data (i32.const 0) "")
+  )
+  "unknown memory"
+)
+
+;; Data segment with memory index 1 (only memory 0 available)
+(assert_invalid
+  (module binary
+    "\00asm" "\01\00\00\00"
+    "\05\03\01"                             ;; memory section
+    "\00\00"                                ;; memory 0
+    "\0b\07\01"                             ;; data section
+    "\02\01\41\00\0b"                       ;; active data segment 0 for memory 1
+    "\00"                                   ;; empty vec(byte)
+  )
+  "unknown memory 1"
+)
+
+;; Data segment with memory index 0 (no memory section)
+(assert_invalid
+  (module binary
+    "\00asm" "\01\00\00\00"
+    "\0b\06\01"                             ;; data section
+    "\00\41\00\0b"                          ;; active data segment 0 for memory 0
+    "\00"                                   ;; empty vec(byte)
+  )
+  "unknown memory 0"
+)
+
+;; Data segment with memory index 1 (no memory section)
+(assert_invalid
+  (module binary
+    "\00asm" "\01\00\00\00"
+    "\0b\07\01"                             ;; data section
+    "\02\01\41\00\0b"                       ;; active data segment 0 for memory 1
+    "\00"                                   ;; empty vec(byte)
+  )
+  "unknown memory 1"
+)
+
+;; Data segment with memory index 1 and vec(byte) as above,
+;; only memory 0 available.
+(assert_invalid
+  (module binary
+    "\00asm" "\01\00\00\00"
+    "\05\03\01"                             ;; memory section
+    "\00\00"                                ;; memory 0
+    "\0b\45\01"                             ;; data section
+    "\02"                                   ;; active segment
+    "\01"                                   ;; memory index
+    "\41\00\0b"                             ;; offset constant expression
+    "\3e"                                   ;; vec(byte) length
+    "\00\01\02\03\04\05\06\07\08\09\0a\0b\0c\0d\0e\0f"
+    "\10\11\12\13\14\15\16\17\18\19\1a\1b\1c\1d\1e\1f"
+    "\20\21\22\23\24\25\26\27\28\29\2a\2b\2c\2d\2e\2f"
+    "\30\31\32\33\34\35\36\37\38\39\3a\3b\3c\3d"
+  )
+  "unknown memory 1"
+)
+
+;; Data segment with memory index 1 and specially crafted vec(byte) after.
+;; This is to detect incorrect validation where memory index is interpreted
+;; as a flag followed by "\41" interpreted as the size of vec(byte)
+;; with the expected number of bytes following.
+(assert_invalid
+  (module binary
+    "\00asm" "\01\00\00\00"
+    "\0b\45\01"                             ;; data section
+    "\02"                                   ;; active segment
+    "\01"                                   ;; memory index
+    "\41\00\0b"                             ;; offset constant expression
+    "\3e"                                   ;; vec(byte) length
+    "\00\01\02\03\04\05\06\07\08\09\0a\0b\0c\0d\0e\0f"
+    "\10\11\12\13\14\15\16\17\18\19\1a\1b\1c\1d\1e\1f"
+    "\20\21\22\23\24\25\26\27\28\29\2a\2b\2c\2d\2e\2f"
+    "\30\31\32\33\34\35\36\37\38\39\3a\3b\3c\3d"
+  )
+  "unknown memory 1"
+)
+
+
+;; Invalid offsets
+
+(assert_invalid
+  (module
+    (memory 1)
+    (data (i64.const 0))
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+  (module
+    (memory 1)
+    (data (ref.null func))
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+  (module 
+    (memory 1)
+    (data (offset (;empty instruction sequence;)))
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+  (module
+    (memory 1)
+    (data (offset (i32.const 0) (i32.const 0)))
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+  (module
+    (global (import "test" "global-i32") i32)
+    (memory 1)
+    (data (offset (global.get 0) (global.get 0)))
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+  (module
+    (global (import "test" "global-i32") i32)
+    (memory 1)
+    (data (offset (global.get 0) (i32.const 0)))
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+  (module
+    (memory 1)
+    (data (i32.ctz (i32.const 0)))
+  )
+  "constant expression required"
+)
+
+(assert_invalid
+  (module
+    (memory 1)
+    (data (nop))
+  )
+  "constant expression required"
+)
+
+(assert_invalid
+  (module
+    (memory 1)
+    (data (offset (nop) (i32.const 0)))
+  )
+  "constant expression required"
+)
+
+(assert_invalid
+  (module
+    (memory 1)
+    (data (offset (i32.const 0) (nop)))
+  )
+  "constant expression required"
+)
+
+(assert_invalid
+  (module
+    (global $g (import "test" "g") (mut i32))
+    (memory 1)
+    (data (global.get $g))
+  )
+  "constant expression required"
+)
+
+(assert_invalid
+   (module 
+     (memory 1)
+     (data (global.get 0))
+   )
+   "unknown global 0"
+)
+
+(assert_invalid
+   (module
+     (global (import "test" "global-i32") i32)
+     (memory 1)
+     (data (global.get 1))
+   )
+   "unknown global 1"
+)
+
+(assert_invalid
+   (module 
+     (global (import "test" "global-mut-i32") (mut i32))
+     (memory 1)
+     (data (global.get 0))
+   )
+   "constant expression required"
+)

--- a/test/parse/module/bad-global-invalid-globalget.txt
+++ b/test/parse/module/bad-global-invalid-globalget.txt
@@ -3,7 +3,7 @@
 (module
   (global i32 (global.get 1)))
 (;; STDERR ;;;
-out/test/parse/module/bad-global-invalid-globalget.txt:4:27: error: global variable out of range: 1 (max 1)
+out/test/parse/module/bad-global-invalid-globalget.txt:4:27: error: global variable out of range: 1 (max 0)
   (global i32 (global.get 1)))
                           ^
 ;;; STDERR ;;)

--- a/test/regress/issue-2526.txt
+++ b/test/regress/issue-2526.txt
@@ -1,0 +1,64 @@
+;;; TOOL: run-interp-spec
+;;; NOTE: ref: issue-2526
+;; A global initializer may reference a defined (non-imported) immutable
+;; global, and elem/data segment offsets may use one as well.
+;; ref: WebAssembly/spec#2004, WebAssembly/testsuite#140
+
+;; elem offset referencing a defined immutable global
+(module
+  (global i32 (i32.const 0))
+  (table 1 funcref)
+  (func $f (export "f"))
+  (elem (global.get 0) $f)
+)
+(assert_return (invoke "f"))
+
+(module
+  (global $g i32 (i32.const 0))
+  (table 1 funcref)
+  (func $f (export "f"))
+  (elem (global.get $g) $f)
+)
+
+;; data offset referencing a defined immutable global
+(module (memory 1) (global i32 (i32.const 0)) (data (global.get 0) "a"))
+(module (memory 1) (global $g i32 (i32.const 0)) (data (global.get $g) "a"))
+
+;; global initializer referencing a defined immutable global
+(module (global i32 (i32.const 0)) (global i32 (global.get 0)))
+(module (global $g i32 (i32.const 0)) (global i32 (global.get $g)))
+(module
+  (global i32 (i32.const 0))
+  (global $x i32 (global.get 0))
+  (func (export "get") (result i32) (global.get $x))
+)
+(assert_return (invoke "get") (i32.const 0))
+
+;; still rejected: self/forward references and mutable globals
+(assert_invalid
+  (module (global i32 (global.get 0)))
+  "global variable out of range")
+(assert_invalid
+  (module (global i32 (global.get 1)) (global i32 (i32.const 0)))
+  "global variable out of range")
+(assert_invalid
+  (module (global (mut i32) (i32.const 0)) (global i32 (global.get 0)))
+  "initializer expression cannot reference a mutable global")
+(assert_invalid
+  (module (table 1 funcref) (global i64 (i64.const 0)) (elem (global.get 0)))
+  "type mismatch")
+(;; STDOUT ;;;
+out/test/regress/issue-2526.txt:39: assert_invalid passed:
+  out/test/regress/issue-2526/issue-2526.7.wasm:000000f: error: global variable out of range: 0 (max 0)
+  000000f: error: OnGlobalGetExpr callback failed
+out/test/regress/issue-2526.txt:42: assert_invalid passed:
+  out/test/regress/issue-2526/issue-2526.8.wasm:000000f: error: global variable out of range: 1 (max 0)
+  000000f: error: OnGlobalGetExpr callback failed
+out/test/regress/issue-2526.txt:45: assert_invalid passed:
+  out/test/regress/issue-2526/issue-2526.9.wasm:0000014: error: initializer expression cannot reference a mutable global
+  0000014: error: OnGlobalGetExpr callback failed
+out/test/regress/issue-2526.txt:48: assert_invalid passed:
+  out/test/regress/issue-2526/issue-2526.10.wasm:000001c: error: type mismatch in initializer expression, expected [i32] but got [i64]
+  000001d: error: EndElemSegmentInitExpr callback failed
+13/13 tests passed.
+;;; STDOUT ;;)

--- a/test/regress/issue-2526.txt
+++ b/test/regress/issue-2526.txt
@@ -8,21 +8,43 @@
 (module
   (global i32 (i32.const 0))
   (table 1 funcref)
-  (func $f (export "f"))
+  (type $t (func (result i32)))
+  (func $f (type $t) (result i32) (i32.const 42))
   (elem (global.get 0) $f)
+  (func (export "main") (result i32)
+    (call_indirect (type $t) (i32.const 0)))
 )
-(assert_return (invoke "f"))
+(assert_return (invoke "main") (i32.const 42))
 
 (module
   (global $g i32 (i32.const 0))
   (table 1 funcref)
-  (func $f (export "f"))
+  (type $t (func (result i32)))
+  (func $f (type $t) (result i32) (i32.const 42))
   (elem (global.get $g) $f)
+  (func (export "main") (result i32)
+    (call_indirect (type $t) (i32.const 0)))
 )
+(assert_return (invoke "main") (i32.const 42))
 
 ;; data offset referencing a defined immutable global
-(module (memory 1) (global i32 (i32.const 0)) (data (global.get 0) "a"))
-(module (memory 1) (global $g i32 (i32.const 0)) (data (global.get $g) "a"))
+(module
+  (memory 1)
+  (global i32 (i32.const 0))
+  (data (global.get 0) "a")
+  (func (export "main") (result i32)
+    (i32.load8_u (global.get 0)))
+)
+(assert_return (invoke "main") (i32.const 97))
+
+(module
+  (memory 1)
+  (global $g i32 (i32.const 0))
+  (data (global.get $g) "a")
+  (func (export "main") (result i32)
+    (i32.load8_u (global.get $g)))
+)
+(assert_return (invoke "main") (i32.const 97))
 
 ;; global initializer referencing a defined immutable global
 (module (global i32 (i32.const 0)) (global i32 (global.get 0)))
@@ -31,6 +53,15 @@
   (global i32 (i32.const 0))
   (global $x i32 (global.get 0))
   (func (export "get") (result i32) (global.get $x))
+)
+(assert_return (invoke "get") (i32.const 0))
+
+;; global chaining: $a visible to $b, $b visible to $c
+(module
+  (global $a i32 (i32.const 0))
+  (global $b i32 (global.get $a))
+  (global $c i32 (global.get $b))
+  (func (export "get") (result i32) (global.get $c))
 )
 (assert_return (invoke "get") (i32.const 0))
 
@@ -48,17 +79,17 @@
   (module (table 1 funcref) (global i64 (i64.const 0)) (elem (global.get 0)))
   "type mismatch")
 (;; STDOUT ;;;
-out/test/regress/issue-2526.txt:39: assert_invalid passed:
-  out/test/regress/issue-2526/issue-2526.7.wasm:000000f: error: global variable out of range: 0 (max 0)
+out/test/regress/issue-2526.txt:70: assert_invalid passed:
+  out/test/regress/issue-2526/issue-2526.8.wasm:000000f: error: global variable out of range: 0 (max 0)
   000000f: error: OnGlobalGetExpr callback failed
-out/test/regress/issue-2526.txt:42: assert_invalid passed:
-  out/test/regress/issue-2526/issue-2526.8.wasm:000000f: error: global variable out of range: 1 (max 0)
+out/test/regress/issue-2526.txt:73: assert_invalid passed:
+  out/test/regress/issue-2526/issue-2526.9.wasm:000000f: error: global variable out of range: 1 (max 0)
   000000f: error: OnGlobalGetExpr callback failed
-out/test/regress/issue-2526.txt:45: assert_invalid passed:
-  out/test/regress/issue-2526/issue-2526.9.wasm:0000014: error: initializer expression cannot reference a mutable global
+out/test/regress/issue-2526.txt:76: assert_invalid passed:
+  out/test/regress/issue-2526/issue-2526.10.wasm:0000014: error: initializer expression cannot reference a mutable global
   0000014: error: OnGlobalGetExpr callback failed
-out/test/regress/issue-2526.txt:48: assert_invalid passed:
-  out/test/regress/issue-2526/issue-2526.10.wasm:000001c: error: type mismatch in initializer expression, expected [i32] but got [i64]
+out/test/regress/issue-2526.txt:79: assert_invalid passed:
+  out/test/regress/issue-2526/issue-2526.11.wasm:000001c: error: type mismatch in initializer expression, expected [i32] but got [i64]
   000001d: error: EndElemSegmentInitExpr callback failed
-13/13 tests passed.
+18/18 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/data.txt
+++ b/test/spec/data.txt
@@ -1,70 +1,64 @@
 ;;; TOOL: run-interp-spec
-;;; STDIN_FILE: third_party/testsuite/data.wast
+;;; STDIN_FILE: test/old-spec/data.wast
 (;; STDOUT ;;;
-out/test/spec/data.wast:85: assert_invalid passed:
-  out/test/spec/data/data.9.wasm:000001b: error: initializer expression can only reference an imported global
-  000001b: error: OnGlobalGetExpr callback failed
-out/test/spec/data.wast:89: assert_invalid passed:
-  out/test/spec/data/data.10.wasm:000001b: error: initializer expression can only reference an imported global
-  000001b: error: OnGlobalGetExpr callback failed
-out/test/spec/data.wast:299: assert_invalid passed:
+out/test/spec/data.wast:296: assert_invalid passed:
   out/test/spec/data/data.41.wasm:000000c: error: memory variable out of range: 0 (max 0)
   000000c: error: BeginDataSegment callback failed
-out/test/spec/data.wast:307: assert_invalid passed:
+out/test/spec/data.wast:304: assert_invalid passed:
   out/test/spec/data/data.42.wasm:0000012: error: memory variable out of range: 1 (max 1)
   0000012: error: BeginDataSegment callback failed
-out/test/spec/data.wast:320: assert_invalid passed:
+out/test/spec/data.wast:317: assert_invalid passed:
   out/test/spec/data/data.43.wasm:000000c: error: memory variable out of range: 0 (max 0)
   000000c: error: BeginDataSegment callback failed
-out/test/spec/data.wast:331: assert_invalid passed:
+out/test/spec/data.wast:328: assert_invalid passed:
   out/test/spec/data/data.44.wasm:000000d: error: memory variable out of range: 1 (max 0)
   000000d: error: BeginDataSegment callback failed
-out/test/spec/data.wast:343: assert_invalid passed:
+out/test/spec/data.wast:340: assert_invalid passed:
   out/test/spec/data/data.45.wasm:0000012: error: memory variable out of range: 1 (max 1)
   0000012: error: BeginDataSegment callback failed
-out/test/spec/data.wast:365: assert_invalid passed:
+out/test/spec/data.wast:362: assert_invalid passed:
   out/test/spec/data/data.46.wasm:000000d: error: memory variable out of range: 1 (max 0)
   000000d: error: BeginDataSegment callback failed
-out/test/spec/data.wast:384: assert_invalid passed:
+out/test/spec/data.wast:381: assert_invalid passed:
   out/test/spec/data/data.47.wasm:0000013: error: type mismatch in initializer expression, expected [i32] but got [i64]
   0000014: error: EndDataSegmentInitExpr callback failed
-out/test/spec/data.wast:392: assert_invalid passed:
+out/test/spec/data.wast:389: assert_invalid passed:
   out/test/spec/data/data.48.wasm:0000013: error: type mismatch in initializer expression, expected [i32] but got [funcref]
   0000014: error: EndDataSegmentInitExpr callback failed
-out/test/spec/data.wast:400: assert_invalid passed:
+out/test/spec/data.wast:397: assert_invalid passed:
   out/test/spec/data/data.49.wasm:0000011: error: type mismatch in initializer expression, expected [i32] but got []
   0000012: error: EndDataSegmentInitExpr callback failed
-out/test/spec/data.wast:408: assert_invalid passed:
+out/test/spec/data.wast:405: assert_invalid passed:
   out/test/spec/data/data.50.wasm:0000015: error: type mismatch at end of initializer expression, expected [] but got [i32]
   0000016: error: EndDataSegmentInitExpr callback failed
-out/test/spec/data.wast:416: assert_invalid passed:
+out/test/spec/data.wast:413: assert_invalid passed:
   out/test/spec/data/data.51.wasm:000002b: error: type mismatch at end of initializer expression, expected [] but got [i32]
   000002c: error: EndDataSegmentInitExpr callback failed
-out/test/spec/data.wast:425: assert_invalid passed:
+out/test/spec/data.wast:422: assert_invalid passed:
   out/test/spec/data/data.52.wasm:000002b: error: type mismatch at end of initializer expression, expected [] but got [i32]
   000002c: error: EndDataSegmentInitExpr callback failed
-out/test/spec/data.wast:434: assert_invalid passed:
+out/test/spec/data.wast:431: assert_invalid passed:
   out/test/spec/data/data.53.wasm:0000014: error: invalid initializer: instruction not valid in initializer expression: i32.ctz
   0000014: error: OnUnaryExpr callback failed
-out/test/spec/data.wast:442: assert_invalid passed:
+out/test/spec/data.wast:439: assert_invalid passed:
   out/test/spec/data/data.54.wasm:0000012: error: invalid initializer: instruction not valid in initializer expression: nop
   0000012: error: OnNopExpr callback failed
-out/test/spec/data.wast:450: assert_invalid passed:
+out/test/spec/data.wast:447: assert_invalid passed:
   out/test/spec/data/data.55.wasm:0000012: error: invalid initializer: instruction not valid in initializer expression: nop
   0000012: error: OnNopExpr callback failed
-out/test/spec/data.wast:458: assert_invalid passed:
+out/test/spec/data.wast:455: assert_invalid passed:
   out/test/spec/data/data.56.wasm:0000014: error: invalid initializer: instruction not valid in initializer expression: nop
   0000014: error: OnNopExpr callback failed
-out/test/spec/data.wast:466: assert_invalid passed:
+out/test/spec/data.wast:463: assert_invalid passed:
   out/test/spec/data/data.57.wasm:0000020: error: initializer expression cannot reference a mutable global
   0000020: error: OnGlobalGetExpr callback failed
-out/test/spec/data.wast:475: assert_invalid passed:
+out/test/spec/data.wast:472: assert_invalid passed:
   out/test/spec/data/data.58.wasm:0000013: error: global variable out of range: 0 (max 0)
   0000013: error: OnGlobalGetExpr callback failed
-out/test/spec/data.wast:483: assert_invalid passed:
+out/test/spec/data.wast:480: assert_invalid passed:
   out/test/spec/data/data.59.wasm:0000029: error: global variable out of range: 1 (max 1)
   0000029: error: OnGlobalGetExpr callback failed
-out/test/spec/data.wast:492: assert_invalid passed:
+out/test/spec/data.wast:489: assert_invalid passed:
   out/test/spec/data/data.60.wasm:000002d: error: initializer expression cannot reference a mutable global
   000002d: error: OnGlobalGetExpr callback failed
 61/61 tests passed.

--- a/test/spec/elem.txt
+++ b/test/spec/elem.txt
@@ -1,85 +1,79 @@
 ;;; TOOL: run-interp-spec
-;;; STDIN_FILE: third_party/testsuite/elem.wast
+;;; STDIN_FILE: test/old-spec/elem.wast
 (;; STDOUT ;;;
-out/test/spec/elem.wast:171: assert_invalid passed:
-  out/test/spec/elem/elem.10.wasm:0000026: error: initializer expression can only reference an imported global
-  0000026: error: OnGlobalGetExpr callback failed
-out/test/spec/elem.wast:175: assert_invalid passed:
-  out/test/spec/elem/elem.11.wasm:0000026: error: initializer expression can only reference an imported global
-  0000026: error: OnGlobalGetExpr callback failed
-out/test/spec/elem.wast:350: assert_trap passed: out of bounds table access: table.init out of bounds
-out/test/spec/elem.wast:360: assert_trap passed: out of bounds table access: table.init out of bounds
-out/test/spec/elem.wast:365: assert_invalid passed:
+out/test/spec/elem.wast:353: assert_trap passed: out of bounds table access: table.init out of bounds
+out/test/spec/elem.wast:363: assert_trap passed: out of bounds table access: table.init out of bounds
+out/test/spec/elem.wast:368: assert_invalid passed:
   out/test/spec/elem/elem.36.wasm:0000016: error: table variable out of range: 0 (max 0)
   0000016: error: BeginElemSegment callback failed
-out/test/spec/elem.wast:375: assert_invalid passed:
+out/test/spec/elem.wast:378: assert_invalid passed:
   out/test/spec/elem/elem.37.wasm:0000014: error: type mismatch in initializer expression, expected [i32] but got [i64]
   0000015: error: EndElemSegmentInitExpr callback failed
-out/test/spec/elem.wast:383: assert_invalid passed:
+out/test/spec/elem.wast:386: assert_invalid passed:
   out/test/spec/elem/elem.38.wasm:0000014: error: type mismatch in initializer expression, expected [i32] but got [funcref]
   0000015: error: EndElemSegmentInitExpr callback failed
-out/test/spec/elem.wast:391: assert_invalid passed:
+out/test/spec/elem.wast:394: assert_invalid passed:
   out/test/spec/elem/elem.39.wasm:0000012: error: type mismatch in initializer expression, expected [i32] but got []
   0000013: error: EndElemSegmentInitExpr callback failed
-out/test/spec/elem.wast:399: assert_invalid passed:
+out/test/spec/elem.wast:402: assert_invalid passed:
   out/test/spec/elem/elem.40.wasm:0000016: error: type mismatch at end of initializer expression, expected [] but got [i32]
   0000017: error: EndElemSegmentInitExpr callback failed
-out/test/spec/elem.wast:407: assert_invalid passed:
+out/test/spec/elem.wast:410: assert_invalid passed:
   out/test/spec/elem/elem.41.wasm:000002c: error: type mismatch at end of initializer expression, expected [] but got [i32]
   000002d: error: EndElemSegmentInitExpr callback failed
-out/test/spec/elem.wast:416: assert_invalid passed:
+out/test/spec/elem.wast:419: assert_invalid passed:
   out/test/spec/elem/elem.42.wasm:000002c: error: type mismatch at end of initializer expression, expected [] but got [i32]
   000002d: error: EndElemSegmentInitExpr callback failed
-out/test/spec/elem.wast:426: assert_invalid passed:
+out/test/spec/elem.wast:429: assert_invalid passed:
   out/test/spec/elem/elem.43.wasm:0000015: error: invalid initializer: instruction not valid in initializer expression: i32.ctz
   0000015: error: OnUnaryExpr callback failed
-out/test/spec/elem.wast:434: assert_invalid passed:
+out/test/spec/elem.wast:437: assert_invalid passed:
   out/test/spec/elem/elem.44.wasm:0000013: error: invalid initializer: instruction not valid in initializer expression: nop
   0000013: error: OnNopExpr callback failed
-out/test/spec/elem.wast:442: assert_invalid passed:
+out/test/spec/elem.wast:445: assert_invalid passed:
   out/test/spec/elem/elem.45.wasm:0000013: error: invalid initializer: instruction not valid in initializer expression: nop
   0000013: error: OnNopExpr callback failed
-out/test/spec/elem.wast:450: assert_invalid passed:
+out/test/spec/elem.wast:453: assert_invalid passed:
   out/test/spec/elem/elem.46.wasm:0000015: error: invalid initializer: instruction not valid in initializer expression: nop
   0000015: error: OnNopExpr callback failed
-out/test/spec/elem.wast:458: assert_invalid passed:
+out/test/spec/elem.wast:461: assert_invalid passed:
   out/test/spec/elem/elem.47.wasm:0000021: error: initializer expression cannot reference a mutable global
   0000021: error: OnGlobalGetExpr callback failed
-out/test/spec/elem.wast:467: assert_invalid passed:
+out/test/spec/elem.wast:470: assert_invalid passed:
   out/test/spec/elem/elem.48.wasm:0000014: error: global variable out of range: 0 (max 0)
   0000014: error: OnGlobalGetExpr callback failed
-out/test/spec/elem.wast:475: assert_invalid passed:
+out/test/spec/elem.wast:478: assert_invalid passed:
   out/test/spec/elem/elem.49.wasm:000002a: error: global variable out of range: 1 (max 1)
   000002a: error: OnGlobalGetExpr callback failed
-out/test/spec/elem.wast:484: assert_invalid passed:
+out/test/spec/elem.wast:487: assert_invalid passed:
   out/test/spec/elem/elem.50.wasm:000002e: error: initializer expression cannot reference a mutable global
   000002e: error: OnGlobalGetExpr callback failed
-out/test/spec/elem.wast:495: assert_invalid passed:
+out/test/spec/elem.wast:498: assert_invalid passed:
   out/test/spec/elem/elem.51.wasm:0000018: error: type mismatch in initializer expression, expected [funcref] but got [externref]
   0000019: error: EndElemExpr callback failed
-out/test/spec/elem.wast:503: assert_invalid passed:
+out/test/spec/elem.wast:506: assert_invalid passed:
   out/test/spec/elem/elem.52.wasm:000001a: error: type mismatch at end of initializer expression, expected [] but got [funcref]
   000001b: error: EndElemExpr callback failed
-out/test/spec/elem.wast:511: assert_invalid passed:
+out/test/spec/elem.wast:514: assert_invalid passed:
   out/test/spec/elem/elem.53.wasm:0000018: error: type mismatch in initializer expression, expected [funcref] but got [i32]
   0000019: error: EndElemExpr callback failed
-out/test/spec/elem.wast:519: assert_invalid passed:
+out/test/spec/elem.wast:522: assert_invalid passed:
   out/test/spec/elem/elem.54.wasm:0000018: error: type mismatch in initializer expression, expected [funcref] but got [i32]
   0000019: error: EndElemExpr callback failed
-out/test/spec/elem.wast:527: assert_invalid passed:
+out/test/spec/elem.wast:530: assert_invalid passed:
   out/test/spec/elem/elem.55.wasm:0000023: error: invalid initializer: instruction not valid in initializer expression: call
   0000023: error: OnCallExpr callback failed
-out/test/spec/elem.wast:585: assert_trap passed: uninitialized table element
-out/test/spec/elem.wast:618: assert_invalid passed:
+out/test/spec/elem.wast:588: assert_trap passed: uninitialized table element
+out/test/spec/elem.wast:621: assert_invalid passed:
   out/test/spec/elem/elem.61.wasm:000001f: error: type mismatch at elem segment. got funcref, expected externref
   000001f: error: OnElemSegmentElemType callback failed
-out/test/spec/elem.wast:623: assert_invalid passed:
+out/test/spec/elem.wast:626: assert_invalid passed:
   out/test/spec/elem/elem.62.wasm:0000017: error: type mismatch at elem segment. got externref, expected funcref
   0000017: error: OnElemSegmentElemType callback failed
-out/test/spec/elem.wast:628: assert_invalid passed:
+out/test/spec/elem.wast:631: assert_invalid passed:
   out/test/spec/elem/elem.63.wasm:0000032: error: type mismatch at table.init. got funcref, expected externref
   0000032: error: OnTableInitExpr callback failed
-out/test/spec/elem.wast:637: assert_invalid passed:
+out/test/spec/elem.wast:640: assert_invalid passed:
   out/test/spec/elem/elem.64.wasm:0000030: error: type mismatch at table.init. got externref, expected funcref
   0000030: error: OnTableInitExpr callback failed
 95/95 tests passed.

--- a/test/spec/extended-const/data.txt
+++ b/test/spec/extended-const/data.txt
@@ -1,71 +1,65 @@
 ;;; TOOL: run-interp-spec
-;;; STDIN_FILE: third_party/testsuite/proposals/extended-const/data.wast
+;;; STDIN_FILE: test/old-spec/proposals/extended-const/data.wast
 ;;; ARGS*: --enable-extended-const
 (;; STDOUT ;;;
-out/test/spec/extended-const/data.wast:85: assert_invalid passed:
-  out/test/spec/extended-const/data/data.9.wasm:000001b: error: initializer expression can only reference an imported global
-  000001b: error: OnGlobalGetExpr callback failed
-out/test/spec/extended-const/data.wast:89: assert_invalid passed:
-  out/test/spec/extended-const/data/data.10.wasm:000001b: error: initializer expression can only reference an imported global
-  000001b: error: OnGlobalGetExpr callback failed
-out/test/spec/extended-const/data.wast:331: assert_invalid passed:
+out/test/spec/extended-const/data.wast:328: assert_invalid passed:
   out/test/spec/extended-const/data/data.45.wasm:000000c: error: memory variable out of range: 0 (max 0)
   000000c: error: BeginDataSegment callback failed
-out/test/spec/extended-const/data.wast:339: assert_invalid passed:
+out/test/spec/extended-const/data.wast:336: assert_invalid passed:
   out/test/spec/extended-const/data/data.46.wasm:0000012: error: memory variable out of range: 1 (max 1)
   0000012: error: BeginDataSegment callback failed
-out/test/spec/extended-const/data.wast:352: assert_invalid passed:
+out/test/spec/extended-const/data.wast:349: assert_invalid passed:
   out/test/spec/extended-const/data/data.47.wasm:000000c: error: memory variable out of range: 0 (max 0)
   000000c: error: BeginDataSegment callback failed
-out/test/spec/extended-const/data.wast:363: assert_invalid passed:
+out/test/spec/extended-const/data.wast:360: assert_invalid passed:
   out/test/spec/extended-const/data/data.48.wasm:000000d: error: memory variable out of range: 1 (max 0)
   000000d: error: BeginDataSegment callback failed
-out/test/spec/extended-const/data.wast:375: assert_invalid passed:
+out/test/spec/extended-const/data.wast:372: assert_invalid passed:
   out/test/spec/extended-const/data/data.49.wasm:0000012: error: memory variable out of range: 1 (max 1)
   0000012: error: BeginDataSegment callback failed
-out/test/spec/extended-const/data.wast:397: assert_invalid passed:
+out/test/spec/extended-const/data.wast:394: assert_invalid passed:
   out/test/spec/extended-const/data/data.50.wasm:000000d: error: memory variable out of range: 1 (max 0)
   000000d: error: BeginDataSegment callback failed
-out/test/spec/extended-const/data.wast:416: assert_invalid passed:
+out/test/spec/extended-const/data.wast:413: assert_invalid passed:
   out/test/spec/extended-const/data/data.51.wasm:0000013: error: type mismatch in initializer expression, expected [i32] but got [i64]
   0000014: error: EndDataSegmentInitExpr callback failed
-out/test/spec/extended-const/data.wast:424: assert_invalid passed:
+out/test/spec/extended-const/data.wast:421: assert_invalid passed:
   out/test/spec/extended-const/data/data.52.wasm:0000013: error: type mismatch in initializer expression, expected [i32] but got [funcref]
   0000014: error: EndDataSegmentInitExpr callback failed
-out/test/spec/extended-const/data.wast:432: assert_invalid passed:
+out/test/spec/extended-const/data.wast:429: assert_invalid passed:
   out/test/spec/extended-const/data/data.53.wasm:0000011: error: type mismatch in initializer expression, expected [i32] but got []
   0000012: error: EndDataSegmentInitExpr callback failed
-out/test/spec/extended-const/data.wast:440: assert_invalid passed:
+out/test/spec/extended-const/data.wast:437: assert_invalid passed:
   out/test/spec/extended-const/data/data.54.wasm:0000015: error: type mismatch at end of initializer expression, expected [] but got [i32]
   0000016: error: EndDataSegmentInitExpr callback failed
-out/test/spec/extended-const/data.wast:448: assert_invalid passed:
+out/test/spec/extended-const/data.wast:445: assert_invalid passed:
   out/test/spec/extended-const/data/data.55.wasm:000002b: error: type mismatch at end of initializer expression, expected [] but got [i32]
   000002c: error: EndDataSegmentInitExpr callback failed
-out/test/spec/extended-const/data.wast:457: assert_invalid passed:
+out/test/spec/extended-const/data.wast:454: assert_invalid passed:
   out/test/spec/extended-const/data/data.56.wasm:000002b: error: type mismatch at end of initializer expression, expected [] but got [i32]
   000002c: error: EndDataSegmentInitExpr callback failed
-out/test/spec/extended-const/data.wast:466: assert_invalid passed:
+out/test/spec/extended-const/data.wast:463: assert_invalid passed:
   out/test/spec/extended-const/data/data.57.wasm:0000014: error: invalid initializer: instruction not valid in initializer expression: i32.ctz
   0000014: error: OnUnaryExpr callback failed
-out/test/spec/extended-const/data.wast:474: assert_invalid passed:
+out/test/spec/extended-const/data.wast:471: assert_invalid passed:
   out/test/spec/extended-const/data/data.58.wasm:0000012: error: invalid initializer: instruction not valid in initializer expression: nop
   0000012: error: OnNopExpr callback failed
-out/test/spec/extended-const/data.wast:482: assert_invalid passed:
+out/test/spec/extended-const/data.wast:479: assert_invalid passed:
   out/test/spec/extended-const/data/data.59.wasm:0000012: error: invalid initializer: instruction not valid in initializer expression: nop
   0000012: error: OnNopExpr callback failed
-out/test/spec/extended-const/data.wast:490: assert_invalid passed:
+out/test/spec/extended-const/data.wast:487: assert_invalid passed:
   out/test/spec/extended-const/data/data.60.wasm:0000014: error: invalid initializer: instruction not valid in initializer expression: nop
   0000014: error: OnNopExpr callback failed
-out/test/spec/extended-const/data.wast:498: assert_invalid passed:
+out/test/spec/extended-const/data.wast:495: assert_invalid passed:
   out/test/spec/extended-const/data/data.61.wasm:0000020: error: initializer expression cannot reference a mutable global
   0000020: error: OnGlobalGetExpr callback failed
-out/test/spec/extended-const/data.wast:507: assert_invalid passed:
+out/test/spec/extended-const/data.wast:504: assert_invalid passed:
   out/test/spec/extended-const/data/data.62.wasm:0000013: error: global variable out of range: 0 (max 0)
   0000013: error: OnGlobalGetExpr callback failed
-out/test/spec/extended-const/data.wast:515: assert_invalid passed:
+out/test/spec/extended-const/data.wast:512: assert_invalid passed:
   out/test/spec/extended-const/data/data.63.wasm:0000029: error: global variable out of range: 1 (max 1)
   0000029: error: OnGlobalGetExpr callback failed
-out/test/spec/extended-const/data.wast:524: assert_invalid passed:
+out/test/spec/extended-const/data.wast:521: assert_invalid passed:
   out/test/spec/extended-const/data/data.64.wasm:000002d: error: initializer expression cannot reference a mutable global
   000002d: error: OnGlobalGetExpr callback failed
 65/65 tests passed.

--- a/test/spec/extended-const/elem.txt
+++ b/test/spec/extended-const/elem.txt
@@ -1,94 +1,88 @@
 ;;; TOOL: run-interp-spec
-;;; STDIN_FILE: third_party/testsuite/proposals/extended-const/elem.wast
+;;; STDIN_FILE: test/old-spec/proposals/extended-const/elem.wast
 ;;; ARGS*: --enable-extended-const
 (;; STDOUT ;;;
-out/test/spec/extended-const/elem.wast:171: assert_invalid passed:
-  out/test/spec/extended-const/elem/elem.10.wasm:0000026: error: initializer expression can only reference an imported global
-  0000026: error: OnGlobalGetExpr callback failed
-out/test/spec/extended-const/elem.wast:175: assert_invalid passed:
-  out/test/spec/extended-const/elem/elem.11.wasm:0000026: error: initializer expression can only reference an imported global
-  0000026: error: OnGlobalGetExpr callback failed
-out/test/spec/extended-const/elem.wast:350: assert_trap passed: out of bounds table access: table.init out of bounds
-out/test/spec/extended-const/elem.wast:360: assert_trap passed: out of bounds table access: table.init out of bounds
-out/test/spec/extended-const/elem.wast:365: assert_invalid passed:
+out/test/spec/extended-const/elem.wast:353: assert_trap passed: out of bounds table access: table.init out of bounds
+out/test/spec/extended-const/elem.wast:363: assert_trap passed: out of bounds table access: table.init out of bounds
+out/test/spec/extended-const/elem.wast:368: assert_invalid passed:
   out/test/spec/extended-const/elem/elem.36.wasm:0000016: error: table variable out of range: 0 (max 0)
   0000016: error: BeginElemSegment callback failed
-out/test/spec/extended-const/elem.wast:375: assert_invalid passed:
+out/test/spec/extended-const/elem.wast:378: assert_invalid passed:
   out/test/spec/extended-const/elem/elem.37.wasm:0000014: error: type mismatch in initializer expression, expected [i32] but got [i64]
   0000015: error: EndElemSegmentInitExpr callback failed
-out/test/spec/extended-const/elem.wast:383: assert_invalid passed:
+out/test/spec/extended-const/elem.wast:386: assert_invalid passed:
   out/test/spec/extended-const/elem/elem.38.wasm:0000014: error: type mismatch in initializer expression, expected [i32] but got [funcref]
   0000015: error: EndElemSegmentInitExpr callback failed
-out/test/spec/extended-const/elem.wast:391: assert_invalid passed:
+out/test/spec/extended-const/elem.wast:394: assert_invalid passed:
   out/test/spec/extended-const/elem/elem.39.wasm:0000012: error: type mismatch in initializer expression, expected [i32] but got []
   0000013: error: EndElemSegmentInitExpr callback failed
-out/test/spec/extended-const/elem.wast:399: assert_invalid passed:
+out/test/spec/extended-const/elem.wast:402: assert_invalid passed:
   out/test/spec/extended-const/elem/elem.40.wasm:0000016: error: type mismatch at end of initializer expression, expected [] but got [i32]
   0000017: error: EndElemSegmentInitExpr callback failed
-out/test/spec/extended-const/elem.wast:407: assert_invalid passed:
+out/test/spec/extended-const/elem.wast:410: assert_invalid passed:
   out/test/spec/extended-const/elem/elem.41.wasm:000002c: error: type mismatch at end of initializer expression, expected [] but got [i32]
   000002d: error: EndElemSegmentInitExpr callback failed
-out/test/spec/extended-const/elem.wast:416: assert_invalid passed:
+out/test/spec/extended-const/elem.wast:419: assert_invalid passed:
   out/test/spec/extended-const/elem/elem.42.wasm:000002c: error: type mismatch at end of initializer expression, expected [] but got [i32]
   000002d: error: EndElemSegmentInitExpr callback failed
-out/test/spec/extended-const/elem.wast:426: assert_invalid passed:
+out/test/spec/extended-const/elem.wast:429: assert_invalid passed:
   out/test/spec/extended-const/elem/elem.43.wasm:0000015: error: invalid initializer: instruction not valid in initializer expression: i32.ctz
   0000015: error: OnUnaryExpr callback failed
-out/test/spec/extended-const/elem.wast:434: assert_invalid passed:
+out/test/spec/extended-const/elem.wast:437: assert_invalid passed:
   out/test/spec/extended-const/elem/elem.44.wasm:0000013: error: invalid initializer: instruction not valid in initializer expression: nop
   0000013: error: OnNopExpr callback failed
-out/test/spec/extended-const/elem.wast:442: assert_invalid passed:
+out/test/spec/extended-const/elem.wast:445: assert_invalid passed:
   out/test/spec/extended-const/elem/elem.45.wasm:0000013: error: invalid initializer: instruction not valid in initializer expression: nop
   0000013: error: OnNopExpr callback failed
-out/test/spec/extended-const/elem.wast:450: assert_invalid passed:
+out/test/spec/extended-const/elem.wast:453: assert_invalid passed:
   out/test/spec/extended-const/elem/elem.46.wasm:0000015: error: invalid initializer: instruction not valid in initializer expression: nop
   0000015: error: OnNopExpr callback failed
-out/test/spec/extended-const/elem.wast:458: assert_invalid passed:
+out/test/spec/extended-const/elem.wast:461: assert_invalid passed:
   out/test/spec/extended-const/elem/elem.47.wasm:0000021: error: initializer expression cannot reference a mutable global
   0000021: error: OnGlobalGetExpr callback failed
-out/test/spec/extended-const/elem.wast:467: assert_invalid passed:
+out/test/spec/extended-const/elem.wast:470: assert_invalid passed:
   out/test/spec/extended-const/elem/elem.48.wasm:0000014: error: global variable out of range: 0 (max 0)
   0000014: error: OnGlobalGetExpr callback failed
-out/test/spec/extended-const/elem.wast:475: assert_invalid passed:
+out/test/spec/extended-const/elem.wast:478: assert_invalid passed:
   out/test/spec/extended-const/elem/elem.49.wasm:000002a: error: global variable out of range: 1 (max 1)
   000002a: error: OnGlobalGetExpr callback failed
-out/test/spec/extended-const/elem.wast:484: assert_invalid passed:
+out/test/spec/extended-const/elem.wast:487: assert_invalid passed:
   out/test/spec/extended-const/elem/elem.50.wasm:000002e: error: initializer expression cannot reference a mutable global
   000002e: error: OnGlobalGetExpr callback failed
-out/test/spec/extended-const/elem.wast:495: assert_invalid passed:
+out/test/spec/extended-const/elem.wast:498: assert_invalid passed:
   out/test/spec/extended-const/elem/elem.51.wasm:0000018: error: type mismatch in initializer expression, expected [funcref] but got [externref]
   0000019: error: EndElemExpr callback failed
-out/test/spec/extended-const/elem.wast:503: assert_invalid passed:
+out/test/spec/extended-const/elem.wast:506: assert_invalid passed:
   out/test/spec/extended-const/elem/elem.52.wasm:000001a: error: type mismatch at end of initializer expression, expected [] but got [funcref]
   000001b: error: EndElemExpr callback failed
-out/test/spec/extended-const/elem.wast:511: assert_invalid passed:
+out/test/spec/extended-const/elem.wast:514: assert_invalid passed:
   out/test/spec/extended-const/elem/elem.53.wasm:0000018: error: type mismatch in initializer expression, expected [funcref] but got [i32]
   0000019: error: EndElemExpr callback failed
-out/test/spec/extended-const/elem.wast:519: assert_invalid passed:
+out/test/spec/extended-const/elem.wast:522: assert_invalid passed:
   out/test/spec/extended-const/elem/elem.54.wasm:0000018: error: type mismatch in initializer expression, expected [funcref] but got [i32]
   0000019: error: EndElemExpr callback failed
-out/test/spec/extended-const/elem.wast:527: assert_invalid passed:
+out/test/spec/extended-const/elem.wast:530: assert_invalid passed:
   out/test/spec/extended-const/elem/elem.55.wasm:0000023: error: invalid initializer: instruction not valid in initializer expression: call
   0000023: error: OnCallExpr callback failed
-out/test/spec/extended-const/elem.wast:536: assert_invalid passed:
+out/test/spec/extended-const/elem.wast:539: assert_invalid passed:
   out/test/spec/extended-const/elem/elem.56.wasm:0000023: error: invalid initializer: instruction not valid in initializer expression: call
   0000023: error: OnCallExpr callback failed
-out/test/spec/extended-const/elem.wast:594: assert_trap passed: uninitialized table element
-out/test/spec/extended-const/elem.wast:627: assert_invalid passed:
+out/test/spec/extended-const/elem.wast:597: assert_trap passed: uninitialized table element
+out/test/spec/extended-const/elem.wast:630: assert_invalid passed:
   out/test/spec/extended-const/elem/elem.62.wasm:000001f: error: type mismatch at elem segment. got funcref, expected externref
   000001f: error: OnElemSegmentElemType callback failed
-out/test/spec/extended-const/elem.wast:632: assert_invalid passed:
+out/test/spec/extended-const/elem.wast:635: assert_invalid passed:
   out/test/spec/extended-const/elem/elem.63.wasm:0000017: error: type mismatch at elem segment. got externref, expected funcref
   0000017: error: OnElemSegmentElemType callback failed
-out/test/spec/extended-const/elem.wast:637: assert_invalid passed:
+out/test/spec/extended-const/elem.wast:640: assert_invalid passed:
   out/test/spec/extended-const/elem/elem.64.wasm:0000032: error: type mismatch at table.init. got funcref, expected externref
   0000032: error: OnTableInitExpr callback failed
-out/test/spec/extended-const/elem.wast:646: assert_invalid passed:
+out/test/spec/extended-const/elem.wast:649: assert_invalid passed:
   out/test/spec/extended-const/elem/elem.65.wasm:0000030: error: type mismatch at table.init. got externref, expected funcref
   0000030: error: OnTableInitExpr callback failed
-out/test/spec/extended-const/elem.wast:714: assert_trap passed: uninitialized table element
-out/test/spec/extended-const/elem.wast:725: assert_trap passed: uninitialized table element
-out/test/spec/extended-const/elem.wast:736: assert_trap passed: uninitialized table element
-out/test/spec/extended-const/elem.wast:758: assert_trap passed: uninitialized table element
+out/test/spec/extended-const/elem.wast:717: assert_trap passed: uninitialized table element
+out/test/spec/extended-const/elem.wast:728: assert_trap passed: uninitialized table element
+out/test/spec/extended-const/elem.wast:739: assert_trap passed: uninitialized table element
+out/test/spec/extended-const/elem.wast:761: assert_trap passed: uninitialized table element
 108/108 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/extended-const/global.txt
+++ b/test/spec/extended-const/global.txt
@@ -1,145 +1,139 @@
 ;;; TOOL: run-interp-spec
-;;; STDIN_FILE: third_party/testsuite/proposals/extended-const/global.wast
+;;; STDIN_FILE: test/old-spec/proposals/extended-const/global.wast
 ;;; ARGS*: --enable-extended-const
 (;; STDOUT ;;;
-out/test/spec/extended-const/global.wast:263: assert_trap passed: undefined table index
-out/test/spec/extended-const/global.wast:285: assert_invalid passed:
+out/test/spec/extended-const/global.wast:266: assert_trap passed: undefined table index
+out/test/spec/extended-const/global.wast:288: assert_invalid passed:
   out/test/spec/extended-const/global/global.1.wasm:0000029: error: can't global.set on immutable global at index 0.
   0000029: error: OnGlobalSetExpr callback failed
-out/test/spec/extended-const/global.wast:290: assert_invalid passed:
+out/test/spec/extended-const/global.wast:293: assert_invalid passed:
   out/test/spec/extended-const/global/global.2.wasm:0000035: error: can't global.set on immutable global at index 0.
   0000035: error: OnGlobalSetExpr callback failed
-out/test/spec/extended-const/global.wast:299: assert_invalid passed:
+out/test/spec/extended-const/global.wast:302: assert_invalid passed:
   out/test/spec/extended-const/global/global.5.wasm:0000013: error: invalid initializer: instruction not valid in initializer expression: f32.neg
   0000013: error: OnUnaryExpr callback failed
-out/test/spec/extended-const/global.wast:304: assert_invalid passed:
+out/test/spec/extended-const/global.wast:307: assert_invalid passed:
   out/test/spec/extended-const/global/global.6.wasm:000000f: error: invalid initializer: instruction not valid in initializer expression: local.get
   000000f: error: OnLocalGetExpr callback failed
-out/test/spec/extended-const/global.wast:309: assert_invalid passed:
+out/test/spec/extended-const/global.wast:312: assert_invalid passed:
   out/test/spec/extended-const/global/global.7.wasm:0000013: error: invalid initializer: instruction not valid in initializer expression: f32.neg
   0000013: error: OnUnaryExpr callback failed
-out/test/spec/extended-const/global.wast:314: assert_invalid passed:
+out/test/spec/extended-const/global.wast:317: assert_invalid passed:
   out/test/spec/extended-const/global/global.8.wasm:0000010: error: invalid initializer: instruction not valid in initializer expression: nop
   0000010: error: OnNopExpr callback failed
-out/test/spec/extended-const/global.wast:319: assert_invalid passed:
+out/test/spec/extended-const/global.wast:322: assert_invalid passed:
   out/test/spec/extended-const/global/global.9.wasm:0000010: error: invalid initializer: instruction not valid in initializer expression: i32.ctz
   0000010: error: OnUnaryExpr callback failed
-out/test/spec/extended-const/global.wast:324: assert_invalid passed:
+out/test/spec/extended-const/global.wast:327: assert_invalid passed:
   out/test/spec/extended-const/global/global.10.wasm:000000e: error: invalid initializer: instruction not valid in initializer expression: nop
   000000e: error: OnNopExpr callback failed
-out/test/spec/extended-const/global.wast:329: assert_invalid passed:
+out/test/spec/extended-const/global.wast:332: assert_invalid passed:
   out/test/spec/extended-const/global/global.11.wasm:0000012: error: type mismatch in initializer expression, expected [i32] but got [f32]
   0000013: error: EndGlobalInitExpr callback failed
-out/test/spec/extended-const/global.wast:334: assert_invalid passed:
+out/test/spec/extended-const/global.wast:337: assert_invalid passed:
   out/test/spec/extended-const/global/global.12.wasm:0000011: error: type mismatch at end of initializer expression, expected [] but got [i32]
   0000012: error: EndGlobalInitExpr callback failed
-out/test/spec/extended-const/global.wast:339: assert_invalid passed:
+out/test/spec/extended-const/global.wast:342: assert_invalid passed:
   out/test/spec/extended-const/global/global.13.wasm:000000d: error: type mismatch in initializer expression, expected [i32] but got []
   000000e: error: EndGlobalInitExpr callback failed
-out/test/spec/extended-const/global.wast:344: assert_invalid passed:
+out/test/spec/extended-const/global.wast:347: assert_invalid passed:
   out/test/spec/extended-const/global/global.14.wasm:0000017: error: type mismatch in initializer expression, expected [funcref] but got [externref]
   0000018: error: EndGlobalInitExpr callback failed
-out/test/spec/extended-const/global.wast:349: assert_invalid passed:
+out/test/spec/extended-const/global.wast:352: assert_invalid passed:
   out/test/spec/extended-const/global/global.15.wasm:0000027: error: type mismatch at end of initializer expression, expected [] but got [i32]
   0000028: error: EndGlobalInitExpr callback failed
-out/test/spec/extended-const/global.wast:354: assert_invalid passed:
+out/test/spec/extended-const/global.wast:357: assert_invalid passed:
   out/test/spec/extended-const/global/global.16.wasm:0000027: error: type mismatch at end of initializer expression, expected [] but got [i32]
   0000028: error: EndGlobalInitExpr callback failed
-out/test/spec/extended-const/global.wast:359: assert_invalid passed:
-  out/test/spec/extended-const/global/global.17.wasm:000000f: error: initializer expression can only reference an imported global
+out/test/spec/extended-const/global.wast:362: assert_invalid passed:
+  out/test/spec/extended-const/global/global.17.wasm:000000f: error: global variable out of range: 0 (max 0)
   000000f: error: OnGlobalGetExpr callback failed
-out/test/spec/extended-const/global.wast:364: assert_invalid passed:
-  out/test/spec/extended-const/global/global.18.wasm:0000014: error: initializer expression can only reference an imported global
-  0000014: error: OnGlobalGetExpr callback failed
-out/test/spec/extended-const/global.wast:368: assert_invalid passed:
-  out/test/spec/extended-const/global/global.19.wasm:0000014: error: initializer expression can only reference an imported global
-  0000014: error: OnGlobalGetExpr callback failed
-out/test/spec/extended-const/global.wast:373: assert_invalid passed:
-  out/test/spec/extended-const/global/global.20.wasm:000000f: error: global variable out of range: 1 (max 1)
+out/test/spec/extended-const/global.wast:367: assert_invalid passed:
+  out/test/spec/extended-const/global/global.18.wasm:000000f: error: global variable out of range: 1 (max 0)
   000000f: error: OnGlobalGetExpr callback failed
-out/test/spec/extended-const/global.wast:378: assert_invalid passed:
-  out/test/spec/extended-const/global/global.21.wasm:0000025: error: global variable out of range: 2 (max 2)
+out/test/spec/extended-const/global.wast:372: assert_invalid passed:
+  out/test/spec/extended-const/global/global.19.wasm:0000025: error: global variable out of range: 2 (max 1)
   0000025: error: OnGlobalGetExpr callback failed
-out/test/spec/extended-const/global.wast:383: assert_invalid passed:
+out/test/spec/extended-const/global.wast:380: assert_invalid passed:
   out/test/spec/extended-const/global/global.22.wasm:0000029: error: initializer expression cannot reference a mutable global
   0000029: error: OnGlobalGetExpr callback failed
-out/test/spec/extended-const/global.wast:391: assert_malformed passed:
+out/test/spec/extended-const/global.wast:388: assert_malformed passed:
   0000026: error: global mutability must be 0 or 1
-out/test/spec/extended-const/global.wast:404: assert_malformed passed:
+out/test/spec/extended-const/global.wast:401: assert_malformed passed:
   0000026: error: global mutability must be 0 or 1
-out/test/spec/extended-const/global.wast:421: assert_malformed passed:
+out/test/spec/extended-const/global.wast:418: assert_malformed passed:
   0000011: error: global mutability must be 0 or 1
-out/test/spec/extended-const/global.wast:433: assert_malformed passed:
+out/test/spec/extended-const/global.wast:430: assert_malformed passed:
   0000011: error: global mutability must be 0 or 1
-out/test/spec/extended-const/global.wast:447: assert_invalid passed:
+out/test/spec/extended-const/global.wast:444: assert_invalid passed:
   out/test/spec/extended-const/global/global.29.wasm:000001a: error: global variable out of range: 0 (max 0)
   000001a: error: OnGlobalGetExpr callback failed
-out/test/spec/extended-const/global.wast:452: assert_invalid passed:
+out/test/spec/extended-const/global.wast:449: assert_invalid passed:
   out/test/spec/extended-const/global/global.30.wasm:0000022: error: global variable out of range: 1 (max 1)
   0000022: error: OnGlobalGetExpr callback failed
-out/test/spec/extended-const/global.wast:460: assert_invalid passed:
+out/test/spec/extended-const/global.wast:457: assert_invalid passed:
   out/test/spec/extended-const/global/global.31.wasm:0000034: error: global variable out of range: 1 (max 1)
   0000034: error: OnGlobalGetExpr callback failed
-out/test/spec/extended-const/global.wast:468: assert_invalid passed:
+out/test/spec/extended-const/global.wast:465: assert_invalid passed:
   out/test/spec/extended-const/global/global.32.wasm:000003c: error: global variable out of range: 2 (max 2)
   000003c: error: OnGlobalGetExpr callback failed
-out/test/spec/extended-const/global.wast:478: assert_invalid passed:
+out/test/spec/extended-const/global.wast:475: assert_invalid passed:
   out/test/spec/extended-const/global/global.33.wasm:000001b: error: global variable out of range: 0 (max 0)
   000001b: error: OnGlobalSetExpr callback failed
-out/test/spec/extended-const/global.wast:483: assert_invalid passed:
+out/test/spec/extended-const/global.wast:480: assert_invalid passed:
   out/test/spec/extended-const/global/global.34.wasm:0000023: error: global variable out of range: 1 (max 1)
   0000023: error: OnGlobalSetExpr callback failed
-out/test/spec/extended-const/global.wast:491: assert_invalid passed:
+out/test/spec/extended-const/global.wast:488: assert_invalid passed:
   out/test/spec/extended-const/global/global.35.wasm:0000035: error: global variable out of range: 1 (max 1)
   0000035: error: OnGlobalSetExpr callback failed
-out/test/spec/extended-const/global.wast:499: assert_invalid passed:
+out/test/spec/extended-const/global.wast:496: assert_invalid passed:
   out/test/spec/extended-const/global/global.36.wasm:000003d: error: global variable out of range: 2 (max 2)
   000003d: error: OnGlobalSetExpr callback failed
-out/test/spec/extended-const/global.wast:509: assert_invalid passed:
+out/test/spec/extended-const/global.wast:506: assert_invalid passed:
   out/test/spec/extended-const/global/global.37.wasm:0000021: error: type mismatch in global.set, expected [i32] but got []
   0000021: error: OnGlobalSetExpr callback failed
-out/test/spec/extended-const/global.wast:518: assert_invalid passed:
+out/test/spec/extended-const/global.wast:515: assert_invalid passed:
   out/test/spec/extended-const/global/global.38.wasm:0000025: error: type mismatch in global.set, expected [i32] but got []
   0000025: error: OnGlobalSetExpr callback failed
-out/test/spec/extended-const/global.wast:528: assert_invalid passed:
+out/test/spec/extended-const/global.wast:525: assert_invalid passed:
   out/test/spec/extended-const/global/global.39.wasm:0000025: error: type mismatch in global.set, expected [i32] but got []
   0000025: error: OnGlobalSetExpr callback failed
-out/test/spec/extended-const/global.wast:538: assert_invalid passed:
+out/test/spec/extended-const/global.wast:535: assert_invalid passed:
   out/test/spec/extended-const/global/global.40.wasm:0000027: error: type mismatch in global.set, expected [i32] but got []
   0000027: error: OnGlobalSetExpr callback failed
-out/test/spec/extended-const/global.wast:548: assert_invalid passed:
+out/test/spec/extended-const/global.wast:545: assert_invalid passed:
   out/test/spec/extended-const/global/global.41.wasm:000002a: error: type mismatch in global.set, expected [i32] but got []
   000002a: error: OnGlobalSetExpr callback failed
-out/test/spec/extended-const/global.wast:558: assert_invalid passed:
+out/test/spec/extended-const/global.wast:555: assert_invalid passed:
   out/test/spec/extended-const/global/global.42.wasm:0000025: error: type mismatch in global.set, expected [i32] but got []
   0000025: error: OnGlobalSetExpr callback failed
-out/test/spec/extended-const/global.wast:568: assert_invalid passed:
+out/test/spec/extended-const/global.wast:565: assert_invalid passed:
   out/test/spec/extended-const/global/global.43.wasm:0000025: error: type mismatch in global.set, expected [i32] but got []
   0000025: error: OnGlobalSetExpr callback failed
-out/test/spec/extended-const/global.wast:578: assert_invalid passed:
+out/test/spec/extended-const/global.wast:575: assert_invalid passed:
   out/test/spec/extended-const/global/global.44.wasm:0000025: error: type mismatch in global.set, expected [i32] but got []
   0000025: error: OnGlobalSetExpr callback failed
-out/test/spec/extended-const/global.wast:588: assert_invalid passed:
+out/test/spec/extended-const/global.wast:585: assert_invalid passed:
   out/test/spec/extended-const/global/global.45.wasm:0000021: error: type mismatch in global.set, expected [i32] but got []
   0000021: error: OnGlobalSetExpr callback failed
-out/test/spec/extended-const/global.wast:597: assert_invalid passed:
+out/test/spec/extended-const/global.wast:594: assert_invalid passed:
   out/test/spec/extended-const/global/global.46.wasm:0000021: error: type mismatch in global.set, expected [i32] but got []
   0000021: error: OnGlobalSetExpr callback failed
-out/test/spec/extended-const/global.wast:606: assert_invalid passed:
+out/test/spec/extended-const/global.wast:603: assert_invalid passed:
   out/test/spec/extended-const/global/global.47.wasm:0000027: error: type mismatch in global.set, expected [i32] but got []
   0000027: error: OnGlobalSetExpr callback failed
-out/test/spec/extended-const/global.wast:616: assert_invalid passed:
+out/test/spec/extended-const/global.wast:613: assert_invalid passed:
   out/test/spec/extended-const/global/global.48.wasm:000003e: error: type mismatch in global.set, expected [i32] but got []
   000003e: error: OnGlobalSetExpr callback failed
-out/test/spec/extended-const/global.wast:634: assert_malformed passed:
+out/test/spec/extended-const/global.wast:631: assert_malformed passed:
   out/test/spec/extended-const/global/global.49.wat:1:33: error: redefinition of global "$foo"
   (global $foo i32 (i32.const 0))(global $foo i32 (i32.const 0))
                                   ^^^^^^
-out/test/spec/extended-const/global.wast:638: assert_malformed passed:
+out/test/spec/extended-const/global.wast:635: assert_malformed passed:
   out/test/spec/extended-const/global/global.50.wat:1:34: error: redefinition of global "$foo"
   (import "" "" (global $foo i32))(global $foo i32 (i32.const 0))
                                    ^^^^^^
-out/test/spec/extended-const/global.wast:642: assert_malformed passed:
+out/test/spec/extended-const/global.wast:639: assert_malformed passed:
   out/test/spec/extended-const/global/global.51.wat:1:34: error: redefinition of global "$foo"
   (import "" "" (global $foo i32))(import "" "" (global $foo i32))
                                    ^^^^^^

--- a/test/spec/function-references/global.txt
+++ b/test/spec/function-references/global.txt
@@ -46,13 +46,13 @@ out/test/spec/function-references/global.wast:342: assert_invalid passed:
   out/test/spec/function-references/global/global.16.wasm:0000027: error: type mismatch at end of initializer expression, expected [] but got [i32]
   0000028: error: EndGlobalInitExpr callback failed
 out/test/spec/function-references/global.wast:347: assert_invalid passed:
-  out/test/spec/function-references/global/global.17.wasm:000000f: error: initializer expression can only reference an imported global
+  out/test/spec/function-references/global/global.17.wasm:000000f: error: global variable out of range: 0 (max 0)
   000000f: error: OnGlobalGetExpr callback failed
 out/test/spec/function-references/global.wast:352: assert_invalid passed:
-  out/test/spec/function-references/global/global.18.wasm:000000f: error: global variable out of range: 1 (max 1)
+  out/test/spec/function-references/global/global.18.wasm:000000f: error: global variable out of range: 1 (max 0)
   000000f: error: OnGlobalGetExpr callback failed
 out/test/spec/function-references/global.wast:357: assert_invalid passed:
-  out/test/spec/function-references/global/global.19.wasm:0000025: error: global variable out of range: 2 (max 2)
+  out/test/spec/function-references/global/global.19.wasm:0000025: error: global variable out of range: 2 (max 1)
   0000025: error: OnGlobalGetExpr callback failed
 out/test/spec/function-references/global.wast:362: assert_invalid passed:
   out/test/spec/function-references/global/global.20.wasm:0000029: error: initializer expression cannot reference a mutable global

--- a/test/spec/function-references/ref.txt
+++ b/test/spec/function-references/ref.txt
@@ -9,8 +9,8 @@ out/test/spec/function-references/ref.wast:32: assert_invalid passed:
   out/test/spec/function-references/ref/ref.2.wasm:0000010: error: reference 1 is out of range (max: 0) in results
   0000010: error: OnFuncType callback failed
 out/test/spec/function-references/ref.wast:37: assert_invalid passed:
-  out/test/spec/function-references/ref/ref.3.wasm:000000e: error: reference 1 is out of range (max: 0) in globals
-  000000e: error: BeginGlobal callback failed
+  out/test/spec/function-references/ref/ref.3.wasm:0000010: error: function type variable out of range: 1 (max 0)
+  0000010: error: OnRefNullExpr callback failed
 out/test/spec/function-references/ref.wast:42: assert_invalid passed:
   out/test/spec/function-references/ref/ref.4.wasm:000000f: error: reference 1 is out of range (max: 0) in tables
   000000f: error: BeginTable callback failed

--- a/test/spec/function-references/ref.txt
+++ b/test/spec/function-references/ref.txt
@@ -9,8 +9,8 @@ out/test/spec/function-references/ref.wast:32: assert_invalid passed:
   out/test/spec/function-references/ref/ref.2.wasm:0000010: error: reference 1 is out of range (max: 0) in results
   0000010: error: OnFuncType callback failed
 out/test/spec/function-references/ref.wast:37: assert_invalid passed:
-  out/test/spec/function-references/ref/ref.3.wasm:0000010: error: function type variable out of range: 1 (max 0)
-  0000010: error: OnRefNullExpr callback failed
+  out/test/spec/function-references/ref/ref.3.wasm:000000e: error: reference 1 is out of range (max: 0) in globals
+  000000e: error: BeginGlobal callback failed
 out/test/spec/function-references/ref.wast:42: assert_invalid passed:
   out/test/spec/function-references/ref/ref.4.wasm:000000f: error: reference 1 is out of range (max: 0) in tables
   000000f: error: BeginTable callback failed

--- a/test/spec/global.txt
+++ b/test/spec/global.txt
@@ -1,144 +1,138 @@
 ;;; TOOL: run-interp-spec
-;;; STDIN_FILE: third_party/testsuite/global.wast
+;;; STDIN_FILE: test/old-spec/global.wast
 (;; STDOUT ;;;
-out/test/spec/global.wast:251: assert_trap passed: undefined table index
-out/test/spec/global.wast:273: assert_invalid passed:
+out/test/spec/global.wast:254: assert_trap passed: undefined table index
+out/test/spec/global.wast:276: assert_invalid passed:
   out/test/spec/global/global.1.wasm:0000029: error: can't global.set on immutable global at index 0.
   0000029: error: OnGlobalSetExpr callback failed
-out/test/spec/global.wast:278: assert_invalid passed:
+out/test/spec/global.wast:281: assert_invalid passed:
   out/test/spec/global/global.2.wasm:0000035: error: can't global.set on immutable global at index 0.
   0000035: error: OnGlobalSetExpr callback failed
-out/test/spec/global.wast:287: assert_invalid passed:
+out/test/spec/global.wast:290: assert_invalid passed:
   out/test/spec/global/global.5.wasm:0000013: error: invalid initializer: instruction not valid in initializer expression: f32.neg
   0000013: error: OnUnaryExpr callback failed
-out/test/spec/global.wast:292: assert_invalid passed:
+out/test/spec/global.wast:295: assert_invalid passed:
   out/test/spec/global/global.6.wasm:000000f: error: invalid initializer: instruction not valid in initializer expression: local.get
   000000f: error: OnLocalGetExpr callback failed
-out/test/spec/global.wast:297: assert_invalid passed:
+out/test/spec/global.wast:300: assert_invalid passed:
   out/test/spec/global/global.7.wasm:0000013: error: invalid initializer: instruction not valid in initializer expression: f32.neg
   0000013: error: OnUnaryExpr callback failed
-out/test/spec/global.wast:302: assert_invalid passed:
+out/test/spec/global.wast:305: assert_invalid passed:
   out/test/spec/global/global.8.wasm:0000010: error: invalid initializer: instruction not valid in initializer expression: nop
   0000010: error: OnNopExpr callback failed
-out/test/spec/global.wast:307: assert_invalid passed:
+out/test/spec/global.wast:310: assert_invalid passed:
   out/test/spec/global/global.9.wasm:0000010: error: invalid initializer: instruction not valid in initializer expression: i32.ctz
   0000010: error: OnUnaryExpr callback failed
-out/test/spec/global.wast:312: assert_invalid passed:
+out/test/spec/global.wast:315: assert_invalid passed:
   out/test/spec/global/global.10.wasm:000000e: error: invalid initializer: instruction not valid in initializer expression: nop
   000000e: error: OnNopExpr callback failed
-out/test/spec/global.wast:317: assert_invalid passed:
+out/test/spec/global.wast:320: assert_invalid passed:
   out/test/spec/global/global.11.wasm:0000012: error: type mismatch in initializer expression, expected [i32] but got [f32]
   0000013: error: EndGlobalInitExpr callback failed
-out/test/spec/global.wast:322: assert_invalid passed:
+out/test/spec/global.wast:325: assert_invalid passed:
   out/test/spec/global/global.12.wasm:0000011: error: type mismatch at end of initializer expression, expected [] but got [i32]
   0000012: error: EndGlobalInitExpr callback failed
-out/test/spec/global.wast:327: assert_invalid passed:
+out/test/spec/global.wast:330: assert_invalid passed:
   out/test/spec/global/global.13.wasm:000000d: error: type mismatch in initializer expression, expected [i32] but got []
   000000e: error: EndGlobalInitExpr callback failed
-out/test/spec/global.wast:332: assert_invalid passed:
+out/test/spec/global.wast:335: assert_invalid passed:
   out/test/spec/global/global.14.wasm:0000017: error: type mismatch in initializer expression, expected [funcref] but got [externref]
   0000018: error: EndGlobalInitExpr callback failed
-out/test/spec/global.wast:337: assert_invalid passed:
+out/test/spec/global.wast:340: assert_invalid passed:
   out/test/spec/global/global.15.wasm:0000027: error: type mismatch at end of initializer expression, expected [] but got [i32]
   0000028: error: EndGlobalInitExpr callback failed
-out/test/spec/global.wast:342: assert_invalid passed:
+out/test/spec/global.wast:345: assert_invalid passed:
   out/test/spec/global/global.16.wasm:0000027: error: type mismatch at end of initializer expression, expected [] but got [i32]
   0000028: error: EndGlobalInitExpr callback failed
-out/test/spec/global.wast:347: assert_invalid passed:
-  out/test/spec/global/global.17.wasm:000000f: error: initializer expression can only reference an imported global
+out/test/spec/global.wast:350: assert_invalid passed:
+  out/test/spec/global/global.17.wasm:000000f: error: global variable out of range: 0 (max 0)
   000000f: error: OnGlobalGetExpr callback failed
-out/test/spec/global.wast:352: assert_invalid passed:
-  out/test/spec/global/global.18.wasm:0000014: error: initializer expression can only reference an imported global
-  0000014: error: OnGlobalGetExpr callback failed
-out/test/spec/global.wast:356: assert_invalid passed:
-  out/test/spec/global/global.19.wasm:0000014: error: initializer expression can only reference an imported global
-  0000014: error: OnGlobalGetExpr callback failed
-out/test/spec/global.wast:361: assert_invalid passed:
-  out/test/spec/global/global.20.wasm:000000f: error: global variable out of range: 1 (max 1)
+out/test/spec/global.wast:355: assert_invalid passed:
+  out/test/spec/global/global.18.wasm:000000f: error: global variable out of range: 1 (max 0)
   000000f: error: OnGlobalGetExpr callback failed
-out/test/spec/global.wast:366: assert_invalid passed:
-  out/test/spec/global/global.21.wasm:0000025: error: global variable out of range: 2 (max 2)
+out/test/spec/global.wast:360: assert_invalid passed:
+  out/test/spec/global/global.19.wasm:0000025: error: global variable out of range: 2 (max 1)
   0000025: error: OnGlobalGetExpr callback failed
-out/test/spec/global.wast:371: assert_invalid passed:
+out/test/spec/global.wast:368: assert_invalid passed:
   out/test/spec/global/global.22.wasm:0000029: error: initializer expression cannot reference a mutable global
   0000029: error: OnGlobalGetExpr callback failed
-out/test/spec/global.wast:379: assert_malformed passed:
+out/test/spec/global.wast:376: assert_malformed passed:
   0000026: error: global mutability must be 0 or 1
-out/test/spec/global.wast:392: assert_malformed passed:
+out/test/spec/global.wast:389: assert_malformed passed:
   0000026: error: global mutability must be 0 or 1
-out/test/spec/global.wast:409: assert_malformed passed:
+out/test/spec/global.wast:406: assert_malformed passed:
   0000011: error: global mutability must be 0 or 1
-out/test/spec/global.wast:421: assert_malformed passed:
+out/test/spec/global.wast:418: assert_malformed passed:
   0000011: error: global mutability must be 0 or 1
-out/test/spec/global.wast:435: assert_invalid passed:
+out/test/spec/global.wast:432: assert_invalid passed:
   out/test/spec/global/global.29.wasm:000001a: error: global variable out of range: 0 (max 0)
   000001a: error: OnGlobalGetExpr callback failed
-out/test/spec/global.wast:440: assert_invalid passed:
+out/test/spec/global.wast:437: assert_invalid passed:
   out/test/spec/global/global.30.wasm:0000022: error: global variable out of range: 1 (max 1)
   0000022: error: OnGlobalGetExpr callback failed
-out/test/spec/global.wast:448: assert_invalid passed:
+out/test/spec/global.wast:445: assert_invalid passed:
   out/test/spec/global/global.31.wasm:0000034: error: global variable out of range: 1 (max 1)
   0000034: error: OnGlobalGetExpr callback failed
-out/test/spec/global.wast:456: assert_invalid passed:
+out/test/spec/global.wast:453: assert_invalid passed:
   out/test/spec/global/global.32.wasm:000003c: error: global variable out of range: 2 (max 2)
   000003c: error: OnGlobalGetExpr callback failed
-out/test/spec/global.wast:466: assert_invalid passed:
+out/test/spec/global.wast:463: assert_invalid passed:
   out/test/spec/global/global.33.wasm:000001b: error: global variable out of range: 0 (max 0)
   000001b: error: OnGlobalSetExpr callback failed
-out/test/spec/global.wast:471: assert_invalid passed:
+out/test/spec/global.wast:468: assert_invalid passed:
   out/test/spec/global/global.34.wasm:0000023: error: global variable out of range: 1 (max 1)
   0000023: error: OnGlobalSetExpr callback failed
-out/test/spec/global.wast:479: assert_invalid passed:
+out/test/spec/global.wast:476: assert_invalid passed:
   out/test/spec/global/global.35.wasm:0000035: error: global variable out of range: 1 (max 1)
   0000035: error: OnGlobalSetExpr callback failed
-out/test/spec/global.wast:487: assert_invalid passed:
+out/test/spec/global.wast:484: assert_invalid passed:
   out/test/spec/global/global.36.wasm:000003d: error: global variable out of range: 2 (max 2)
   000003d: error: OnGlobalSetExpr callback failed
-out/test/spec/global.wast:497: assert_invalid passed:
+out/test/spec/global.wast:494: assert_invalid passed:
   out/test/spec/global/global.37.wasm:0000021: error: type mismatch in global.set, expected [i32] but got []
   0000021: error: OnGlobalSetExpr callback failed
-out/test/spec/global.wast:506: assert_invalid passed:
+out/test/spec/global.wast:503: assert_invalid passed:
   out/test/spec/global/global.38.wasm:0000025: error: type mismatch in global.set, expected [i32] but got []
   0000025: error: OnGlobalSetExpr callback failed
-out/test/spec/global.wast:516: assert_invalid passed:
+out/test/spec/global.wast:513: assert_invalid passed:
   out/test/spec/global/global.39.wasm:0000025: error: type mismatch in global.set, expected [i32] but got []
   0000025: error: OnGlobalSetExpr callback failed
-out/test/spec/global.wast:526: assert_invalid passed:
+out/test/spec/global.wast:523: assert_invalid passed:
   out/test/spec/global/global.40.wasm:0000027: error: type mismatch in global.set, expected [i32] but got []
   0000027: error: OnGlobalSetExpr callback failed
-out/test/spec/global.wast:536: assert_invalid passed:
+out/test/spec/global.wast:533: assert_invalid passed:
   out/test/spec/global/global.41.wasm:000002a: error: type mismatch in global.set, expected [i32] but got []
   000002a: error: OnGlobalSetExpr callback failed
-out/test/spec/global.wast:546: assert_invalid passed:
+out/test/spec/global.wast:543: assert_invalid passed:
   out/test/spec/global/global.42.wasm:0000025: error: type mismatch in global.set, expected [i32] but got []
   0000025: error: OnGlobalSetExpr callback failed
-out/test/spec/global.wast:556: assert_invalid passed:
+out/test/spec/global.wast:553: assert_invalid passed:
   out/test/spec/global/global.43.wasm:0000025: error: type mismatch in global.set, expected [i32] but got []
   0000025: error: OnGlobalSetExpr callback failed
-out/test/spec/global.wast:566: assert_invalid passed:
+out/test/spec/global.wast:563: assert_invalid passed:
   out/test/spec/global/global.44.wasm:0000025: error: type mismatch in global.set, expected [i32] but got []
   0000025: error: OnGlobalSetExpr callback failed
-out/test/spec/global.wast:576: assert_invalid passed:
+out/test/spec/global.wast:573: assert_invalid passed:
   out/test/spec/global/global.45.wasm:0000021: error: type mismatch in global.set, expected [i32] but got []
   0000021: error: OnGlobalSetExpr callback failed
-out/test/spec/global.wast:585: assert_invalid passed:
+out/test/spec/global.wast:582: assert_invalid passed:
   out/test/spec/global/global.46.wasm:0000021: error: type mismatch in global.set, expected [i32] but got []
   0000021: error: OnGlobalSetExpr callback failed
-out/test/spec/global.wast:594: assert_invalid passed:
+out/test/spec/global.wast:591: assert_invalid passed:
   out/test/spec/global/global.47.wasm:0000027: error: type mismatch in global.set, expected [i32] but got []
   0000027: error: OnGlobalSetExpr callback failed
-out/test/spec/global.wast:604: assert_invalid passed:
+out/test/spec/global.wast:601: assert_invalid passed:
   out/test/spec/global/global.48.wasm:000003e: error: type mismatch in global.set, expected [i32] but got []
   000003e: error: OnGlobalSetExpr callback failed
-out/test/spec/global.wast:622: assert_malformed passed:
+out/test/spec/global.wast:619: assert_malformed passed:
   out/test/spec/global/global.49.wat:1:33: error: redefinition of global "$foo"
   (global $foo i32 (i32.const 0))(global $foo i32 (i32.const 0))
                                   ^^^^^^
-out/test/spec/global.wast:626: assert_malformed passed:
+out/test/spec/global.wast:623: assert_malformed passed:
   out/test/spec/global/global.50.wat:1:34: error: redefinition of global "$foo"
   (import "" "" (global $foo i32))(global $foo i32 (i32.const 0))
                                    ^^^^^^
-out/test/spec/global.wast:630: assert_malformed passed:
+out/test/spec/global.wast:627: assert_malformed passed:
   out/test/spec/global/global.51.wat:1:34: error: redefinition of global "$foo"
   (import "" "" (global $foo i32))(import "" "" (global $foo i32))
                                    ^^^^^^

--- a/test/spec/global.txt
+++ b/test/spec/global.txt
@@ -47,11 +47,11 @@ out/test/spec/global.wast:345: assert_invalid passed:
 out/test/spec/global.wast:350: assert_invalid passed:
   out/test/spec/global/global.17.wasm:000000f: error: global variable out of range: 0 (max 0)
   000000f: error: OnGlobalGetExpr callback failed
-out/test/spec/global.wast:355: assert_invalid passed:
-  out/test/spec/global/global.18.wasm:000000f: error: global variable out of range: 1 (max 0)
+out/test/spec/global.wast:358: assert_invalid passed:
+  out/test/spec/global/global.20.wasm:000000f: error: global variable out of range: 1 (max 0)
   000000f: error: OnGlobalGetExpr callback failed
-out/test/spec/global.wast:360: assert_invalid passed:
-  out/test/spec/global/global.19.wasm:0000025: error: global variable out of range: 2 (max 1)
+out/test/spec/global.wast:363: assert_invalid passed:
+  out/test/spec/global/global.21.wasm:0000025: error: global variable out of range: 2 (max 1)
   0000025: error: OnGlobalGetExpr callback failed
 out/test/spec/global.wast:368: assert_invalid passed:
   out/test/spec/global/global.22.wasm:0000029: error: initializer expression cannot reference a mutable global

--- a/test/spec/multi-memory/data.txt
+++ b/test/spec/multi-memory/data.txt
@@ -1,71 +1,65 @@
 ;;; TOOL: run-interp-spec
-;;; STDIN_FILE: third_party/testsuite/proposals/multi-memory/data.wast
+;;; STDIN_FILE: test/old-spec/proposals/multi-memory/data.wast
 ;;; ARGS*: --enable-multi-memory
 (;; STDOUT ;;;
-out/test/spec/multi-memory/data.wast:86: assert_invalid passed:
-  out/test/spec/multi-memory/data/data.9.wasm:000001b: error: initializer expression can only reference an imported global
-  000001b: error: OnGlobalGetExpr callback failed
-out/test/spec/multi-memory/data.wast:90: assert_invalid passed:
-  out/test/spec/multi-memory/data/data.10.wasm:000001b: error: initializer expression can only reference an imported global
-  000001b: error: OnGlobalGetExpr callback failed
-out/test/spec/multi-memory/data.wast:300: assert_invalid passed:
+out/test/spec/multi-memory/data.wast:297: assert_invalid passed:
   out/test/spec/multi-memory/data/data.41.wasm:000000c: error: memory variable out of range: 0 (max 0)
   000000c: error: BeginDataSegment callback failed
-out/test/spec/multi-memory/data.wast:308: assert_invalid passed:
+out/test/spec/multi-memory/data.wast:305: assert_invalid passed:
   out/test/spec/multi-memory/data/data.42.wasm:0000012: error: memory variable out of range: 1 (max 1)
   0000012: error: BeginDataSegment callback failed
-out/test/spec/multi-memory/data.wast:321: assert_invalid passed:
+out/test/spec/multi-memory/data.wast:318: assert_invalid passed:
   out/test/spec/multi-memory/data/data.43.wasm:000000c: error: memory variable out of range: 0 (max 0)
   000000c: error: BeginDataSegment callback failed
-out/test/spec/multi-memory/data.wast:332: assert_invalid passed:
+out/test/spec/multi-memory/data.wast:329: assert_invalid passed:
   out/test/spec/multi-memory/data/data.44.wasm:000000d: error: memory variable out of range: 1 (max 0)
   000000d: error: BeginDataSegment callback failed
-out/test/spec/multi-memory/data.wast:344: assert_invalid passed:
+out/test/spec/multi-memory/data.wast:341: assert_invalid passed:
   out/test/spec/multi-memory/data/data.45.wasm:0000012: error: memory variable out of range: 1 (max 1)
   0000012: error: BeginDataSegment callback failed
-out/test/spec/multi-memory/data.wast:366: assert_invalid passed:
+out/test/spec/multi-memory/data.wast:363: assert_invalid passed:
   out/test/spec/multi-memory/data/data.46.wasm:000000d: error: memory variable out of range: 1 (max 0)
   000000d: error: BeginDataSegment callback failed
-out/test/spec/multi-memory/data.wast:385: assert_invalid passed:
+out/test/spec/multi-memory/data.wast:382: assert_invalid passed:
   out/test/spec/multi-memory/data/data.47.wasm:0000013: error: type mismatch in initializer expression, expected [i32] but got [i64]
   0000014: error: EndDataSegmentInitExpr callback failed
-out/test/spec/multi-memory/data.wast:393: assert_invalid passed:
+out/test/spec/multi-memory/data.wast:390: assert_invalid passed:
   out/test/spec/multi-memory/data/data.48.wasm:0000013: error: type mismatch in initializer expression, expected [i32] but got [funcref]
   0000014: error: EndDataSegmentInitExpr callback failed
-out/test/spec/multi-memory/data.wast:401: assert_invalid passed:
+out/test/spec/multi-memory/data.wast:398: assert_invalid passed:
   out/test/spec/multi-memory/data/data.49.wasm:0000011: error: type mismatch in initializer expression, expected [i32] but got []
   0000012: error: EndDataSegmentInitExpr callback failed
-out/test/spec/multi-memory/data.wast:409: assert_invalid passed:
+out/test/spec/multi-memory/data.wast:406: assert_invalid passed:
   out/test/spec/multi-memory/data/data.50.wasm:0000015: error: type mismatch at end of initializer expression, expected [] but got [i32]
   0000016: error: EndDataSegmentInitExpr callback failed
-out/test/spec/multi-memory/data.wast:417: assert_invalid passed:
+out/test/spec/multi-memory/data.wast:414: assert_invalid passed:
   out/test/spec/multi-memory/data/data.51.wasm:000002b: error: type mismatch at end of initializer expression, expected [] but got [i32]
   000002c: error: EndDataSegmentInitExpr callback failed
-out/test/spec/multi-memory/data.wast:426: assert_invalid passed:
+out/test/spec/multi-memory/data.wast:423: assert_invalid passed:
   out/test/spec/multi-memory/data/data.52.wasm:000002b: error: type mismatch at end of initializer expression, expected [] but got [i32]
   000002c: error: EndDataSegmentInitExpr callback failed
-out/test/spec/multi-memory/data.wast:435: assert_invalid passed:
+out/test/spec/multi-memory/data.wast:432: assert_invalid passed:
   out/test/spec/multi-memory/data/data.53.wasm:0000014: error: invalid initializer: instruction not valid in initializer expression: i32.ctz
   0000014: error: OnUnaryExpr callback failed
-out/test/spec/multi-memory/data.wast:443: assert_invalid passed:
+out/test/spec/multi-memory/data.wast:440: assert_invalid passed:
   out/test/spec/multi-memory/data/data.54.wasm:0000012: error: invalid initializer: instruction not valid in initializer expression: nop
   0000012: error: OnNopExpr callback failed
-out/test/spec/multi-memory/data.wast:451: assert_invalid passed:
+out/test/spec/multi-memory/data.wast:448: assert_invalid passed:
   out/test/spec/multi-memory/data/data.55.wasm:0000012: error: invalid initializer: instruction not valid in initializer expression: nop
   0000012: error: OnNopExpr callback failed
-out/test/spec/multi-memory/data.wast:459: assert_invalid passed:
+out/test/spec/multi-memory/data.wast:456: assert_invalid passed:
   out/test/spec/multi-memory/data/data.56.wasm:0000014: error: invalid initializer: instruction not valid in initializer expression: nop
   0000014: error: OnNopExpr callback failed
-out/test/spec/multi-memory/data.wast:467: assert_invalid passed:
+out/test/spec/multi-memory/data.wast:464: assert_invalid passed:
   out/test/spec/multi-memory/data/data.57.wasm:0000020: error: initializer expression cannot reference a mutable global
   0000020: error: OnGlobalGetExpr callback failed
-out/test/spec/multi-memory/data.wast:476: assert_invalid passed:
+out/test/spec/multi-memory/data.wast:473: assert_invalid passed:
   out/test/spec/multi-memory/data/data.58.wasm:0000013: error: global variable out of range: 0 (max 0)
   0000013: error: OnGlobalGetExpr callback failed
-out/test/spec/multi-memory/data.wast:484: assert_invalid passed:
+out/test/spec/multi-memory/data.wast:481: assert_invalid passed:
   out/test/spec/multi-memory/data/data.59.wasm:0000029: error: global variable out of range: 1 (max 1)
   0000029: error: OnGlobalGetExpr callback failed
-out/test/spec/multi-memory/data.wast:493: assert_invalid passed:
+out/test/spec/multi-memory/data.wast:490: assert_invalid passed:
   out/test/spec/multi-memory/data/data.60.wasm:000002d: error: initializer expression cannot reference a mutable global
   000002d: error: OnGlobalGetExpr callback failed
 61/61 tests passed.

--- a/test/update-spec-tests.py
+++ b/test/update-spec-tests.py
@@ -28,7 +28,25 @@ SPEC_TEST_DIR = os.path.join(TEST_DIR, 'spec')
 WASM2C_SPEC_TEST_DIR = os.path.join(TEST_DIR, 'wasm2c', 'spec')
 
 # snapshot of older version of proposals where WABT doesn't support current version
-OLD_PROPOSALS_DIR = os.path.join(REPO_ROOT_DIR, 'test', 'old-spec', 'proposals')
+OLD_SPEC_DIR = os.path.join(REPO_ROOT_DIR, 'test', 'old-spec')
+OLD_PROPOSALS_DIR = os.path.join(OLD_SPEC_DIR, 'proposals')
+
+# Core testsuite files patched for spec changes not yet in the pinned testsuite.
+CORE_OLD_SPEC_OVERRIDES = {
+    'global': os.path.join(OLD_SPEC_DIR, 'global.wast'),
+    'elem': os.path.join(OLD_SPEC_DIR, 'elem.wast'),
+    'data': os.path.join(OLD_SPEC_DIR, 'data.wast'),
+}
+
+# Proposal directories fully replaced by patched snapshots under test/old-spec/.
+OLD_PROPOSAL_DIRS = {
+    'extended-const': os.path.join(OLD_PROPOSALS_DIR, 'extended-const'),
+}
+
+# Individual proposal tests replaced by patched snapshots.
+OLD_PROPOSAL_WAST_OVERRIDES = {
+    'multi-memory/data': os.path.join(OLD_PROPOSALS_DIR, 'multi-memory', 'data.wast'),
+}
 
 options = None
 
@@ -43,7 +61,17 @@ def GetFilesWithExtension(src_dir, want_ext):
     return result
 
 
-def ProcessDir(wabt_test_dir, testsuite_dir, tool, flags=None):
+def GetWastPath(testsuite_dir, test_name, overrides=None):
+    if overrides and test_name in overrides:
+        override_path = overrides[test_name]
+        assert os.path.exists(override_path), override_path
+        return os.path.relpath(override_path, REPO_ROOT_DIR).replace(os.sep, '/')
+    return os.path.join(
+        os.path.relpath(testsuite_dir, REPO_ROOT_DIR),
+        test_name + '.wast').replace(os.sep, '/')
+
+
+def ProcessDir(wabt_test_dir, testsuite_dir, tool, flags=None, overrides=None):
     testsuite_tests = GetFilesWithExtension(testsuite_dir, '.wast')
     wabt_tests = GetFilesWithExtension(wabt_test_dir, '.txt')
 
@@ -54,9 +82,7 @@ def ProcessDir(wabt_test_dir, testsuite_dir, tool, flags=None):
         os.remove(test_filename)
 
     for added_test_name in testsuite_tests - wabt_tests:
-        wast_filename = os.path.join(
-            os.path.relpath(testsuite_dir, REPO_ROOT_DIR),
-            added_test_name + '.wast')
+        wast_filename = GetWastPath(testsuite_dir, added_test_name, overrides)
         test_filename = os.path.join(wabt_test_dir, added_test_name + '.txt')
         if options.verbose:
             print('Adding %s' % test_filename)
@@ -67,21 +93,35 @@ def ProcessDir(wabt_test_dir, testsuite_dir, tool, flags=None):
 
         with open(test_filename, 'w') as f:
             f.write(';;; TOOL: %s\n' % tool)
-            f.write(';;; STDIN_FILE: %s\n' % wast_filename.replace(os.sep, '/'))
+            f.write(';;; STDIN_FILE: %s\n' % wast_filename)
             if flags:
                 f.write(';;; ARGS*: %s\n' % flags)
 
 
 def ProcessProposalDir(name, flags=None, old=False):
-    proposals_dir = OLD_PROPOSALS_DIR if old else PROPOSALS_DIR
+    if old:
+        proposals_dir = os.path.join(OLD_PROPOSALS_DIR, name)
+    elif name in OLD_PROPOSAL_DIRS:
+        proposals_dir = OLD_PROPOSAL_DIRS[name]
+    else:
+        proposals_dir = os.path.join(PROPOSALS_DIR, name)
+
+    per_proposal_overrides = {}
+    for test_name in GetFilesWithExtension(proposals_dir, '.wast'):
+        override_key = '%s/%s' % (name, test_name)
+        if override_key in OLD_PROPOSAL_WAST_OVERRIDES:
+            per_proposal_overrides[test_name] = OLD_PROPOSAL_WAST_OVERRIDES[override_key]
+
     ProcessDir(os.path.join(SPEC_TEST_DIR, name),
-               os.path.join(proposals_dir, name),
+               proposals_dir,
                'run-interp-spec',
-               flags)
+               flags,
+               per_proposal_overrides)
     ProcessDir(os.path.join(WASM2C_SPEC_TEST_DIR, name),
-               os.path.join(proposals_dir, name),
+               proposals_dir,
                'run-spec-wasm2c',
-               flags)
+               flags,
+               per_proposal_overrides)
 
 
 def main(args):
@@ -91,8 +131,10 @@ def main(args):
     global options
     options = parser.parse_args(args)
 
-    ProcessDir(SPEC_TEST_DIR, TESTSUITE_DIR, 'run-interp-spec')
-    ProcessDir(WASM2C_SPEC_TEST_DIR, TESTSUITE_DIR, 'run-spec-wasm2c')
+    ProcessDir(SPEC_TEST_DIR, TESTSUITE_DIR, 'run-interp-spec',
+               overrides=CORE_OLD_SPEC_OVERRIDES)
+    ProcessDir(WASM2C_SPEC_TEST_DIR, TESTSUITE_DIR, 'run-spec-wasm2c',
+               overrides=CORE_OLD_SPEC_OVERRIDES)
 
     all_proposals = [e.name for e in os.scandir(PROPOSALS_DIR) if e.is_dir()]
 
@@ -124,6 +166,13 @@ def main(args):
     # sanity check to verify that all unimplemented are valid
     for proposal in unimplemented:
         assert proposal in all_proposals, proposal
+
+    for name, path in CORE_OLD_SPEC_OVERRIDES.items():
+        assert os.path.exists(path), path
+    for name, path in OLD_PROPOSAL_WAST_OVERRIDES.items():
+        assert os.path.exists(path), path
+    for name, path in OLD_PROPOSAL_DIRS.items():
+        assert os.path.isdir(path), path
 
     proposals = [p for p in all_proposals if p not in unimplemented]
     for proposal in proposals:


### PR DESCRIPTION
Fixes #2526

## Problem

WABT currently rejects `global.get` of any non-imported global in initializer expressions. This prevents element/data segment offsets and global initializers from referencing immutable globals defined earlier in the same module.

The current WebAssembly validation rules allow `global.get` to reference a previously defined immutable global. The referenced global must still be immutable and previously defined; self-references, forward references, invalid indexes, and wrong types remain invalid.

## Fix

Remove the imported-global restriction from `SharedValidator::OnGlobalGet` while preserving the mutable-global check.

Split global handling into `OnGlobalType` (declaration validation via `CheckReferenceType`) and `OnGlobal` (publication into `globals_`). Validate each initializer before publishing the global so it is visible to later globals but not to itself. Failed type checks do not publish the global.

Apply the same ordering semantics to both `Validator::CheckModule` and `BinaryReaderInterp`.

Remove the now-unused `num_imported_globals_` bookkeeping.

## Tests

Add regression coverage in `test/regress/issue-2526.txt` for:
- element segment offsets using a defined immutable global (runtime-observable via `call_indirect` → 42)
- data segment offsets using a defined immutable global (runtime-observable via `i32.load8_u` → 97)
- global initializers referencing an earlier immutable global
- global chaining (`$a` → `$b` → `$c`)
- self-references, forward references, mutable globals, and invalid offset types

Update affected spec-test expectations using minimal patched snapshots under `test/old-spec/` (core `global`/`elem`/`data` plus proposal suites) and extend `test/update-spec-tests.py` to preserve those overrides during regeneration.

## Test plan

- [x] `./test/run-tests.py issue-2526`
- [x] `./test/run-tests.py spec/global spec/elem spec/data`
- [x] `./test/run-tests.py wasm2c/spec/global wasm2c/spec/elem wasm2c/spec/data`
- [x] `cmake --build out --target run-unittests`
- [x] `cmake --build out --target run-c-api-tests`
- [x] `cmake --build out --target run-tests`
- [x] Feature flags: default, `--enable-all`, `--enable-extended-const` on valid repro
- [x] Self-reference rejected by `wasm-validate` / `wasm-interp` paths