### PR TITLE
interp: assert stop_on_first_error in ReadBinaryInterp

### DIFF
--- a/src/interp/binary-reader-interp.cc
+++ b/src/interp/binary-reader-interp.cc
@@ -742,21 +742,11 @@ Result BinaryReaderInterp::OnExport(Index index,
 
   std::unique_ptr<ExternType> type;
   switch (kind) {
-    case ExternalKind::Func:
-      type = func_types_[item_index].Clone();
-      break;
-    case ExternalKind::Table:
-      type = table_types_[item_index].Clone();
-      break;
-    case ExternalKind::Memory:
-      type = memory_types_[item_index].Clone();
-      break;
-    case ExternalKind::Global:
-      type = global_types_[item_index].Clone();
-      break;
-    case ExternalKind::Tag:
-      type = tag_types_[item_index].Clone();
-      break;
+    case ExternalKind::Func:   type = func_types_[item_index].Clone(); break;
+    case ExternalKind::Table:  type = table_types_[item_index].Clone(); break;
+    case ExternalKind::Memory: type = memory_types_[item_index].Clone(); break;
+    case ExternalKind::Global: type = global_types_[item_index].Clone(); break;
+    case ExternalKind::Tag:    type = tag_types_[item_index].Clone(); break;
   }
   module_.exports.push_back(
       ExportDesc{ExportType(std::string(name), std::move(type)), item_index});

--- a/src/interp/binary-reader-interp.cc
+++ b/src/interp/binary-reader-interp.cc
@@ -742,11 +742,21 @@ Result BinaryReaderInterp::OnExport(Index index,
 
   std::unique_ptr<ExternType> type;
   switch (kind) {
-    case ExternalKind::Func:   type = func_types_[item_index].Clone(); break;
-    case ExternalKind::Table:  type = table_types_[item_index].Clone(); break;
-    case ExternalKind::Memory: type = memory_types_[item_index].Clone(); break;
-    case ExternalKind::Global: type = global_types_[item_index].Clone(); break;
-    case ExternalKind::Tag:    type = tag_types_[item_index].Clone(); break;
+    case ExternalKind::Func:
+      type = func_types_[item_index].Clone();
+      break;
+    case ExternalKind::Table:
+      type = table_types_[item_index].Clone();
+      break;
+    case ExternalKind::Memory:
+      type = memory_types_[item_index].Clone();
+      break;
+    case ExternalKind::Global:
+      type = global_types_[item_index].Clone();
+      break;
+    case ExternalKind::Tag:
+      type = tag_types_[item_index].Clone();
+      break;
   }
   module_.exports.push_back(
       ExportDesc{ExportType(std::string(name), std::move(type)), item_index});
@@ -1812,6 +1822,9 @@ Result ReadBinaryInterp(std::string_view filename,
                         const ReadBinaryOptions& options,
                         Errors* errors,
                         ModuleDesc* out_module) {
+  // BinaryReaderInterp does not support collect-all-errors mode; only readers
+  // such as BinaryReaderIR/objdump may be used with stop_on_first_error=false.
+  assert(options.stop_on_first_error);
   BinaryReaderInterp reader(out_module, filename, errors, options.features);
   return ReadBinary(data, &reader, options);
 }


### PR DESCRIPTION
## Summary
- Assert that `ReadBinaryInterp` is only used with `stop_on_first_error=true`.
- Documents that collect-all-errors mode is unsupported for the interp reader.

Follow-up to #2812 / #2747 ( @sbc100  ) .

## Test plan
- [x] Debug: `stop_on_first_error=false` hits the assert
- [x] `wabt-unittests` (135 passed)