### PR TITLE
wasm2c: optimize performance of float handling

### DIFF
--- a/src/c-writer.cc
+++ b/src/c-writer.cc
@@ -792,6 +792,21 @@ static void NormalizeFloatRadix(char* buffer) {
   }
 }
 
+// 32-bit Floating point in C expects a suffix "f" and requires constants like 1
+// to be written as 1.0f (not 1f)
+static void EnsureFloat32Suffix(char* buf) {
+  if (std::strchr(buf, 'e') != nullptr || std::strchr(buf, 'E') != nullptr ||
+      std::strcmp(buf, "inf") == 0 || std::strcmp(buf, "-inf") == 0 ||
+      std::strcmp(buf, "nan") == 0) {
+    return;
+  }
+
+  if (std::strchr(buf, '.') == nullptr) {
+    std::strcat(buf, ".0");
+  }
+  std::strcat(buf, "f");
+}
+
 // static
 std::string CWriter::Mangle(std::string_view name, bool double_underscores) {
   /*
@@ -1348,6 +1363,7 @@ void CWriter::Write(const Const& const_) {
         char buf[128];
         snprintf(buf, sizeof(buf), "%.9g", Bitcast<float>(f32_bits));
         NormalizeFloatRadix(buf);
+        EnsureFloat32Suffix(buf);
         Writef("%s", buf);
       }
       break;

--- a/src/prebuilt/wasm2c_source_declarations.cc
+++ b/src/prebuilt/wasm2c_source_declarations.cc
@@ -1107,7 +1107,26 @@ R"w2c_template(    return quiet_nan(x);
 )w2c_template"
 R"w2c_template(  }
 )w2c_template"
+R"w2c_template(
+#if __has_builtin(__builtin_elementwise_sqrt)
+)w2c_template"
+R"w2c_template(  // Fastest option: doesn't set errno
+)w2c_template"
+R"w2c_template(  return __builtin_elementwise_sqrt(x);
+)w2c_template"
+R"w2c_template(#elif __has_builtin(__builtin_sqrt)
+)w2c_template"
+R"w2c_template(  // Optimized if -fno-math-errno is set
+)w2c_template"
+R"w2c_template(  return __builtin_sqrt(x);
+)w2c_template"
+R"w2c_template(#else
+)w2c_template"
+R"w2c_template(  // Libc call. May/may not be optimized
+)w2c_template"
 R"w2c_template(  return sqrt(x);
+)w2c_template"
+R"w2c_template(#endif
 )w2c_template"
 R"w2c_template(}
 )w2c_template"
@@ -1120,7 +1139,26 @@ R"w2c_template(    return quiet_nanf(x);
 )w2c_template"
 R"w2c_template(  }
 )w2c_template"
+R"w2c_template(
+#if __has_builtin(__builtin_elementwise_sqrt)
+)w2c_template"
+R"w2c_template(  // Fastest option: doesn't set errno
+)w2c_template"
+R"w2c_template(  return __builtin_elementwise_sqrt(x);
+)w2c_template"
+R"w2c_template(#elif __has_builtin(__builtin_sqrt)
+)w2c_template"
+R"w2c_template(  // Optimized if -fno-math-errno is set
+)w2c_template"
+R"w2c_template(  return __builtin_sqrtf(x);
+)w2c_template"
+R"w2c_template(#else
+)w2c_template"
+R"w2c_template(  // Libc call. May/may not be optimized
+)w2c_template"
 R"w2c_template(  return sqrtf(x);
+)w2c_template"
+R"w2c_template(#endif
 )w2c_template"
 R"w2c_template(}
 )w2c_template"

--- a/src/template/wasm2c.declarations.c
+++ b/src/template/wasm2c.declarations.c
@@ -592,14 +592,34 @@ static double wasm_sqrt(double x) {
   if (UNLIKELY(isnan(x))) {
     return quiet_nan(x);
   }
+
+#if __has_builtin(__builtin_elementwise_sqrt)
+  // Fastest option: doesn't set errno
+  return __builtin_elementwise_sqrt(x);
+#elif __has_builtin(__builtin_sqrt)
+  // Optimized if -fno-math-errno is set
+  return __builtin_sqrt(x);
+#else
+  // Libc call. May/may not be optimized
   return sqrt(x);
+#endif
 }
 
 static float wasm_sqrtf(float x) {
   if (UNLIKELY(isnan(x))) {
     return quiet_nanf(x);
   }
+
+#if __has_builtin(__builtin_elementwise_sqrt)
+  // Fastest option: doesn't set errno
+  return __builtin_elementwise_sqrt(x);
+#elif __has_builtin(__builtin_sqrt)
+  // Optimized if -fno-math-errno is set
+  return __builtin_sqrtf(x);
+#else
+  // Libc call. May/may not be optimized
   return sqrtf(x);
+#endif
 }
 
 static inline void memory_fill(wasm_rt_memory_t* mem, u64 d, u32 val, u64 n) {

--- a/test/run-spec-wasm2c.py
+++ b/test/run-spec-wasm2c.py
@@ -467,6 +467,8 @@ def Compile(cc, c_filename, out_dir, use_c11, *cflags):
         # When compiling with -O2/-O3, GCC and clang require '-fno-optimize-sibling-calls'
         # and '-frounding-math' to maintain conformance with the spec tests
         # (GCC also requires '-fsignaling-nans')
+        # '-fno-math-errno' is a performance optimization to improve speed of
+        # operations like sqrt
         if use_c11:
             args.append('-std=c11')
         else:
@@ -482,6 +484,7 @@ def Compile(cc, c_filename, out_dir, use_c11, *cflags):
                  '-Wno-pass-failed',
                  '-fno-optimize-sibling-calls',
                  '-frounding-math', '-fsignaling-nans',
+                 '-fno-math-errno',
                  '-D_DEFAULT_SOURCE']
     # Use RunWithArgsForStdout and discard stdout because cl.exe
     # unconditionally prints the name of input files on stdout

--- a/test/wasm2c/add.txt
+++ b/test/wasm2c/add.txt
@@ -659,14 +659,34 @@ static double wasm_sqrt(double x) {
   if (UNLIKELY(isnan(x))) {
     return quiet_nan(x);
   }
+
+#if __has_builtin(__builtin_elementwise_sqrt)
+  // Fastest option: doesn't set errno
+  return __builtin_elementwise_sqrt(x);
+#elif __has_builtin(__builtin_sqrt)
+  // Optimized if -fno-math-errno is set
+  return __builtin_sqrt(x);
+#else
+  // Libc call. May/may not be optimized
   return sqrt(x);
+#endif
 }
 
 static float wasm_sqrtf(float x) {
   if (UNLIKELY(isnan(x))) {
     return quiet_nanf(x);
   }
+
+#if __has_builtin(__builtin_elementwise_sqrt)
+  // Fastest option: doesn't set errno
+  return __builtin_elementwise_sqrt(x);
+#elif __has_builtin(__builtin_sqrt)
+  // Optimized if -fno-math-errno is set
+  return __builtin_sqrtf(x);
+#else
+  // Libc call. May/may not be optimized
   return sqrtf(x);
+#endif
 }
 
 static inline void memory_fill(wasm_rt_memory_t* mem, u64 d, u32 val, u64 n) {

--- a/test/wasm2c/check-imports.txt
+++ b/test/wasm2c/check-imports.txt
@@ -684,14 +684,34 @@ static double wasm_sqrt(double x) {
   if (UNLIKELY(isnan(x))) {
     return quiet_nan(x);
   }
+
+#if __has_builtin(__builtin_elementwise_sqrt)
+  // Fastest option: doesn't set errno
+  return __builtin_elementwise_sqrt(x);
+#elif __has_builtin(__builtin_sqrt)
+  // Optimized if -fno-math-errno is set
+  return __builtin_sqrt(x);
+#else
+  // Libc call. May/may not be optimized
   return sqrt(x);
+#endif
 }
 
 static float wasm_sqrtf(float x) {
   if (UNLIKELY(isnan(x))) {
     return quiet_nanf(x);
   }
+
+#if __has_builtin(__builtin_elementwise_sqrt)
+  // Fastest option: doesn't set errno
+  return __builtin_elementwise_sqrt(x);
+#elif __has_builtin(__builtin_sqrt)
+  // Optimized if -fno-math-errno is set
+  return __builtin_sqrtf(x);
+#else
+  // Libc call. May/may not be optimized
   return sqrtf(x);
+#endif
 }
 
 static inline void memory_fill(wasm_rt_memory_t* mem, u64 d, u32 val, u64 n) {

--- a/test/wasm2c/export-names.txt
+++ b/test/wasm2c/export-names.txt
@@ -684,14 +684,34 @@ static double wasm_sqrt(double x) {
   if (UNLIKELY(isnan(x))) {
     return quiet_nan(x);
   }
+
+#if __has_builtin(__builtin_elementwise_sqrt)
+  // Fastest option: doesn't set errno
+  return __builtin_elementwise_sqrt(x);
+#elif __has_builtin(__builtin_sqrt)
+  // Optimized if -fno-math-errno is set
+  return __builtin_sqrt(x);
+#else
+  // Libc call. May/may not be optimized
   return sqrt(x);
+#endif
 }
 
 static float wasm_sqrtf(float x) {
   if (UNLIKELY(isnan(x))) {
     return quiet_nanf(x);
   }
+
+#if __has_builtin(__builtin_elementwise_sqrt)
+  // Fastest option: doesn't set errno
+  return __builtin_elementwise_sqrt(x);
+#elif __has_builtin(__builtin_sqrt)
+  // Optimized if -fno-math-errno is set
+  return __builtin_sqrtf(x);
+#else
+  // Libc call. May/may not be optimized
   return sqrtf(x);
+#endif
 }
 
 static inline void memory_fill(wasm_rt_memory_t* mem, u64 d, u32 val, u64 n) {

--- a/test/wasm2c/hello.txt
+++ b/test/wasm2c/hello.txt
@@ -691,14 +691,34 @@ static double wasm_sqrt(double x) {
   if (UNLIKELY(isnan(x))) {
     return quiet_nan(x);
   }
+
+#if __has_builtin(__builtin_elementwise_sqrt)
+  // Fastest option: doesn't set errno
+  return __builtin_elementwise_sqrt(x);
+#elif __has_builtin(__builtin_sqrt)
+  // Optimized if -fno-math-errno is set
+  return __builtin_sqrt(x);
+#else
+  // Libc call. May/may not be optimized
   return sqrt(x);
+#endif
 }
 
 static float wasm_sqrtf(float x) {
   if (UNLIKELY(isnan(x))) {
     return quiet_nanf(x);
   }
+
+#if __has_builtin(__builtin_elementwise_sqrt)
+  // Fastest option: doesn't set errno
+  return __builtin_elementwise_sqrt(x);
+#elif __has_builtin(__builtin_sqrt)
+  // Optimized if -fno-math-errno is set
+  return __builtin_sqrtf(x);
+#else
+  // Libc call. May/may not be optimized
   return sqrtf(x);
+#endif
 }
 
 static inline void memory_fill(wasm_rt_memory_t* mem, u64 d, u32 val, u64 n) {

--- a/test/wasm2c/minimal.txt
+++ b/test/wasm2c/minimal.txt
@@ -653,14 +653,34 @@ static double wasm_sqrt(double x) {
   if (UNLIKELY(isnan(x))) {
     return quiet_nan(x);
   }
+
+#if __has_builtin(__builtin_elementwise_sqrt)
+  // Fastest option: doesn't set errno
+  return __builtin_elementwise_sqrt(x);
+#elif __has_builtin(__builtin_sqrt)
+  // Optimized if -fno-math-errno is set
+  return __builtin_sqrt(x);
+#else
+  // Libc call. May/may not be optimized
   return sqrt(x);
+#endif
 }
 
 static float wasm_sqrtf(float x) {
   if (UNLIKELY(isnan(x))) {
     return quiet_nanf(x);
   }
+
+#if __has_builtin(__builtin_elementwise_sqrt)
+  // Fastest option: doesn't set errno
+  return __builtin_elementwise_sqrt(x);
+#elif __has_builtin(__builtin_sqrt)
+  // Optimized if -fno-math-errno is set
+  return __builtin_sqrtf(x);
+#else
+  // Libc call. May/may not be optimized
   return sqrtf(x);
+#endif
 }
 
 static inline void memory_fill(wasm_rt_memory_t* mem, u64 d, u32 val, u64 n) {

--- a/test/wasm2c/tail-calls.txt
+++ b/test/wasm2c/tail-calls.txt
@@ -683,14 +683,34 @@ static double wasm_sqrt(double x) {
   if (UNLIKELY(isnan(x))) {
     return quiet_nan(x);
   }
+
+#if __has_builtin(__builtin_elementwise_sqrt)
+  // Fastest option: doesn't set errno
+  return __builtin_elementwise_sqrt(x);
+#elif __has_builtin(__builtin_sqrt)
+  // Optimized if -fno-math-errno is set
+  return __builtin_sqrt(x);
+#else
+  // Libc call. May/may not be optimized
   return sqrt(x);
+#endif
 }
 
 static float wasm_sqrtf(float x) {
   if (UNLIKELY(isnan(x))) {
     return quiet_nanf(x);
   }
+
+#if __has_builtin(__builtin_elementwise_sqrt)
+  // Fastest option: doesn't set errno
+  return __builtin_elementwise_sqrt(x);
+#elif __has_builtin(__builtin_sqrt)
+  // Optimized if -fno-math-errno is set
+  return __builtin_sqrtf(x);
+#else
+  // Libc call. May/may not be optimized
   return sqrtf(x);
+#endif
 }
 
 static inline void memory_fill(wasm_rt_memory_t* mem, u64 d, u32 val, u64 n) {
@@ -954,7 +974,7 @@ void w2c_test_tailcaller_0(w2c_test* instance) {
   u32 var_i0, var_i2;
   f32 var_f1;
   var_i0 = 1u;
-  var_f1 = 2;
+  var_f1 = 2.0f;
   var_i2 = 0u;
   static_assert(sizeof(struct wasm_multi_if) <= 1024);
   CHECK_CALL_INDIRECT(instance->w2c_tab, w2c_test_i32_f32, var_i2);
@@ -986,7 +1006,7 @@ void wasm_tailcall_w2c_test_tailcaller_0(void **instance_ptr, void *tail_call_st
   u32 var_i0, var_i2;
   f32 var_f1;
   var_i0 = 1u;
-  var_f1 = 2;
+  var_f1 = 2.0f;
   var_i2 = 0u;
   static_assert(sizeof(struct wasm_multi_if) <= 1024);
   CHECK_CALL_INDIRECT(instance->w2c_tab, w2c_test_i32_f32, var_i2);


### PR DESCRIPTION
Optimize performance of float handling in wasm2c

- The `sqrt` and `sqrtf` calls currently use the libc functions. The libc version of this function goes through the PLT and has extra operations to do with setting `errno`. However, using the `__builtin_elementwise_sqrt` (available only in clang), reduces this to a single instruction in x86-64. `__builtin_sqrt` works on gcc/clang but requires the caller to pass in the  `-fno-math-errno` flag. 
- Currently f32 constants are emitted without a "f" suffix, i.e., it is emitted as doubles. Unfortunately, with `-frounding-math`, this means that double to float conversion is done at runtime instead of compile time.

Together these 2 changes shave off another 3% when running a sandboxed libsoundtouch which is used by Firefox to adjust the playback speed of audio files.