### PR TITLE
wasm2c: Optimize force_read performance

### DIFF
--- a/src/prebuilt/wasm2c_atomicops_source_declarations.cc
+++ b/src/prebuilt/wasm2c_atomicops_source_declarations.cc
@@ -29,9 +29,11 @@ R"w2c_template(        (_Atomic volatile t1*)MEM_ADDR(mem, addr, sizeof(t1)),   
 )w2c_template"
 R"w2c_template(        memory_order_relaxed);                                                \
 )w2c_template"
-R"w2c_template(    force_read(result);                                                       \
+R"w2c_template(    t3 ret = (t3)(t2)result;                                                  \
 )w2c_template"
-R"w2c_template(    return (t3)(t2)result;                                                    \
+R"w2c_template(    force_read(ret);                                                          \
+)w2c_template"
+R"w2c_template(    return ret;                                                               \
 )w2c_template"
 R"w2c_template(  }                                                                           \
 )w2c_template"
@@ -117,9 +119,11 @@ R"w2c_template(    wasm_rt_memcpy(&result, MEM_ADDR_MEMOP(mem, addr, sizeof(t1))
 )w2c_template"
 R"w2c_template(                   sizeof(t1));                                             \
 )w2c_template"
-R"w2c_template(    force_read(result);                                                     \
+R"w2c_template(    t3 ret = (t3)(t2)result;                                                \
 )w2c_template"
-R"w2c_template(    return (t3)(t2)result;                                                  \
+R"w2c_template(    force_read(ret);                                                        \
+)w2c_template"
+R"w2c_template(    return ret;                                                             \
 )w2c_template"
 R"w2c_template(  }                                                                         \
 )w2c_template"
@@ -137,9 +141,11 @@ R"w2c_template(    result =                                                     
 )w2c_template"
 R"w2c_template(        atomic_load((_Atomic volatile t1*)MEM_ADDR(mem, addr, sizeof(t1))); \
 )w2c_template"
-R"w2c_template(    force_read(result);                                                     \
+R"w2c_template(    t3 ret = (t3)(t2)result;                                                \
 )w2c_template"
-R"w2c_template(    return (t3)(t2)result;                                                  \
+R"w2c_template(    force_read(ret);                                                        \
+)w2c_template"
+R"w2c_template(    return ret;                                                             \
 )w2c_template"
 R"w2c_template(  }                                                                         \
 )w2c_template"

--- a/src/prebuilt/wasm2c_source_declarations.cc
+++ b/src/prebuilt/wasm2c_source_declarations.cc
@@ -294,21 +294,61 @@ R"w2c_template(#ifdef __GNUC__
 )w2c_template"
 R"w2c_template(#define FORCE_READ_INT(var) __asm__("" ::"r"(var));
 )w2c_template"
-R"w2c_template(// Clang on Mips requires "f" constraints on floats
+R"w2c_template(
+#if defined(__i386__) || defined(__x86_64__)
 )w2c_template"
-R"w2c_template(// See https://github.com/llvm/llvm-project/issues/64241
+R"w2c_template(#if defined(__SSE__)
 )w2c_template"
-R"w2c_template(#if defined(__clang__) && \
+R"w2c_template(#define FORCE_READ_FLOAT_CONSTRAINT "x"
 )w2c_template"
-R"w2c_template(    (defined(mips) || defined(__mips__) || defined(__mips))
+R"w2c_template(#else  // No SSE, old x87
 )w2c_template"
-R"w2c_template(#define FORCE_READ_FLOAT(var) __asm__("" ::"f"(var));
+R"w2c_template(#define FORCE_READ_FLOAT_CONSTRAINT "f"
+)w2c_template"
+R"w2c_template(#endif
+)w2c_template"
+R"w2c_template(#elif (defined(__arm__) || defined(__aarch64__)) && defined(__ARM_FP) && \
+)w2c_template"
+R"w2c_template(    ((__ARM_FP & 0x4) != 0)
+)w2c_template"
+R"w2c_template(#ifdef __aarch64__
+)w2c_template"
+R"w2c_template(#define FORCE_READ_FLOAT_CONSTRAINT "w"
 )w2c_template"
 R"w2c_template(#else
 )w2c_template"
