### PR TITLE
[interp] Fix out-of-bounds read tracing call_ref and return_call_ref

### DIFF
--- a/src/interp/istream.cc
+++ b/src/interp/istream.cc
@@ -807,8 +807,13 @@ Instr Istream::Read(Offset* offset) const {
       instr.imm_v128 = ReadAt<v128>(offset);
       break;
 
-    case Opcode::Block:
     case Opcode::CallRef:
+    case Opcode::ReturnCallRef:
+      // 0 immediates, 1 operand (the callee reference).
+      instr.kind = InstrKind::Imm_0_Op_1;
+      break;
+
+    case Opcode::Block:
     case Opcode::Catch:
     case Opcode::CatchAll:
     case Opcode::Delegate:
@@ -821,7 +826,6 @@ Instr Istream::Read(Offset* offset) const {
     case Opcode::Try:
     case Opcode::TryTable:
     case Opcode::ReturnCall:
-    case Opcode::ReturnCallRef:
       // Not used.
       break;
   }

--- a/test/interp/tracing-call-ref.txt
+++ b/test/interp/tracing-call-ref.txt
@@ -1,0 +1,40 @@
+;;; TOOL: run-interp-spec
+;;; ARGS*: --enable-function-references --enable-tail-call
+;;; ARGS1: --trace
+(module
+  ;; call_ref/return_call_ref carry no istream immediate, so Istream::Read has to
+  ;; give them an InstrKind explicitly; otherwise the tracer decodes them with the
+  ;; previous instruction's kind and picks operands that are not on the stack. The
+  ;; store in front leaves a two-operand kind behind to exercise that path.
+  (type $v (func))
+  (memory 1)
+  (elem declare func $t)
+  (func $t)
+  (func (export "call")
+    ref.func $t
+    (i32.store (i32.const 0) (i32.const 0))
+    call_ref $v)
+  (func (export "retcall")
+    ref.func $t
+    (i32.store (i32.const 0) (i32.const 0))
+    return_call_ref $v))
+(invoke "call")
+(invoke "retcall")
+(;; STDOUT ;;;
+#0.   16: V:0  | ref.func $0
+#0.   24: V:1  | i32.const 0
+#0.   32: V:2  | i32.const 0
+#0.   40: V:3  | i32.store $0:0+$0, 0
+#0.   56: V:1  | call_ref ?
+#1.   12: V:0  | return
+#0.   60: V:0  | return
+call() =>
+#0.   64: V:0  | ref.func $0
+#0.   72: V:1  | i32.const 0
+#0.   80: V:2  | i32.const 0
+#0.   88: V:3  | i32.store $0:0+$0, 0
+#0.  104: V:1  | return_call_ref ?
+#0.   12: V:0  | return
+retcall() =>
+3/3 tests passed.
+;;; STDOUT ;;)


### PR DESCRIPTION
`Istream::Read` never initialises `Instr::kind` for `call_ref/return_call_ref` though both are emitted into the istream, so under `--trace` the tracer decodes them with the previous instruction's kind and `Pick()` reads past the end of the value stack; give them `Imm_0_Op_1` (no immediate, one operand: the callee reference) like the other reachable opcodes.