### PR TITLE
Don't abort on an empty input file

### DIFF
--- a/src/lexer-source.cc
+++ b/src/lexer-source.cc
@@ -45,7 +45,9 @@ size_t LexerSource::Fill(void* dest, Offset size) {
 }
 
 Result LexerSource::Seek(Offset offset) {
-  if (offset < size_) {
+  // Seeking to the end is allowed: it is where an empty source starts, and
+  // reading from there just yields nothing (ReadRange already clamps).
+  if (offset <= size_) {
     read_offset_ = offset;
     return Result::Ok;
   }

--- a/test/parse/zero-length-file.txt
+++ b/test/parse/zero-length-file.txt
@@ -1,0 +1,5 @@
+;;; TOOL: wat2wasm
+;;; STDIN_FILE: test/parse/zero-length.wat
+(;; STDERR ;;;
+out/test/parse/zero-length.wat:1:1: warning: empty module
+;;; STDERR ;;)


### PR DESCRIPTION
An empty input file aborts every tool that formats errors, in any build with assertions on:

```console
$ : > empty.wat
$ wat2wasm empty.wat -o /dev/null
wat2wasm: src/lexer-source-line-finder.cc:30: wabt::LexerSourceLineFinder::LexerSourceLineFinder(...): Assertion `Succeeded(result)' failed.
Aborted
```

Same for `wast2json` and `wat-desugar`.

`LexerSource::Seek` refuses to seek to the end:

```cpp
if (offset < size_) {
```

On a zero-length source that makes `Seek(0)` fail, and `LexerSourceLineFinder`'s constructor asserts it succeeded. `Seek` has exactly that one caller, and `ReadRange` already clamps to `size_`, so accepting `offset == size_` is consistent with the rest of the class — it's simply where an empty source starts, and reading from there yields nothing.

With that, the tools do what they already meant to. `wat2wasm` warns `empty module` and writes out an empty module, `wast2json` warns `empty script`, and `wat-desugar` reports `no module in file` — all of those paths already existed, the assert just fired before they could run.

The test is `test/parse/zero-length-file.txt`, using `STDIN_FILE` to point at a checked-in zero byte file. Writing the input inline doesn't work for this: `CreateInputFile` pads the input with one newline per header line so the reported line numbers line up, so the file is never actually empty. That's also why the existing `test/parse/empty-file.txt` doesn't catch this — its input is a comment, not nothing. Without the fix the new test fails with `expected error code 0, got -6`.

Found while fuzzing the text front end. For what it's worth, `fuzzers/wat2wasm_fuzzer.cc` parses but never formats errors, and the line finder is only constructed when formatting, so a zero-length input never reaches it there — which is presumably how this survived.