-R"w2c_template(#define FORCE_READ_FLOAT(var) __asm__("" ::"r"(var));
+R"w2c_template(#define FORCE_READ_FLOAT_CONSTRAINT "t"
 )w2c_template"
 R"w2c_template(#endif
+)w2c_template"
+R"w2c_template(#elif defined(__mips__) && defined(__clang__) && !defined(__mips_soft_float)
+)w2c_template"
+R"w2c_template(// Clang before v18 uses hard floats which has a different constraint
+)w2c_template"
+R"w2c_template(#define FORCE_READ_FLOAT_CONSTRAINT "f"
+)w2c_template"
+R"w2c_template(#elif (defined(__powerpc__) || defined(__ppc__) || defined(__PPC__)) || \
+)w2c_template"
+R"w2c_template(    !(defined(_SOFT_FLOAT) || defined(__NO_FPRS__))
+)w2c_template"
+R"w2c_template(#define FORCE_READ_FLOAT_CONSTRAINT "f"
+)w2c_template"
+R"w2c_template(#elif defined(__riscv) && defined(__riscv_flen) && (__riscv_flen >= 32)
+)w2c_template"
+R"w2c_template(#define FORCE_READ_FLOAT_CONSTRAINT "f"
+)w2c_template"
+R"w2c_template(#elif defined(__s390__) || defined(__s390x__)
+)w2c_template"
+R"w2c_template(#define FORCE_READ_FLOAT_CONSTRAINT "f"
+)w2c_template"
+R"w2c_template(#else
+)w2c_template"
+R"w2c_template(#define FORCE_READ_FLOAT_CONSTRAINT "r"
+)w2c_template"
+R"w2c_template(#endif
+)w2c_template"
+R"w2c_template(
+#define FORCE_READ_FLOAT(var) __asm__("" ::FORCE_READ_FLOAT_CONSTRAINT(var));
 )w2c_template"
 R"w2c_template(#endif
 )w2c_template"
@@ -468,9 +508,11 @@ R"w2c_template(    wasm_rt_memcpy(&result, MEM_ADDR_MEMOP(mem, addr, sizeof(t1))
 )w2c_template"
 R"w2c_template(                   sizeof(t1));                                        \
 )w2c_template"
-R"w2c_template(    force_read(result);                                                \
+R"w2c_template(    t3 ret = (t3)(t2)result;                                           \
 )w2c_template"
-R"w2c_template(    return (t3)(t2)result;                                             \
+R"w2c_template(    force_read(ret);                                                   \
+)w2c_template"
+R"w2c_template(    return ret;                                                        \
 )w2c_template"
 R"w2c_template(  }                                                                    \
 )w2c_template"

