### PR TITLE
wasm2c: reject contradictory imports instead of aborting

### DIFF
--- a/src/c-writer.cc
+++ b/src/c-writer.cc
@@ -378,7 +378,7 @@ class CWriter {
   void Write(const FuncTypeExpr&);
   void WriteTagDecls();
   void WriteTags();
-  void ComputeUniqueImports();
+  Result ComputeUniqueImports();
   void BeginInstance();
   void WriteImports();
   void WriteTailCallWeakImports();
@@ -1810,7 +1810,7 @@ void CWriter::WriteTags() {
   }
 }
 
-void CWriter::ComputeUniqueImports() {
+Result CWriter::ComputeUniqueImports() {
   using modname_name_pair = std::pair<std::string, std::string>;
   std::map<modname_name_pair, const Import*> import_map;
   for (const Import* import : module_->imports) {
@@ -1821,7 +1821,13 @@ void CWriter::ComputeUniqueImports() {
         modname_name_pair(import->module_name, import->field_name), import);
     if (!iterator_and_insertion_bool.second) {
       if (iterator_and_insertion_bool.first->second->kind() != import->kind()) {
-        UNIMPLEMENTED("contradictory import declaration");
+        fprintf(stderr,
+                "error: contradictory import declaration: \"%s\".\"%s\" is "
+                "imported as both a %s and a %s\n",
+                import->module_name.c_str(), import->field_name.c_str(),
+                GetKindName(iterator_and_insertion_bool.first->second->kind()),
+                GetKindName(import->kind()));
+        return Result::Error;
       } else {
         fprintf(stderr, "warning: duplicate import declaration \"%s\" \"%s\"\n",
                 import->module_name.c_str(), import->field_name.c_str());
@@ -1838,6 +1844,7 @@ void CWriter::ComputeUniqueImports() {
   for (const auto& node : import_map) {
     unique_imports_.push_back(node.second);
   }
+  return Result::Ok;
 }
 
 void CWriter::BeginInstance() {
@@ -1845,8 +1852,6 @@ void CWriter::BeginInstance() {
     Write("typedef struct ", ModuleInstanceTypeName(), " ", OpenBrace());
     return;
   }
-
-  ComputeUniqueImports();
 
   // define names of per-instance imports
   for (const Import* import : module_->imports) {
@@ -6193,6 +6198,9 @@ void CWriter::WriteCSource() {
 Result CWriter::WriteModule(const Module& module) {
   WABT_USE(options_);
   module_ = &module;
+
+  CHECK_RESULT(ComputeUniqueImports());
+
   WriteCHeader();
   WriteCSource();
   return result_;

--- a/src/c-writer.cc
+++ b/src/c-writer.cc
@@ -1811,6 +1811,11 @@ void CWriter::WriteTags() {
 }
 
 Result CWriter::ComputeUniqueImports() {
+  unique_imports_.clear();
+  import_module_set_.clear();
+  import_func_module_set_.clear();
+  import_func_module_map_.clear();
+
   using modname_name_pair = std::pair<std::string, std::string>;
   std::map<modname_name_pair, const Import*> import_map;
   for (const Import* import : module_->imports) {
@@ -1850,6 +1855,10 @@ Result CWriter::ComputeUniqueImports() {
 void CWriter::BeginInstance() {
   if (module_->imports.empty()) {
     Write("typedef struct ", ModuleInstanceTypeName(), " ", OpenBrace());
+    return;
+  }
+
+  if (Failed(ComputeUniqueImports())) {
     return;
   }
 

--- a/src/c-writer.cc
+++ b/src/c-writer.cc
@@ -1859,6 +1859,7 @@ void CWriter::BeginInstance() {
   }
 
   if (Failed(ComputeUniqueImports())) {
+    result_ = Result::Error;
     return;
   }
 
@@ -2133,6 +2134,9 @@ void CWriter::WriteV128Decl() {
 
 void CWriter::WriteModuleInstance() {
   BeginInstance();
+  if (Failed(result_)) {
+    return;
+  }
   WriteGlobals();
   WriteMemories();
   WriteTables();
@@ -6145,6 +6149,9 @@ void CWriter::WriteCHeader() {
   Write(s_header_top);
   Write(Newline());
   WriteModuleInstance();
+  if (Failed(result_)) {
+    return;
+  }
   WriteInitDecl();
   WriteFreeDecl();
   WriteGetFuncTypeDecl();
@@ -6208,9 +6215,10 @@ Result CWriter::WriteModule(const Module& module) {
   WABT_USE(options_);
   module_ = &module;
 
-  CHECK_RESULT(ComputeUniqueImports());
-
   WriteCHeader();
+  if (Failed(result_)) {
+    return result_;
+  }
   WriteCSource();
   return result_;
 }

--- a/src/c-writer.cc
+++ b/src/c-writer.cc
@@ -1811,11 +1811,6 @@ void CWriter::WriteTags() {
 }
 
 Result CWriter::ComputeUniqueImports() {
-  unique_imports_.clear();
-  import_module_set_.clear();
-  import_func_module_set_.clear();
-  import_func_module_map_.clear();
-
   using modname_name_pair = std::pair<std::string, std::string>;
   std::map<modname_name_pair, const Import*> import_map;
   for (const Import* import : module_->imports) {

--- a/test/wasm2c/contradictory-imports.txt
+++ b/test/wasm2c/contradictory-imports.txt
@@ -1,0 +1,9 @@
+;;; RUN: %(wat2wasm)s %(in_file)s -o %(temp_file)s.wasm
+;;; RUN: %(wasm2c)s %(temp_file)s.wasm -o %(temp_file)s.c
+;;; ERROR: 1
+(module
+  (import "e" "x" (func))
+  (import "e" "x" (global i32)))
+(;; STDERR ;;;
+error: contradictory import declaration: "e"."x" is imported as both a func and a global
+;;; STDERR ;;)


### PR DESCRIPTION

Fixes #2751

## Summary
- Replace `UNIMPLEMENTED("contradictory import declaration")` with a stderr diagnostic and `Result::Error`
- Preflight `ComputeUniqueImports()` at the start of `WriteModule()` so codegen never runs on unlinkable modules
- Add `test/wasm2c/contradictory-imports.txt`

## Test plan
- [x] Manual: `wasm2c dup.wasm` exits 1 with error message (no abort)
- [x] `python3 test/run-tests.py test/wasm2c/contradictory-imports.txt`
- [x] `python3 test/run-tests.py test/wasm2c/`
- [x] `./out/wabt-unittests`


<img width="1031" height="142" alt="image" src="https://github.com/user-attachments/assets/4ad11801-1900-4982-96a3-3d6062cc2a33" />

