### PR TITLE
Fix float argument types in wasm-interp --run-export

### DIFF
--- a/src/tools/wasm-interp.cc
+++ b/src/tools/wasm-interp.cc
@@ -123,12 +123,12 @@ Result ParseWasmValue(std::string argument, Value& val) {
   if (strcmp(ptype, "f32") == 0) {
     uint32_t parsed_value;
     result |= ParseFloat(LiteralType::Float, pval, pval_end, &parsed_value);
-    val.Set(parsed_value);
+    val.Set(Bitcast<f32>(parsed_value));
   }
   if (strcmp(ptype, "f64") == 0) {
     uint64_t parsed_value;
     result |= ParseDouble(LiteralType::Float, pval, pval_end, &parsed_value);
-    val.Set(parsed_value);
+    val.Set(Bitcast<f64>(parsed_value));
   }
   return result;
 }

--- a/test/interp/run-export-with-float-arguments.txt
+++ b/test/interp/run-export-with-float-arguments.txt
@@ -1,0 +1,17 @@
+;;; TOOL: run-interp
+;;; ARGS1: --run-export=f32_add --argument=f32:1.5 --argument=f32:2.25 --run-export=f64_add --argument=f64:1.5 --argument=f64:2.25
+(module
+  (func (export "f32_add") (param f32 f32) (result f32)
+    local.get 0
+    local.get 1
+    f32.add)
+
+  (func (export "f64_add") (param f64 f64) (result f64)
+    local.get 0
+    local.get 1
+    f64.add)
+)
+(;; STDOUT ;;;
+f32_add(f32:1.500000, f32:2.250000) => f32:3.750000
+f64_add(f64:1.500000, f64:2.250000) => f64:3.750000
+;;; STDOUT ;;)


### PR DESCRIPTION
Fixes #2664.

`ParseFloat` and `ParseDouble` return the IEEE-754 bit pattern in an unsigned integer. `ParseWasmValue` passed those integers directly to `Value::Set`, so debug builds tagged `f32`/`f64` command-line arguments as `i32`/`i64`. The interpreter then failed its value-stack type check as soon as the exported function consumed an argument.

Bitcast the parsed bits to the corresponding floating-point type before storing them. This preserves both the value and the interpreter type tag.

A CLI regression test covers both `f32` and `f64` arguments.

Validation:

- The original #2664 reproduction now completes successfully.
- `python3 test/run-tests.py interp/run-export-with-float-arguments --bindir=build -v`
- `python3 test/run-tests.py interp --bindir=build -j4`
- `./build/wabt-unittests` (135 tests passed)