--- a/src/template/wasm2c.declarations.c
+++ b/src/template/wasm2c.declarations.c
@@ -156,14 +156,35 @@ static inline uint64_t checked_add_u64(uint64_t a, uint64_t b) {
 // trap checks are applied in the right place, and not optimized away.
 #ifdef __GNUC__
 #define FORCE_READ_INT(var) __asm__("" ::"r"(var));
-// Clang on Mips requires "f" constraints on floats
-// See https://github.com/llvm/llvm-project/issues/64241
-#if defined(__clang__) && \
-    (defined(mips) || defined(__mips__) || defined(__mips))
-#define FORCE_READ_FLOAT(var) __asm__("" ::"f"(var));
-#else
-#define FORCE_READ_FLOAT(var) __asm__("" ::"r"(var));
+
+#if defined(__i386__) || defined(__x86_64__)
+#if defined(__SSE__)
+#define FORCE_READ_FLOAT_CONSTRAINT "x"
+#else  // No SSE, old x87
+#define FORCE_READ_FLOAT_CONSTRAINT "f"
 #endif
+#elif (defined(__arm__) || defined(__aarch64__)) && defined(__ARM_FP) && \
+    ((__ARM_FP & 0x4) != 0)
+#ifdef __aarch64__
+#define FORCE_READ_FLOAT_CONSTRAINT "w"
+#else
+#define FORCE_READ_FLOAT_CONSTRAINT "t"
+#endif
+#elif defined(__mips__) && defined(__clang__) && !defined(__mips_soft_float)
+// Clang before v18 uses hard floats which has a different constraint
+#define FORCE_READ_FLOAT_CONSTRAINT "f"
+#elif (defined(__powerpc__) || defined(__ppc__) || defined(__PPC__)) || \
+    !(defined(_SOFT_FLOAT) || defined(__NO_FPRS__))
+#define FORCE_READ_FLOAT_CONSTRAINT "f"
+#elif defined(__riscv) && defined(__riscv_flen) && (__riscv_flen >= 32)
+#define FORCE_READ_FLOAT_CONSTRAINT "f"
+#elif defined(__s390__) || defined(__s390x__)
+#define FORCE_READ_FLOAT_CONSTRAINT "f"
+#else
+#define FORCE_READ_FLOAT_CONSTRAINT "r"
+#endif
+
+#define FORCE_READ_FLOAT(var) __asm__("" ::FORCE_READ_FLOAT_CONSTRAINT(var));
 #endif
 
 #else
@@ -248,8 +269,9 @@ static inline void load_data(u8* dest, const u8* src, size_t n) {
     t1 result;                                                         \
     wasm_rt_memcpy(&result, MEM_ADDR_MEMOP(mem, addr, sizeof(t1)),     \
                    sizeof(t1));                                        \
-    force_read(result);                                                \
-    return (t3)(t2)result;                                             \
+    t3 ret = (t3)(t2)result;                                           \
+    force_read(ret);                                                   \
+    return ret;                                                        \
   }                                                                    \
   DEF_MEM_CHECKS0(name, _, t1, return, t3)
 

--- a/src/template/wasm2c_atomicops.declarations.c
+++ b/src/template/wasm2c_atomicops.declarations.c
@@ -15,8 +15,9 @@
     result = atomic_load_explicit(                                            \
         (_Atomic volatile t1*)MEM_ADDR(mem, addr, sizeof(t1)),                \
         memory_order_relaxed);                                                \
-    force_read(result);                                                       \
-    return (t3)(t2)result;                                                    \
+    t3 ret = (t3)(t2)result;                                                  \
+    force_read(ret);                                                          \
+    return ret;                                                               \
   }                                                                           \
   DEF_MEM_CHECKS0(name, _shared_, t1, return, t3)
 
@@ -61,8 +62,9 @@ DEFINE_SHARED_STORE(i64_store32_shared, u32, u64)
     t1 result;                                                              \
     wasm_rt_memcpy(&result, MEM_ADDR_MEMOP(mem, addr, sizeof(t1)),          \
                    sizeof(t1));                                             \
-    force_read(result);                                                     \
-    return (t3)(t2)result;                                                  \
+    t3 ret = (t3)(t2)result;                                                \
+    force_read(ret);                                                        \
+    return ret;                                                             \
   }                                                                         \
   DEF_MEM_CHECKS0(name, _, t1, return, t3)                                  \
   static inline t3 name##_shared_unchecked(wasm_rt_shared_memory_t* mem,    \
@@ -71,8 +73,9 @@ DEFINE_SHARED_STORE(i64_store32_shared, u32, u64)
     t1 result;                                                              \
     result =                                                                \
         atomic_load((_Atomic volatile t1*)MEM_ADDR(mem, addr, sizeof(t1))); \
