### PR TITLE
Give the tools an 8MB stack on msvc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -506,6 +506,14 @@ function(wabt_executable)
   add_dependencies(everything ${EXE_NAME})
   target_link_libraries(${EXE_NAME} ${EXE_LIBS})
 
+  if (MSVC)
+    # The wast parser is recursive descent, so nesting depth costs stack, and
+    # real modules nest deeply: a switch lowers to a br_table wrapped in one
+    # block per case. msvc's 1MB default is not enough for that, so ask for
+    # the 8MB Linux and macOS give us.
+    target_link_options(${EXE_NAME} PRIVATE "/STACK:8388608")
+  endif ()
+
   if (EMSCRIPTEN)
     set(EXTRA_LINK_FLAGS
       "${EXTRA_LINK_FLAGS} -sNODERAWFS -Oz -sALLOW_MEMORY_GROWTH"


### PR DESCRIPTION
`wat2wasm` faults on deeply nested input instead of reporting anything. On Windows it exits `0xC00000FD` (`STATUS_STACK_OVERFLOW`); on Linux with a small stack it segfaults. Same for `wast2json` and `wat-desugar`, since they share the parser. That's #2377.

The parser is recursive descent, so every nesting level costs a few stack frames — measured at roughly 600 bytes per level for a gcc debug build, and msvc debug is several times that.

This started out as a nesting limit, but that was the wrong fix: real modules nest deeply, because a switch lowers to a `br_table` wrapped in one block per case. Measuring the max control depth of real toolchain output:

```
webp_enc (emscripten)     29
resvg (wasm-pack)        180
sqlite via sql.js (emsc) 282
esbuild (go)            3457
```

Any limit low enough to fit msvc's 1MB default would have rejected sqlite and esbuild, which parse fine elsewhere today.

The stack size is what actually matters here, so that's all this does now. With 8MB a debug build handles 14000 levels, and esbuild's own text reads back:

```
stack 1024 KB  CRASH
stack 8192 KB  ok
```

That's the whole 1.9GB `.wat` with no limit in the parser at all.

This doesn't make the recursion unbounded-safe — deep enough input will still exhaust any stack. Doing that properly means not recursing at all, the way wasm-tools' `wast` crate does, which is a much bigger change and doesn't need to block this.

Fixes #2377.
