### PR TITLE
wasm2c: Remove unnecessary force_read in bounds check mode for performance

### DIFF
--- a/src/prebuilt/wasm2c_simd_source_declarations.cc
+++ b/src/prebuilt/wasm2c_simd_source_declarations.cc
@@ -1,8 +1,12 @@
-const char* s_simd_source_declarations = R"w2c_template(#if defined(__GNUC__) && defined(__x86_64__)
+const char* s_simd_source_declarations = R"w2c_template(#if WASM_RT_MEMCHECK_GUARD_PAGES
+)w2c_template"
+R"w2c_template(#ifdef __GNUC__
+)w2c_template"
+R"w2c_template(#if defined(__x86_64__)
 )w2c_template"
 R"w2c_template(#define SIMD_FORCE_READ(var) __asm__("" ::"x"(var));
 )w2c_template"
-R"w2c_template(#elif defined(__GNUC__) && defined(__aarch64__)
+R"w2c_template(#elif defined(__aarch64__)
 )w2c_template"
 R"w2c_template(#define SIMD_FORCE_READ(var) __asm__("" ::"w"(var));
 )w2c_template"
@@ -10,13 +14,21 @@ R"w2c_template(#elif defined(__s390x__)
 )w2c_template"
 R"w2c_template(#define SIMD_FORCE_READ(var) __asm__("" ::"d"(var));
 )w2c_template"
-R"w2c_template(#else
+R"w2c_template(#endif
+)w2c_template"
+R"w2c_template(#endif
+)w2c_template"
+R"w2c_template(#endif
+)w2c_template"
+R"w2c_template(
+#ifndef SIMD_FORCE_READ
 )w2c_template"
 R"w2c_template(#define SIMD_FORCE_READ(var)
 )w2c_template"
 R"w2c_template(#endif
 )w2c_template"
-R"w2c_template(// TODO: equivalent constraint for ARM and other architectures
+R"w2c_template(
+// TODO: equivalent constraint for ARM and other architectures
 )w2c_template"
 R"w2c_template(
 // The below SIMD operations copy to a local variable first as the

--- a/src/prebuilt/wasm2c_source_declarations.cc
+++ b/src/prebuilt/wasm2c_source_declarations.cc
@@ -285,7 +285,35 @@ R"w2c_template(#if WASM_RT_MEMCHECK_GUARD_PAGES
 )w2c_template"
 R"w2c_template(#define MEMCHECK_DEFAULT32(mem, a, t) WASM_RT_CHECK_BASE(mem);
 )w2c_template"
+R"w2c_template(
+// When using guard pages, reads have to be immediately consumed so that OOB
+)w2c_template"
+R"w2c_template(// trap checks are applied in the right place, and not optimized away.
+)w2c_template"
+R"w2c_template(#ifdef __GNUC__
+)w2c_template"
+R"w2c_template(#define FORCE_READ_INT(var) __asm__("" ::"r"(var));
+)w2c_template"
+R"w2c_template(// Clang on Mips requires "f" constraints on floats
+)w2c_template"
+R"w2c_template(// See https://github.com/llvm/llvm-project/issues/64241
+)w2c_template"
+R"w2c_template(#if defined(__clang__) && \
+)w2c_template"
+R"w2c_template(    (defined(mips) || defined(__mips__) || defined(__mips))
+)w2c_template"
+R"w2c_template(#define FORCE_READ_FLOAT(var) __asm__("" ::"f"(var));
+)w2c_template"
 R"w2c_template(#else
+)w2c_template"
+R"w2c_template(#define FORCE_READ_FLOAT(var) __asm__("" ::"r"(var));
+)w2c_template"
+R"w2c_template(#endif
+)w2c_template"
+R"w2c_template(#endif
+)w2c_template"
+R"w2c_template(
+#else
 )w2c_template"
 R"w2c_template(#define MEMCHECK_DEFAULT32(mem, a, t)                \
 )w2c_template"
@@ -307,29 +335,14 @@ R"w2c_template(  WASM_RT_CHECK_BASE(mem);          \
 R"w2c_template(  RANGE_CHECK(mem, a, sizeof(t));
 )w2c_template"
 R"w2c_template(
-#ifdef __GNUC__
+#ifndef FORCE_READ_INT
 )w2c_template"