-    force_read(result);                                                     \
-    return (t3)(t2)result;                                                  \
+    t3 ret = (t3)(t2)result;                                                \
+    force_read(ret);                                                        \
+    return ret;                                                             \
   }                                                                         \
   DEF_MEM_CHECKS0(name##_shared, _shared_, t1, return, t3)
 

--- a/test/wasm2c/add.txt
+++ b/test/wasm2c/add.txt
@@ -223,14 +223,35 @@ static inline uint64_t checked_add_u64(uint64_t a, uint64_t b) {
 // trap checks are applied in the right place, and not optimized away.
 #ifdef __GNUC__
 #define FORCE_READ_INT(var) __asm__("" ::"r"(var));
-// Clang on Mips requires "f" constraints on floats
-// See https://github.com/llvm/llvm-project/issues/64241
-#if defined(__clang__) && \
-    (defined(mips) || defined(__mips__) || defined(__mips))
-#define FORCE_READ_FLOAT(var) __asm__("" ::"f"(var));
-#else
-#define FORCE_READ_FLOAT(var) __asm__("" ::"r"(var));
+
+#if defined(__i386__) || defined(__x86_64__)
+#if defined(__SSE__)
+#define FORCE_READ_FLOAT_CONSTRAINT "x"
+#else  // No SSE, old x87
+#define FORCE_READ_FLOAT_CONSTRAINT "f"
 #endif
+#elif (defined(__arm__) || defined(__aarch64__)) && defined(__ARM_FP) && \
+    ((__ARM_FP & 0x4) != 0)
+#ifdef __aarch64__
+#define FORCE_READ_FLOAT_CONSTRAINT "w"
+#else
+#define FORCE_READ_FLOAT_CONSTRAINT "t"
+#endif
+#elif defined(__mips__) && defined(__clang__) && !defined(__mips_soft_float)
+// Clang before v18 uses hard floats which has a different constraint
+#define FORCE_READ_FLOAT_CONSTRAINT "f"
+#elif (defined(__powerpc__) || defined(__ppc__) || defined(__PPC__)) || \
+    !(defined(_SOFT_FLOAT) || defined(__NO_FPRS__))
+#define FORCE_READ_FLOAT_CONSTRAINT "f"
+#elif defined(__riscv) && defined(__riscv_flen) && (__riscv_flen >= 32)
+#define FORCE_READ_FLOAT_CONSTRAINT "f"
+#elif defined(__s390__) || defined(__s390x__)
+#define FORCE_READ_FLOAT_CONSTRAINT "f"
+#else
+#define FORCE_READ_FLOAT_CONSTRAINT "r"
+#endif
+
+#define FORCE_READ_FLOAT(var) __asm__("" ::FORCE_READ_FLOAT_CONSTRAINT(var));
 #endif
 
 #else
@@ -315,8 +336,9 @@ static inline void load_data(u8* dest, const u8* src, size_t n) {
     t1 result;                                                         \
     wasm_rt_memcpy(&result, MEM_ADDR_MEMOP(mem, addr, sizeof(t1)),     \
                    sizeof(t1));                                        \
-    force_read(result);                                                \
-    return (t3)(t2)result;                                             \
+    t3 ret = (t3)(t2)result;                                           \
+    force_read(ret);                                                   \
+    return ret;                                                        \
   }                                                                    \
   DEF_MEM_CHECKS0(name, _, t1, return, t3)
 

--- a/test/wasm2c/check-imports.txt
+++ b/test/wasm2c/check-imports.txt
@@ -248,14 +248,35 @@ static inline uint64_t checked_add_u64(uint64_t a, uint64_t b) {
 // trap checks are applied in the right place, and not optimized away.
 #ifdef __GNUC__
 #define FORCE_READ_INT(var) __asm__("" ::"r"(var));
-// Clang on Mips requires "f" constraints on floats
-// See https://github.com/llvm/llvm-project/issues/64241
-#if defined(__clang__) && \
-    (defined(mips) || defined(__mips__) || defined(__mips))
-#define FORCE_READ_FLOAT(var) __asm__("" ::"f"(var));
-#else
-#define FORCE_READ_FLOAT(var) __asm__("" ::"r"(var));
+
+#if defined(__i386__) || defined(__x86_64__)
+#if defined(__SSE__)
+#define FORCE_READ_FLOAT_CONSTRAINT "x"
+#else  // No SSE, old x87
+#define FORCE_READ_FLOAT_CONSTRAINT "f"
 #endif
+#elif (defined(__arm__) || defined(__aarch64__)) && defined(__ARM_FP) && \
+    ((__ARM_FP & 0x4) != 0)
+#ifdef __aarch64__
+#define FORCE_READ_FLOAT_CONSTRAINT "w"
+#else
+#define FORCE_READ_FLOAT_CONSTRAINT "t"
+#endif
+#elif defined(__mips__) && defined(__clang__) && !defined(__mips_soft_float)
+// Clang before v18 uses hard floats which has a different constraint
+#define FORCE_READ_FLOAT_CONSTRAINT "f"
+#elif (defined(__powerpc__) || defined(__ppc__) || defined(__PPC__)) || \
+    !(defined(_SOFT_FLOAT) || defined(__NO_FPRS__))
+#define FORCE_READ_FLOAT_CONSTRAINT "f"
+#elif defined(__riscv) && defined(__riscv_flen) && (__riscv_flen >= 32)
+#define FORCE_READ_FLOAT_CONSTRAINT "f"
+#elif defined(__s390__) || defined(__s390x__)
+#define FORCE_READ_FLOAT_CONSTRAINT "f"
+#else
+#define FORCE_READ_FLOAT_CONSTRAINT "r"
+#endif
+
+#define FORCE_READ_FLOAT(var) __asm__("" ::FORCE_READ_FLOAT_CONSTRAINT(var));
 #endif
 
 #else
@@ -340,8 +361,9 @@ static inline void load_data(u8* dest, const u8* src, size_t n) {
     t1 result;                                                         \
     wasm_rt_memcpy(&result, MEM_ADDR_MEMOP(mem, addr, sizeof(t1)),     \
                    sizeof(t1));                                        \
-    force_read(result);                                                \
-    return (t3)(t2)result;                                             \
+    t3 ret = (t3)(t2)result;                                           \
+    force_read(ret);                                                   \
+    return ret;                                                        \
   }                                                                    \
   DEF_MEM_CHECKS0(name, _, t1, return, t3)
 

--- a/test/wasm2c/export-names.txt
+++ b/test/wasm2c/export-names.txt
@@ -248,14 +248,35 @@ static inline uint64_t checked_add_u64(uint64_t a, uint64_t b) {
 // trap checks are applied in the right place, and not optimized away.
 #ifdef __GNUC__
 #define FORCE_READ_INT(var) __asm__("" ::"r"(var));
-// Clang on Mips requires "f" constraints on floats
-// See https://github.com/llvm/llvm-project/issues/64241
-#if defined(__clang__) && \
-    (defined(mips) || defined(__mips__) || defined(__mips))
-#define FORCE_READ_FLOAT(var) __asm__("" ::"f"(var));
-#else
-#define FORCE_READ_FLOAT(var) __asm__("" ::"r"(var));
+
+#if defined(__i386__) || defined(__x86_64__)
+#if defined(__SSE__)
+#define FORCE_READ_FLOAT_CONSTRAINT "x"
+#else  // No SSE, old x87
+#define FORCE_READ_FLOAT_CONSTRAINT "f"
 #endif
+#elif (defined(__arm__) || defined(__aarch64__)) && defined(__ARM_FP) && \
+    ((__ARM_FP & 0x4) != 0)
+#ifdef __aarch64__
+#define FORCE_READ_FLOAT_CONSTRAINT "w"
+#else
+#define FORCE_READ_FLOAT_CONSTRAINT "t"
+#endif
+#elif defined(__mips__) && defined(__clang__) && !defined(__mips_soft_float)
+// Clang before v18 uses hard floats which has a different constraint
+#define FORCE_READ_FLOAT_CONSTRAINT "f"
+#elif (defined(__powerpc__) || defined(__ppc__) || defined(__PPC__)) || \
+    !(defined(_SOFT_FLOAT) || defined(__NO_FPRS__))
+#define FORCE_READ_FLOAT_CONSTRAINT "f"
+#elif defined(__riscv) && defined(__riscv_flen) && (__riscv_flen >= 32)
+#define FORCE_READ_FLOAT_CONSTRAINT "f"
+#elif defined(__s390__) || defined(__s390x__)
+#define FORCE_READ_FLOAT_CONSTRAINT "f"
+#else
+#define FORCE_READ_FLOAT_CONSTRAINT "r"
+#endif
+
+#define FORCE_READ_FLOAT(var) __asm__("" ::FORCE_READ_FLOAT_CONSTRAINT(var));
 #endif
 
 #else
@@ -340,8 +361,9 @@ static inline void load_data(u8* dest, const u8* src, size_t n) {
     t1 result;                                                         \
     wasm_rt_memcpy(&result, MEM_ADDR_MEMOP(mem, addr, sizeof(t1)),     \
                    sizeof(t1));                                        \
-    force_read(result);                                                \
-    return (t3)(t2)result;                                             \
+    t3 ret = (t3)(t2)result;                                           \
+    force_read(ret);                                                   \
+    return ret;                                                        \
   }                                                                    \
   DEF_MEM_CHECKS0(name, _, t1, return, t3)
 

--- a/test/wasm2c/hello.txt
+++ b/test/wasm2c/hello.txt
@@ -255,14 +255,35 @@ static inline uint64_t checked_add_u64(uint64_t a, uint64_t b) {
 // trap checks are applied in the right place, and not optimized away.
 #ifdef __GNUC__
 #define FORCE_READ_INT(var) __asm__("" ::"r"(var));
-// Clang on Mips requires "f" constraints on floats
-// See https://github.com/llvm/llvm-project/issues/64241
-#if defined(__clang__) && \
-    (defined(mips) || defined(__mips__) || defined(__mips))
-#define FORCE_READ_FLOAT(var) __asm__("" ::"f"(var));
-#else
-#define FORCE_READ_FLOAT(var) __asm__("" ::"r"(var));
+
+#if defined(__i386__) || defined(__x86_64__)
+#if defined(__SSE__)
+#define FORCE_READ_FLOAT_CONSTRAINT "x"
+#else  // No SSE, old x87
+#define FORCE_READ_FLOAT_CONSTRAINT "f"
 #endif
+#elif (defined(__arm__) || defined(__aarch64__)) && defined(__ARM_FP) && \
+    ((__ARM_FP & 0x4) != 0)
+#ifdef __aarch64__
+#define FORCE_READ_FLOAT_CONSTRAINT "w"
+#else
+#define FORCE_READ_FLOAT_CONSTRAINT "t"
+#endif
+#elif defined(__mips__) && defined(__clang__) && !defined(__mips_soft_float)
+// Clang before v18 uses hard floats which has a different constraint
+#define FORCE_READ_FLOAT_CONSTRAINT "f"
+#elif (defined(__powerpc__) || defined(__ppc__) || defined(__PPC__)) || \
+    !(defined(_SOFT_FLOAT) || defined(__NO_FPRS__))
+#define FORCE_READ_FLOAT_CONSTRAINT "f"
+#elif defined(__riscv) && defined(__riscv_flen) && (__riscv_flen >= 32)
+#define FORCE_READ_FLOAT_CONSTRAINT "f"
+#elif defined(__s390__) || defined(__s390x__)
+#define FORCE_READ_FLOAT_CONSTRAINT "f"
+#else
+#define FORCE_READ_FLOAT_CONSTRAINT "r"
+#endif
+
+#define FORCE_READ_FLOAT(var) __asm__("" ::FORCE_READ_FLOAT_CONSTRAINT(var));
 #endif
 
 #else
@@ -347,8 +368,9 @@ static inline void load_data(u8* dest, const u8* src, size_t n) {
     t1 result;                                                         \
     wasm_rt_memcpy(&result, MEM_ADDR_MEMOP(mem, addr, sizeof(t1)),     \
                    sizeof(t1));                                        \
-    force_read(result);                                                \
-    return (t3)(t2)result;                                             \
+    t3 ret = (t3)(t2)result;                                           \
+    force_read(ret);                                                   \
+    return ret;                                                        \
   }                                                                    \
   DEF_MEM_CHECKS0(name, _, t1, return, t3)
 

--- a/test/wasm2c/minimal.txt
+++ b/test/wasm2c/minimal.txt
@@ -217,14 +217,35 @@ static inline uint64_t checked_add_u64(uint64_t a, uint64_t b) {
 // trap checks are applied in the right place, and not optimized away.
 #ifdef __GNUC__
 #define FORCE_READ_INT(var) __asm__("" ::"r"(var));
-// Clang on Mips requires "f" constraints on floats
-// See https://github.com/llvm/llvm-project/issues/64241
-#if defined(__clang__) && \
-    (defined(mips) || defined(__mips__) || defined(__mips))
-#define FORCE_READ_FLOAT(var) __asm__("" ::"f"(var));
-#else
-#define FORCE_READ_FLOAT(var) __asm__("" ::"r"(var));
+
+#if defined(__i386__) || defined(__x86_64__)
+#if defined(__SSE__)
+#define FORCE_READ_FLOAT_CONSTRAINT "x"
+#else  // No SSE, old x87
+#define FORCE_READ_FLOAT_CONSTRAINT "f"
 #endif
+#elif (defined(__arm__) || defined(__aarch64__)) && defined(__ARM_FP) && \
+    ((__ARM_FP & 0x4) != 0)
+#ifdef __aarch64__
+#define FORCE_READ_FLOAT_CONSTRAINT "w"
+#else
+#define FORCE_READ_FLOAT_CONSTRAINT "t"
+#endif
+#elif defined(__mips__) && defined(__clang__) && !defined(__mips_soft_float)
+// Clang before v18 uses hard floats which has a different constraint
+#define FORCE_READ_FLOAT_CONSTRAINT "f"
+#elif (defined(__powerpc__) || defined(__ppc__) || defined(__PPC__)) || \
+    !(defined(_SOFT_FLOAT) || defined(__NO_FPRS__))
+#define FORCE_READ_FLOAT_CONSTRAINT "f"
+#elif defined(__riscv) && defined(__riscv_flen) && (__riscv_flen >= 32)
+#define FORCE_READ_FLOAT_CONSTRAINT "f"
+#elif defined(__s390__) || defined(__s390x__)
+#define FORCE_READ_FLOAT_CONSTRAINT "f"
+#else
+#define FORCE_READ_FLOAT_CONSTRAINT "r"
+#endif
+
+#define FORCE_READ_FLOAT(var) __asm__("" ::FORCE_READ_FLOAT_CONSTRAINT(var));
 #endif
 
 #else
@@ -309,8 +330,9 @@ static inline void load_data(u8* dest, const u8* src, size_t n) {
     t1 result;                                                         \
     wasm_rt_memcpy(&result, MEM_ADDR_MEMOP(mem, addr, sizeof(t1)),     \
                    sizeof(t1));                                        \
-    force_read(result);                                                \
-    return (t3)(t2)result;                                             \
+    t3 ret = (t3)(t2)result;                                           \
+    force_read(ret);                                                   \
+    return ret;                                                        \
   }                                                                    \
   DEF_MEM_CHECKS0(name, _, t1, return, t3)
 

--- a/test/wasm2c/tail-calls.txt
+++ b/test/wasm2c/tail-calls.txt
@@ -247,14 +247,35 @@ static inline uint64_t checked_add_u64(uint64_t a, uint64_t b) {
 // trap checks are applied in the right place, and not optimized away.
 #ifdef __GNUC__
 #define FORCE_READ_INT(var) __asm__("" ::"r"(var));
-// Clang on Mips requires "f" constraints on floats
-// See https://github.com/llvm/llvm-project/issues/64241
-#if defined(__clang__) && \
-    (defined(mips) || defined(__mips__) || defined(__mips))
-#define FORCE_READ_FLOAT(var) __asm__("" ::"f"(var));
-#else
-#define FORCE_READ_FLOAT(var) __asm__("" ::"r"(var));
+
+#if defined(__i386__) || defined(__x86_64__)
+#if defined(__SSE__)
+#define FORCE_READ_FLOAT_CONSTRAINT "x"
+#else  // No SSE, old x87
+#define FORCE_READ_FLOAT_CONSTRAINT "f"
 #endif
+#elif (defined(__arm__) || defined(__aarch64__)) && defined(__ARM_FP) && \
+    ((__ARM_FP & 0x4) != 0)
+#ifdef __aarch64__
+#define FORCE_READ_FLOAT_CONSTRAINT "w"
+#else
+#define FORCE_READ_FLOAT_CONSTRAINT "t"
+#endif
+#elif defined(__mips__) && defined(__clang__) && !defined(__mips_soft_float)
+// Clang before v18 uses hard floats which has a different constraint
+#define FORCE_READ_FLOAT_CONSTRAINT "f"
+#elif (defined(__powerpc__) || defined(__ppc__) || defined(__PPC__)) || \
+    !(defined(_SOFT_FLOAT) || defined(__NO_FPRS__))
+#define FORCE_READ_FLOAT_CONSTRAINT "f"
+#elif defined(__riscv) && defined(__riscv_flen) && (__riscv_flen >= 32)
+#define FORCE_READ_FLOAT_CONSTRAINT "f"
+#elif defined(__s390__) || defined(__s390x__)
+#define FORCE_READ_FLOAT_CONSTRAINT "f"
+#else
+#define FORCE_READ_FLOAT_CONSTRAINT "r"
+#endif
+
+#define FORCE_READ_FLOAT(var) __asm__("" ::FORCE_READ_FLOAT_CONSTRAINT(var));
 #endif
 
 #else
@@ -339,8 +360,9 @@ static inline void load_data(u8* dest, const u8* src, size_t n) {
     t1 result;                                                         \
     wasm_rt_memcpy(&result, MEM_ADDR_MEMOP(mem, addr, sizeof(t1)),     \
                    sizeof(t1));                                        \
-    force_read(result);                                                \
-    return (t3)(t2)result;                                             \
+    t3 ret = (t3)(t2)result;                                           \
+    force_read(ret);                                                   \
+    return ret;                                                        \
   }                                                                    \
   DEF_MEM_CHECKS0(name, _, t1, return, t3)
 


### PR DESCRIPTION
wasm2c's `FORCE_READ_*` macros allow spec compliance when using guard pages by preventing elimination of potentially trapping loads, but introduces several low-level performance issues in the generated code.

1. It prevents load followed by a modification to be prevented from being combined into a “load with modification”. This occurs in one the libraries sandboxed by Firefox. The library loads a byte and extends it to 32-bits before processing it --- all in tight loop. Since wasm2c's load byte corresponds to the following code

    ```
    u8 result;
    memcpy(&result, &mem[addr], sizeof(u8)); 
    __asm__("" ::"r"(result)); 
    return (u32) result;
    ```
  
    the generated assembly first performs a load with 32-bit load shifted to a byte, sends the byte result to the asm block, and then performs a widening. However a faster option here, is to just read the byte whie sign extending it, and then consume the sign extended result. This only requires moving the last cast prior to the asm. This simple change speeds up this  library by 3%.

2. The force_read currently uses the general purpose register "r" for force_read_float. This forces C compilers to emit an expensive float-register to int-register conversion on most architectures. The result of this is roughly an extra 7% overhead when running a sandboxed libsoundtouch which is used by Firefox to adjust the playback speed of audio files.
