### PR TITLE
Assert that ReadBinaryIr is not used with skip_function_bodies

### DIFF
--- a/src/binary-reader-ir.cc
+++ b/src/binary-reader-ir.cc
@@ -1894,6 +1894,11 @@ Result ReadBinaryIr(const char* filename,
                     const ReadBinaryOptions& options,
                     Errors* errors,
                     Module* out_module) {
+  // BinaryReaderIR does not support skipping function bodies; that option is
+  // for readers such as objdump that do not build a module. Skipping the
+  // bodies here leaves each function's label unclosed, because the end marker
+  // that would pop it is never read.
+  assert(!options.skip_function_bodies);
   BinaryReaderIR reader(out_module, filename, errors);
   return ReadBinary(data, &reader, options);
 }


### PR DESCRIPTION
`ReadBinaryIr` fails on any module that has a function in it once `skip_function_bodies` is set. Reading sqlite (built with emscripten) both ways:

```
skip_function_bodies=0 -> ok
skip_function_bodies=1 -> FAILED
    function 34 missing end marker
```

34 is just its first non-imported function, so it gives up on the first body it reaches.

`BeginFunctionBody` pushes a label for the function, but with bodies skipped the reader steps straight over the body and the `end` that would pop that label never arrives. `EndFunctionBody` then sees it still sitting on the stack and reports the body as missing its end marker.

The option was only ever meant for the objdump reader, which doesn't build a module, so this declares it unsupported here instead of teaching the IR reader to work around it, along the lines of #2816. Nothing in the tree passes it to `ReadBinaryIr` today, so nothing starts asserting.

Fixes #2534.