-R"w2c_template(#define FORCE_READ_INT(var) __asm__("" ::"r"(var));
-)w2c_template"
-R"w2c_template(// Clang on Mips requires "f" constraints on floats
-)w2c_template"
-R"w2c_template(// See https://github.com/llvm/llvm-project/issues/64241
-)w2c_template"
-R"w2c_template(#if defined(__clang__) && \
-)w2c_template"
-R"w2c_template(    (defined(mips) || defined(__mips__) || defined(__mips))
-)w2c_template"
-R"w2c_template(#define FORCE_READ_FLOAT(var) __asm__("" ::"f"(var));
-)w2c_template"
-R"w2c_template(#else
-)w2c_template"
-R"w2c_template(#define FORCE_READ_FLOAT(var) __asm__("" ::"r"(var));
+R"w2c_template(#define FORCE_READ_INT(var)
 )w2c_template"
 R"w2c_template(#endif
 )w2c_template"
-R"w2c_template(#else
-)w2c_template"
-R"w2c_template(#define FORCE_READ_INT(var)
+R"w2c_template(
+#ifndef FORCE_READ_FLOAT
 )w2c_template"
 R"w2c_template(#define FORCE_READ_FLOAT(var)
 )w2c_template"

--- a/src/template/wasm2c.declarations.c
+++ b/src/template/wasm2c.declarations.c
@@ -151,6 +151,21 @@ static inline uint64_t checked_add_u64(uint64_t a, uint64_t b) {
 // or it may do a slightly faster RANGE_CHECK.
 #if WASM_RT_MEMCHECK_GUARD_PAGES
 #define MEMCHECK_DEFAULT32(mem, a, t) WASM_RT_CHECK_BASE(mem);
+
+// When using guard pages, reads have to be immediately consumed so that OOB
+// trap checks are applied in the right place, and not optimized away.
+#ifdef __GNUC__
+#define FORCE_READ_INT(var) __asm__("" ::"r"(var));
+// Clang on Mips requires "f" constraints on floats
+// See https://github.com/llvm/llvm-project/issues/64241
+#if defined(__clang__) && \
+    (defined(mips) || defined(__mips__) || defined(__mips))
+#define FORCE_READ_FLOAT(var) __asm__("" ::"f"(var));
+#else
+#define FORCE_READ_FLOAT(var) __asm__("" ::"r"(var));
+#endif
+#endif
+
 #else
 #define MEMCHECK_DEFAULT32(mem, a, t)                \
   WASM_RT_CHECK_BASE(mem);                           \
@@ -163,18 +178,11 @@ static inline uint64_t checked_add_u64(uint64_t a, uint64_t b) {
   WASM_RT_CHECK_BASE(mem);          \
   RANGE_CHECK(mem, a, sizeof(t));
 
-#ifdef __GNUC__
-#define FORCE_READ_INT(var) __asm__("" ::"r"(var));
-// Clang on Mips requires "f" constraints on floats
-// See https://github.com/llvm/llvm-project/issues/64241
-#if defined(__clang__) && \
-    (defined(mips) || defined(__mips__) || defined(__mips))
-#define FORCE_READ_FLOAT(var) __asm__("" ::"f"(var));
-#else
-#define FORCE_READ_FLOAT(var) __asm__("" ::"r"(var));
-#endif
-#else
+#ifndef FORCE_READ_INT
 #define FORCE_READ_INT(var)
+#endif
+
+#ifndef FORCE_READ_FLOAT
 #define FORCE_READ_FLOAT(var)
 #endif
 

--- a/src/template/wasm2c_simd.declarations.c
+++ b/src/template/wasm2c_simd.declarations.c
@@ -1,12 +1,19 @@
-#if defined(__GNUC__) && defined(__x86_64__)
+#if WASM_RT_MEMCHECK_GUARD_PAGES
+#ifdef __GNUC__
+#if defined(__x86_64__)
 #define SIMD_FORCE_READ(var) __asm__("" ::"x"(var));
-#elif defined(__GNUC__) && defined(__aarch64__)
+#elif defined(__aarch64__)
 #define SIMD_FORCE_READ(var) __asm__("" ::"w"(var));
 #elif defined(__s390x__)
 #define SIMD_FORCE_READ(var) __asm__("" ::"d"(var));
-#else
+#endif
+#endif
+#endif
+
+#ifndef SIMD_FORCE_READ
 #define SIMD_FORCE_READ(var)
 #endif
+
 // TODO: equivalent constraint for ARM and other architectures
 
 // The below SIMD operations copy to a local variable first as the

--- a/test/wasm2c/add.txt
+++ b/test/wasm2c/add.txt
@@ -218,6 +218,21 @@ static inline uint64_t checked_add_u64(uint64_t a, uint64_t b) {
 // or it may do a slightly faster RANGE_CHECK.
 #if WASM_RT_MEMCHECK_GUARD_PAGES
 #define MEMCHECK_DEFAULT32(mem, a, t) WASM_RT_CHECK_BASE(mem);
+
+// When using guard pages, reads have to be immediately consumed so that OOB
+// trap checks are applied in the right place, and not optimized away.
+#ifdef __GNUC__
+#define FORCE_READ_INT(var) __asm__("" ::"r"(var));
+// Clang on Mips requires "f" constraints on floats
+// See https://github.com/llvm/llvm-project/issues/64241
+#if defined(__clang__) && \
+    (defined(mips) || defined(__mips__) || defined(__mips))
+#define FORCE_READ_FLOAT(var) __asm__("" ::"f"(var));
+#else
+#define FORCE_READ_FLOAT(var) __asm__("" ::"r"(var));
+#endif
+#endif
+
 #else
 #define MEMCHECK_DEFAULT32(mem, a, t)                \
   WASM_RT_CHECK_BASE(mem);                           \
@@ -230,18 +245,11 @@ static inline uint64_t checked_add_u64(uint64_t a, uint64_t b) {
   WASM_RT_CHECK_BASE(mem);          \
   RANGE_CHECK(mem, a, sizeof(t));
 
-#ifdef __GNUC__
-#define FORCE_READ_INT(var) __asm__("" ::"r"(var));
-// Clang on Mips requires "f" constraints on floats
-// See https://github.com/llvm/llvm-project/issues/64241
-#if defined(__clang__) && \
-    (defined(mips) || defined(__mips__) || defined(__mips))
-#define FORCE_READ_FLOAT(var) __asm__("" ::"f"(var));
-#else
-#define FORCE_READ_FLOAT(var) __asm__("" ::"r"(var));
-#endif
-#else
+#ifndef FORCE_READ_INT
 #define FORCE_READ_INT(var)
+#endif
+
+#ifndef FORCE_READ_FLOAT
 #define FORCE_READ_FLOAT(var)
 #endif
 

--- a/test/wasm2c/check-imports.txt
+++ b/test/wasm2c/check-imports.txt
@@ -243,6 +243,21 @@ static inline uint64_t checked_add_u64(uint64_t a, uint64_t b) {
 // or it may do a slightly faster RANGE_CHECK.
 #if WASM_RT_MEMCHECK_GUARD_PAGES
 #define MEMCHECK_DEFAULT32(mem, a, t) WASM_RT_CHECK_BASE(mem);
+
+// When using guard pages, reads have to be immediately consumed so that OOB
+// trap checks are applied in the right place, and not optimized away.
+#ifdef __GNUC__
+#define FORCE_READ_INT(var) __asm__("" ::"r"(var));
+// Clang on Mips requires "f" constraints on floats
+// See https://github.com/llvm/llvm-project/issues/64241
+#if defined(__clang__) && \
+    (defined(mips) || defined(__mips__) || defined(__mips))
+#define FORCE_READ_FLOAT(var) __asm__("" ::"f"(var));
+#else
+#define FORCE_READ_FLOAT(var) __asm__("" ::"r"(var));
+#endif
+#endif
+
 #else
 #define MEMCHECK_DEFAULT32(mem, a, t)                \
   WASM_RT_CHECK_BASE(mem);                           \
@@ -255,18 +270,11 @@ static inline uint64_t checked_add_u64(uint64_t a, uint64_t b) {
   WASM_RT_CHECK_BASE(mem);          \
   RANGE_CHECK(mem, a, sizeof(t));
 
-#ifdef __GNUC__
-#define FORCE_READ_INT(var) __asm__("" ::"r"(var));
-// Clang on Mips requires "f" constraints on floats
-// See https://github.com/llvm/llvm-project/issues/64241
-#if defined(__clang__) && \
-    (defined(mips) || defined(__mips__) || defined(__mips))
-#define FORCE_READ_FLOAT(var) __asm__("" ::"f"(var));
-#else
-#define FORCE_READ_FLOAT(var) __asm__("" ::"r"(var));
-#endif
-#else
+#ifndef FORCE_READ_INT
 #define FORCE_READ_INT(var)
+#endif
+
+#ifndef FORCE_READ_FLOAT
 #define FORCE_READ_FLOAT(var)
 #endif
 

--- a/test/wasm2c/export-names.txt
+++ b/test/wasm2c/export-names.txt
@@ -243,6 +243,21 @@ static inline uint64_t checked_add_u64(uint64_t a, uint64_t b) {
 // or it may do a slightly faster RANGE_CHECK.
 #if WASM_RT_MEMCHECK_GUARD_PAGES
 #define MEMCHECK_DEFAULT32(mem, a, t) WASM_RT_CHECK_BASE(mem);
+
+// When using guard pages, reads have to be immediately consumed so that OOB
+// trap checks are applied in the right place, and not optimized away.
+#ifdef __GNUC__
+#define FORCE_READ_INT(var) __asm__("" ::"r"(var));
+// Clang on Mips requires "f" constraints on floats
+// See https://github.com/llvm/llvm-project/issues/64241
+#if defined(__clang__) && \
+    (defined(mips) || defined(__mips__) || defined(__mips))
+#define FORCE_READ_FLOAT(var) __asm__("" ::"f"(var));
+#else
+#define FORCE_READ_FLOAT(var) __asm__("" ::"r"(var));
+#endif
+#endif
+
 #else
 #define MEMCHECK_DEFAULT32(mem, a, t)                \
   WASM_RT_CHECK_BASE(mem);                           \
@@ -255,18 +270,11 @@ static inline uint64_t checked_add_u64(uint64_t a, uint64_t b) {
   WASM_RT_CHECK_BASE(mem);          \
   RANGE_CHECK(mem, a, sizeof(t));
 
-#ifdef __GNUC__
-#define FORCE_READ_INT(var) __asm__("" ::"r"(var));
-// Clang on Mips requires "f" constraints on floats
-// See https://github.com/llvm/llvm-project/issues/64241
-#if defined(__clang__) && \
-    (defined(mips) || defined(__mips__) || defined(__mips))
-#define FORCE_READ_FLOAT(var) __asm__("" ::"f"(var));
-#else
-#define FORCE_READ_FLOAT(var) __asm__("" ::"r"(var));
-#endif
-#else
+#ifndef FORCE_READ_INT
 #define FORCE_READ_INT(var)
+#endif
+
+#ifndef FORCE_READ_FLOAT
 #define FORCE_READ_FLOAT(var)
 #endif
 

--- a/test/wasm2c/hello.txt
+++ b/test/wasm2c/hello.txt
@@ -250,6 +250,21 @@ static inline uint64_t checked_add_u64(uint64_t a, uint64_t b) {
 // or it may do a slightly faster RANGE_CHECK.
 #if WASM_RT_MEMCHECK_GUARD_PAGES
 #define MEMCHECK_DEFAULT32(mem, a, t) WASM_RT_CHECK_BASE(mem);
+
+// When using guard pages, reads have to be immediately consumed so that OOB
+// trap checks are applied in the right place, and not optimized away.
+#ifdef __GNUC__
+#define FORCE_READ_INT(var) __asm__("" ::"r"(var));
+// Clang on Mips requires "f" constraints on floats
+// See https://github.com/llvm/llvm-project/issues/64241
+#if defined(__clang__) && \
+    (defined(mips) || defined(__mips__) || defined(__mips))
+#define FORCE_READ_FLOAT(var) __asm__("" ::"f"(var));
+#else
+#define FORCE_READ_FLOAT(var) __asm__("" ::"r"(var));
+#endif
+#endif
+
 #else
 #define MEMCHECK_DEFAULT32(mem, a, t)                \
   WASM_RT_CHECK_BASE(mem);                           \
@@ -262,18 +277,11 @@ static inline uint64_t checked_add_u64(uint64_t a, uint64_t b) {
   WASM_RT_CHECK_BASE(mem);          \
   RANGE_CHECK(mem, a, sizeof(t));
 
-#ifdef __GNUC__
-#define FORCE_READ_INT(var) __asm__("" ::"r"(var));
-// Clang on Mips requires "f" constraints on floats
-// See https://github.com/llvm/llvm-project/issues/64241
-#if defined(__clang__) && \
-    (defined(mips) || defined(__mips__) || defined(__mips))
-#define FORCE_READ_FLOAT(var) __asm__("" ::"f"(var));
-#else
-#define FORCE_READ_FLOAT(var) __asm__("" ::"r"(var));
-#endif
-#else
+#ifndef FORCE_READ_INT
 #define FORCE_READ_INT(var)
+#endif
+
+#ifndef FORCE_READ_FLOAT
 #define FORCE_READ_FLOAT(var)
 #endif
 

--- a/test/wasm2c/minimal.txt
+++ b/test/wasm2c/minimal.txt
@@ -212,6 +212,21 @@ static inline uint64_t checked_add_u64(uint64_t a, uint64_t b) {
 // or it may do a slightly faster RANGE_CHECK.
 #if WASM_RT_MEMCHECK_GUARD_PAGES
 #define MEMCHECK_DEFAULT32(mem, a, t) WASM_RT_CHECK_BASE(mem);
+
+// When using guard pages, reads have to be immediately consumed so that OOB
+// trap checks are applied in the right place, and not optimized away.
+#ifdef __GNUC__
+#define FORCE_READ_INT(var) __asm__("" ::"r"(var));
+// Clang on Mips requires "f" constraints on floats
+// See https://github.com/llvm/llvm-project/issues/64241
+#if defined(__clang__) && \
+    (defined(mips) || defined(__mips__) || defined(__mips))
+#define FORCE_READ_FLOAT(var) __asm__("" ::"f"(var));
+#else
+#define FORCE_READ_FLOAT(var) __asm__("" ::"r"(var));
+#endif
+#endif
+
 #else
 #define MEMCHECK_DEFAULT32(mem, a, t)                \
   WASM_RT_CHECK_BASE(mem);                           \
@@ -224,18 +239,11 @@ static inline uint64_t checked_add_u64(uint64_t a, uint64_t b) {
   WASM_RT_CHECK_BASE(mem);          \
   RANGE_CHECK(mem, a, sizeof(t));
 
-#ifdef __GNUC__
-#define FORCE_READ_INT(var) __asm__("" ::"r"(var));
-// Clang on Mips requires "f" constraints on floats
-// See https://github.com/llvm/llvm-project/issues/64241
-#if defined(__clang__) && \
-    (defined(mips) || defined(__mips__) || defined(__mips))
-#define FORCE_READ_FLOAT(var) __asm__("" ::"f"(var));
-#else
-#define FORCE_READ_FLOAT(var) __asm__("" ::"r"(var));
-#endif
-#else
+#ifndef FORCE_READ_INT
 #define FORCE_READ_INT(var)
+#endif
+
+#ifndef FORCE_READ_FLOAT
 #define FORCE_READ_FLOAT(var)
 #endif
 

--- a/test/wasm2c/tail-calls.txt
+++ b/test/wasm2c/tail-calls.txt
@@ -242,6 +242,21 @@ static inline uint64_t checked_add_u64(uint64_t a, uint64_t b) {
 // or it may do a slightly faster RANGE_CHECK.
 #if WASM_RT_MEMCHECK_GUARD_PAGES
 #define MEMCHECK_DEFAULT32(mem, a, t) WASM_RT_CHECK_BASE(mem);
+
+// When using guard pages, reads have to be immediately consumed so that OOB
+// trap checks are applied in the right place, and not optimized away.
+#ifdef __GNUC__
+#define FORCE_READ_INT(var) __asm__("" ::"r"(var));
+// Clang on Mips requires "f" constraints on floats
+// See https://github.com/llvm/llvm-project/issues/64241
+#if defined(__clang__) && \
+    (defined(mips) || defined(__mips__) || defined(__mips))
+#define FORCE_READ_FLOAT(var) __asm__("" ::"f"(var));
+#else
+#define FORCE_READ_FLOAT(var) __asm__("" ::"r"(var));
+#endif
+#endif
+
 #else
 #define MEMCHECK_DEFAULT32(mem, a, t)                \
   WASM_RT_CHECK_BASE(mem);                           \
@@ -254,18 +269,11 @@ static inline uint64_t checked_add_u64(uint64_t a, uint64_t b) {
   WASM_RT_CHECK_BASE(mem);          \
   RANGE_CHECK(mem, a, sizeof(t));
 
-#ifdef __GNUC__
-#define FORCE_READ_INT(var) __asm__("" ::"r"(var));
-// Clang on Mips requires "f" constraints on floats
-// See https://github.com/llvm/llvm-project/issues/64241
-#if defined(__clang__) && \
-    (defined(mips) || defined(__mips__) || defined(__mips))
-#define FORCE_READ_FLOAT(var) __asm__("" ::"f"(var));
-#else
-#define FORCE_READ_FLOAT(var) __asm__("" ::"r"(var));
-#endif
-#else
+#ifndef FORCE_READ_INT
 #define FORCE_READ_INT(var)
+#endif
+
+#ifndef FORCE_READ_FLOAT
 #define FORCE_READ_FLOAT(var)
 #endif
 


### PR DESCRIPTION
When using wasm2c with guard pages, the force_read macro (containing an asm block) is used to make sure the C compiler doesn't optimize away memory reads which are dead or move them around in Wasm functions. This is because reads in Wasm have a side-effect --- they can trap if they are out-of-bounds of the linear memory. This macro is however unnecessary for bounds check mode (as the bounds check explicitly captures this side effect), and keeping the asm block around has a large performance impact as it hinders various compiler optimizations. For example, when using a Wasm2c sandboxed libwoff2 font compression library in bounds check mode, removing the force_read macro reduces overhead from 55% to 44%. This PR defines the force_read macro to empty for bounds check mode.