### PR TITLE
Propagate parse errors out of instruction and expression lists

### DIFF
--- a/src/wast-parser.cc
+++ b/src/wast-parser.cc
@@ -2282,6 +2282,11 @@ Result WastParser::ParseResultList(TypeVector* result_types,
 
 Result WastParser::ParseInstrList(ExprList* exprs) {
   WABT_TRACE(ParseInstrList);
+  // Keep going after a bad instruction so the rest of the errors get reported,
+  // but remember that one was dropped. Returning Ok here would tell the caller
+  // the field parsed cleanly when part of it was thrown away, and anything the
+  // discarded expressions registered for later would outlive them.
+  Result result = Result::Ok;
   ExprList new_exprs;
   while (true) {
     auto pair = PeekPair();
@@ -2289,19 +2294,21 @@ Result WastParser::ParseInstrList(ExprList* exprs) {
       if (Succeeded(ParseInstr(&new_exprs))) {
         exprs->splice(exprs->end(), new_exprs);
       } else {
+        result = Result::Error;
         CHECK_RESULT(Synchronize(IsInstr));
       }
     } else if (IsLparAnn(pair)) {
       if (Succeeded(ParseCodeMetadataAnnotation(&new_exprs))) {
         exprs->splice(exprs->end(), new_exprs);
       } else {
+        result = Result::Error;
         CHECK_RESULT(Synchronize(IsLparAnn));
       }
     } else {
       break;
     }
   }
-  return Result::Ok;
+  return result;
 }
 
 Result WastParser::ParseTerminatingInstrList(ExprList* exprs) {
@@ -3433,15 +3440,17 @@ Result WastParser::ParseBlock(Block* block) {
 
 Result WastParser::ParseExprList(ExprList* exprs) {
   WABT_TRACE(ParseExprList);
+  Result result = Result::Ok;
   ExprList new_exprs;
   while (PeekMatchExpr()) {
     if (Succeeded(ParseExpr(&new_exprs))) {
       exprs->splice(exprs->end(), new_exprs);
     } else {
+      result = Result::Error;
       CHECK_RESULT(Synchronize(IsExpr));
     }
   }
-  return Result::Ok;
+  return result;
 }
 
 Result WastParser::ParseExpr(ExprList* exprs) {

--- a/test/parse/bad-block-ref-result-discarded.txt
+++ b/test/parse/bad-block-ref-result-discarded.txt
@@ -1,0 +1,32 @@
+;;; TOOL: wat2wasm
+;;; ARGS: --enable-function-references
+;;; ERROR: 1
+;; The block registers its result type for later resolution, then fails to
+;; parse and is discarded. Resolution used to run over the freed block.
+(func $n(param $r(ref $t))(result i32)(call_ref $t(block $l(result(ref $t))(n(l g(t f)n l(local.get $r))
+(;; STDERR ;;;
+out/test/parse/bad-block-ref-result-discarded.txt:6:76: error: unexpected token (, expected ).
+...result i32)(call_ref $t(block $l(result(ref $t))(n(l g(t f)n l(local.get $r))
+                                                   ^
+out/test/parse/bad-block-ref-result-discarded.txt:6:77: error: unexpected token n.
+...result i32)(call_ref $t(block $l(result(ref $t))(n(l g(t f)n l(local.get $r))
+                                                    ^
+out/test/parse/bad-block-ref-result-discarded.txt:6:79: error: unexpected token l.
+...result i32)(call_ref $t(block $l(result(ref $t))(n(l g(t f)n l(local.get $r))
+                                                      ^
+out/test/parse/bad-block-ref-result-discarded.txt:6:81: error: unexpected token g.
+...result i32)(call_ref $t(block $l(result(ref $t))(n(l g(t f)n l(local.get $r))
+                                                        ^
+out/test/parse/bad-block-ref-result-discarded.txt:6:83: error: unexpected token t.
+...result i32)(call_ref $t(block $l(result(ref $t))(n(l g(t f)n l(local.get $r))
+                                                          ^
+out/test/parse/bad-block-ref-result-discarded.txt:6:85: error: unexpected token f.
+...result i32)(call_ref $t(block $l(result(ref $t))(n(l g(t f)n l(local.get $r))
+                                                            ^
+out/test/parse/bad-block-ref-result-discarded.txt:6:87: error: unexpected token n.
+...result i32)(call_ref $t(block $l(result(ref $t))(n(l g(t f)n l(local.get $r))
+                                                              ^
+out/test/parse/bad-block-ref-result-discarded.txt:6:89: error: unexpected token l.
+...result i32)(call_ref $t(block $l(result(ref $t))(n(l g(t f)n l(local.get $r))
+                                                                ^
+;;; STDERR ;;)

--- a/test/parse/expr/bad-load-align.txt
+++ b/test/parse/expr/bad-load-align.txt
@@ -5,7 +5,4 @@
 out/test/parse/expr/bad-load-align.txt:3:25: error: unexpected token align=foo, expected ).
 (module (func (i32.load align=foo (i32.const 0))))
                         ^^^^^^^^^
-out/test/parse/expr/bad-load-align.txt:3:50: error: unexpected token ), expected EOF.
-(module (func (i32.load align=foo (i32.const 0))))
-                                                 ^
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-try-delegate.txt
+++ b/test/parse/expr/bad-try-delegate.txt
@@ -9,7 +9,4 @@
 out/test/parse/expr/bad-try-delegate.txt:5:25: error: unexpected token ")", expected a numeric index or a name (e.g. 12 or $foo).
   (func try nop delegate)
                         ^
-out/test/parse/expr/bad-try-delegate.txt:6:28: error: unexpected token end, expected ).
-  (func try nop delegate 0 end)
-                           ^^^
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-try-multiple-catch.txt
+++ b/test/parse/expr/bad-try-multiple-catch.txt
@@ -25,13 +25,7 @@
 out/test/parse/expr/bad-try-multiple-catch.txt:11:5: error: multiple catch_all clauses not allowed
     catch_all
     ^^^^^^^^^
-out/test/parse/expr/bad-try-multiple-catch.txt:13:5: error: unexpected token end, expected ).
-    end)
-    ^^^
 out/test/parse/expr/bad-try-multiple-catch.txt:22:8: error: multiple catch_all clauses not allowed
       (catch_all
        ^^^^^^^^^
-out/test/parse/expr/bad-try-multiple-catch.txt:23:16: error: unexpected token ), expected EOF.
-        (nop))))
-               ^
 ;;; STDERR ;;)

--- a/test/spec/block.txt
+++ b/test/spec/block.txt
@@ -29,9 +29,6 @@ out/test/spec/block.wast:464: assert_malformed passed:
   out/test/spec/block/block.7.wat:1:35: error: unexpected token $x, expected ).
   (func (i32.const 0) (block (param $x i32) (drop)))
                                     ^^
-  out/test/spec/block/block.7.wat:1:50: error: unexpected token ), expected EOF.
-  (func (i32.const 0) (block (param $x i32) (drop)))
-                                                   ^
 out/test/spec/block.wast:468: assert_malformed passed:
   out/test/spec/block/block.8.wat:1:25: error: expected 0 results, got 1
   (type $sig (func))(func (block (type $sig) (result i32) (i32.const 0)) (unrea...

--- a/test/spec/call_indirect.txt
+++ b/test/spec/call_indirect.txt
@@ -23,51 +23,30 @@ out/test/spec/call_indirect.wast:669: assert_malformed passed:
   out/test/spec/call_indirect/call_indirect.2.wat:1:122: error: unexpected token "param", expected an expr.
   ...indirect (type $sig) (result i32) (param i32)    (i32.const 0) (i32.const ...
                                         ^^^^^
-  out/test/spec/call_indirect/call_indirect.2.wat:1:166: error: unexpected token ), expected EOF.
-  ...irect (type $sig) (result i32) (param i32)    (i32.const 0) (i32.const 0)  ))
-                                                                                 ^
 out/test/spec/call_indirect.wast:681: assert_malformed passed:
   out/test/spec/call_indirect/call_indirect.3.wat:1:109: error: unexpected token "type", expected an expr.
   ... i32)  (call_indirect (param i32) (type $sig) (result i32)    (i32.const 0...
                                         ^^^^
-  out/test/spec/call_indirect/call_indirect.3.wat:1:166: error: unexpected token ), expected EOF.
-  ...irect (param i32) (type $sig) (result i32)    (i32.const 0) (i32.const 0)  ))
-                                                                                 ^
 out/test/spec/call_indirect.wast:693: assert_malformed passed:
   out/test/spec/call_indirect/call_indirect.4.wat:1:122: error: unexpected token "type", expected an expr.
   ...indirect (param i32) (result i32) (type $sig)    (i32.const 0) (i32.const ...
                                         ^^^^
-  out/test/spec/call_indirect/call_indirect.4.wat:1:166: error: unexpected token ), expected EOF.
-  ...irect (param i32) (result i32) (type $sig)    (i32.const 0) (i32.const 0)  ))
-                                                                                 ^
 out/test/spec/call_indirect.wast:705: assert_malformed passed:
   out/test/spec/call_indirect/call_indirect.5.wat:1:110: error: unexpected token "type", expected an expr.
   ...i32)  (call_indirect (result i32) (type $sig) (param i32)    (i32.const 0)...
                                         ^^^^
-  out/test/spec/call_indirect/call_indirect.5.wat:1:166: error: unexpected token ), expected EOF.
-  ...irect (result i32) (type $sig) (param i32)    (i32.const 0) (i32.const 0)  ))
-                                                                                 ^
 out/test/spec/call_indirect.wast:717: assert_malformed passed:
   out/test/spec/call_indirect/call_indirect.6.wat:1:110: error: unexpected token "param", expected an expr.
   ...i32)  (call_indirect (result i32) (param i32) (type $sig)    (i32.const 0)...
                                         ^^^^^
-  out/test/spec/call_indirect/call_indirect.6.wat:1:166: error: unexpected token ), expected EOF.
-  ...irect (result i32) (param i32) (type $sig)    (i32.const 0) (i32.const 0)  ))
-                                                                                 ^
 out/test/spec/call_indirect.wast:729: assert_malformed passed:
   out/test/spec/call_indirect/call_indirect.7.wat:1:67: error: unexpected token "param", expected an expr.
   ...t i32)  (call_indirect (result i32) (param i32) (i32.const 0) (i32.const 0)))
                                           ^^^^^
-  out/test/spec/call_indirect/call_indirect.7.wat:1:106: error: unexpected token ), expected EOF.
-  ...t i32)  (call_indirect (result i32) (param i32) (i32.const 0) (i32.const 0)))
-                                                                                 ^
 out/test/spec/call_indirect.wast:739: assert_malformed passed:
   out/test/spec/call_indirect/call_indirect.8.wat:1:46: error: unexpected token $x, expected ).
   ...e 0 funcref)(func (call_indirect (param $x i32) (i32.const 0) (i32.const 0)))
                                              ^^
-  out/test/spec/call_indirect/call_indirect.8.wat:1:82: error: unexpected token ), expected EOF.
-  ...e 0 funcref)(func (call_indirect (param $x i32) (i32.const 0) (i32.const 0)))
-                                                                                 ^
 out/test/spec/call_indirect.wast:746: assert_malformed passed:
   out/test/spec/call_indirect/call_indirect.9.wat:1:57: error: expected 0 results, got 1
   ...0 funcref)(func (result i32)  (call_indirect (type $sig) (result i32) (i32...

--- a/test/spec/function-references/if.txt
+++ b/test/spec/function-references/if.txt
@@ -49,9 +49,6 @@ out/test/spec/function-references/if.wast:788: assert_malformed passed:
   out/test/spec/function-references/if/if.7.wat:1:47: error: unexpected token $x, expected ).
   ...(i32.const 0) (i32.const 1)  (if (param $x i32) (then (drop)) (else (drop))))
                                              ^^
-  out/test/spec/function-references/if/if.7.wat:1:69: error: unexpected token (, expected EOF.
-  ...(i32.const 0) (i32.const 1)  (if (param $x i32) (then (drop)) (else (drop))))
-                                                                   ^
 out/test/spec/function-references/if.wast:796: assert_malformed passed:
   out/test/spec/function-references/if/if.8.wat:1:40: error: expected 0 results, got 1
   (type $sig (func))(func (i32.const 1)  (if (type $sig) (result i32) (then (i3...

--- a/test/spec/function-references/return_call_indirect.txt
+++ b/test/spec/function-references/return_call_indirect.txt
@@ -13,51 +13,30 @@ out/test/spec/function-references/return_call_indirect.wast:273: assert_malforme
   out/test/spec/function-references/return_call_indirect/return_call_indirect.1.wat:1:129: error: unexpected token "param", expected an expr.
   ...indirect (type $sig) (result i32) (param i32)    (i32.const 0) (i32.const ...
                                         ^^^^^
-  out/test/spec/function-references/return_call_indirect/return_call_indirect.1.wat:1:173: error: unexpected token ), expected EOF.
-  ...irect (type $sig) (result i32) (param i32)    (i32.const 0) (i32.const 0)  ))
-                                                                                 ^
 out/test/spec/function-references/return_call_indirect.wast:285: assert_malformed passed:
   out/test/spec/function-references/return_call_indirect/return_call_indirect.2.wat:1:116: error: unexpected token "type", expected an expr.
   ...(return_call_indirect (param i32) (type $sig) (result i32)    (i32.const 0...
                                         ^^^^
-  out/test/spec/function-references/return_call_indirect/return_call_indirect.2.wat:1:173: error: unexpected token ), expected EOF.
-  ...irect (param i32) (type $sig) (result i32)    (i32.const 0) (i32.const 0)  ))
-                                                                                 ^
 out/test/spec/function-references/return_call_indirect.wast:297: assert_malformed passed:
   out/test/spec/function-references/return_call_indirect/return_call_indirect.3.wat:1:129: error: unexpected token "type", expected an expr.
   ...indirect (param i32) (result i32) (type $sig)    (i32.const 0) (i32.const ...
                                         ^^^^
-  out/test/spec/function-references/return_call_indirect/return_call_indirect.3.wat:1:173: error: unexpected token ), expected EOF.
-  ...irect (param i32) (result i32) (type $sig)    (i32.const 0) (i32.const 0)  ))
-                                                                                 ^
 out/test/spec/function-references/return_call_indirect.wast:309: assert_malformed passed:
   out/test/spec/function-references/return_call_indirect/return_call_indirect.4.wat:1:117: error: unexpected token "type", expected an expr.
   ...return_call_indirect (result i32) (type $sig) (param i32)    (i32.const 0)...
                                         ^^^^
-  out/test/spec/function-references/return_call_indirect/return_call_indirect.4.wat:1:173: error: unexpected token ), expected EOF.
-  ...irect (result i32) (type $sig) (param i32)    (i32.const 0) (i32.const 0)  ))
-                                                                                 ^
 out/test/spec/function-references/return_call_indirect.wast:321: assert_malformed passed:
   out/test/spec/function-references/return_call_indirect/return_call_indirect.5.wat:1:117: error: unexpected token "param", expected an expr.
   ...return_call_indirect (result i32) (param i32) (type $sig)    (i32.const 0)...
                                         ^^^^^
-  out/test/spec/function-references/return_call_indirect/return_call_indirect.5.wat:1:173: error: unexpected token ), expected EOF.
-  ...irect (result i32) (param i32) (type $sig)    (i32.const 0) (i32.const 0)  ))
-                                                                                 ^
 out/test/spec/function-references/return_call_indirect.wast:333: assert_malformed passed:
   out/test/spec/function-references/return_call_indirect/return_call_indirect.6.wat:1:74: error: unexpected token "param", expected an expr.
   ...return_call_indirect (result i32) (param i32)    (i32.const 0) (i32.const ...
                                         ^^^^^
-  out/test/spec/function-references/return_call_indirect/return_call_indirect.6.wat:1:118: error: unexpected token ), expected EOF.
-  ...urn_call_indirect (result i32) (param i32)    (i32.const 0) (i32.const 0)  ))
-                                                                                 ^
 out/test/spec/function-references/return_call_indirect.wast:345: assert_malformed passed:
   out/test/spec/function-references/return_call_indirect/return_call_indirect.7.wat:1:53: error: unexpected token $x, expected ).
   ...cref)(func (return_call_indirect (param $x i32) (i32.const 0) (i32.const 0)))
                                              ^^
-  out/test/spec/function-references/return_call_indirect/return_call_indirect.7.wat:1:89: error: unexpected token ), expected EOF.
-  ...cref)(func (return_call_indirect (param $x i32) (i32.const 0) (i32.const 0)))
-                                                                                 ^
 out/test/spec/function-references/return_call_indirect.wast:352: assert_malformed passed:
   out/test/spec/function-references/return_call_indirect/return_call_indirect.8.wat:1:57: error: expected 0 results, got 1
   ...ncref)(func (result i32)  (return_call_indirect (type $sig) (result i32) (...

--- a/test/spec/if.txt
+++ b/test/spec/if.txt
@@ -48,9 +48,6 @@ out/test/spec/if.wast:788: assert_malformed passed:
   out/test/spec/if/if.7.wat:1:47: error: unexpected token $x, expected ).
   ...(i32.const 0) (i32.const 1)  (if (param $x i32) (then (drop)) (else (drop))))
                                              ^^
-  out/test/spec/if/if.7.wat:1:69: error: unexpected token (, expected EOF.
-  ...(i32.const 0) (i32.const 1)  (if (param $x i32) (then (drop)) (else (drop))))
-                                                                   ^
 out/test/spec/if.wast:796: assert_malformed passed:
   out/test/spec/if/if.8.wat:1:40: error: expected 0 results, got 1
   (type $sig (func))(func (i32.const 1)  (if (type $sig) (result i32) (then (i3...

--- a/test/spec/loop.txt
+++ b/test/spec/loop.txt
@@ -29,9 +29,6 @@ out/test/spec/loop.wast:568: assert_malformed passed:
   out/test/spec/loop/loop.7.wat:1:34: error: unexpected token $x, expected ).
   (func (i32.const 0) (loop (param $x i32) (drop)))
                                    ^^
-  out/test/spec/loop/loop.7.wat:1:49: error: unexpected token ), expected EOF.
-  (func (i32.const 0) (loop (param $x i32) (drop)))
-                                                  ^
 out/test/spec/loop.wast:572: assert_malformed passed:
   out/test/spec/loop/loop.8.wat:1:25: error: expected 0 results, got 1
   (type $sig (func))(func (loop (type $sig) (result i32) (i32.const 0)) (unreac...

--- a/test/spec/memory64/call_indirect.txt
+++ b/test/spec/memory64/call_indirect.txt
@@ -24,51 +24,30 @@ out/test/spec/memory64/call_indirect.wast:679: assert_malformed passed:
   out/test/spec/memory64/call_indirect/call_indirect.2.wat:1:122: error: unexpected token "param", expected an expr.
   ...indirect (type $sig) (result i32) (param i32)    (i32.const 0) (i32.const ...
                                         ^^^^^
-  out/test/spec/memory64/call_indirect/call_indirect.2.wat:1:166: error: unexpected token ), expected EOF.
-  ...irect (type $sig) (result i32) (param i32)    (i32.const 0) (i32.const 0)  ))
-                                                                                 ^
 out/test/spec/memory64/call_indirect.wast:691: assert_malformed passed:
   out/test/spec/memory64/call_indirect/call_indirect.3.wat:1:109: error: unexpected token "type", expected an expr.
   ... i32)  (call_indirect (param i32) (type $sig) (result i32)    (i32.const 0...
                                         ^^^^
-  out/test/spec/memory64/call_indirect/call_indirect.3.wat:1:166: error: unexpected token ), expected EOF.
-  ...irect (param i32) (type $sig) (result i32)    (i32.const 0) (i32.const 0)  ))
-                                                                                 ^
 out/test/spec/memory64/call_indirect.wast:703: assert_malformed passed:
   out/test/spec/memory64/call_indirect/call_indirect.4.wat:1:122: error: unexpected token "type", expected an expr.
   ...indirect (param i32) (result i32) (type $sig)    (i32.const 0) (i32.const ...
                                         ^^^^
-  out/test/spec/memory64/call_indirect/call_indirect.4.wat:1:166: error: unexpected token ), expected EOF.
-  ...irect (param i32) (result i32) (type $sig)    (i32.const 0) (i32.const 0)  ))
-                                                                                 ^
 out/test/spec/memory64/call_indirect.wast:715: assert_malformed passed:
   out/test/spec/memory64/call_indirect/call_indirect.5.wat:1:110: error: unexpected token "type", expected an expr.
   ...i32)  (call_indirect (result i32) (type $sig) (param i32)    (i32.const 0)...
                                         ^^^^
-  out/test/spec/memory64/call_indirect/call_indirect.5.wat:1:166: error: unexpected token ), expected EOF.
-  ...irect (result i32) (type $sig) (param i32)    (i32.const 0) (i32.const 0)  ))
-                                                                                 ^
 out/test/spec/memory64/call_indirect.wast:727: assert_malformed passed:
   out/test/spec/memory64/call_indirect/call_indirect.6.wat:1:110: error: unexpected token "param", expected an expr.
   ...i32)  (call_indirect (result i32) (param i32) (type $sig)    (i32.const 0)...
                                         ^^^^^
-  out/test/spec/memory64/call_indirect/call_indirect.6.wat:1:166: error: unexpected token ), expected EOF.
-  ...irect (result i32) (param i32) (type $sig)    (i32.const 0) (i32.const 0)  ))
-                                                                                 ^
 out/test/spec/memory64/call_indirect.wast:739: assert_malformed passed:
   out/test/spec/memory64/call_indirect/call_indirect.7.wat:1:67: error: unexpected token "param", expected an expr.
   ...t i32)  (call_indirect (result i32) (param i32) (i32.const 0) (i32.const 0)))
                                           ^^^^^
-  out/test/spec/memory64/call_indirect/call_indirect.7.wat:1:106: error: unexpected token ), expected EOF.
-  ...t i32)  (call_indirect (result i32) (param i32) (i32.const 0) (i32.const 0)))
-                                                                                 ^
 out/test/spec/memory64/call_indirect.wast:749: assert_malformed passed:
   out/test/spec/memory64/call_indirect/call_indirect.8.wat:1:46: error: unexpected token $x, expected ).
   ...e 0 funcref)(func (call_indirect (param $x i32) (i32.const 0) (i32.const 0)))
                                              ^^
-  out/test/spec/memory64/call_indirect/call_indirect.8.wat:1:82: error: unexpected token ), expected EOF.
-  ...e 0 funcref)(func (call_indirect (param $x i32) (i32.const 0) (i32.const 0)))
-                                                                                 ^
 out/test/spec/memory64/call_indirect.wast:756: assert_malformed passed:
   out/test/spec/memory64/call_indirect/call_indirect.9.wat:1:57: error: expected 0 results, got 1
   ...0 funcref)(func (result i32)  (call_indirect (type $sig) (result i32) (i32...

--- a/test/spec/memory64/simd_address.txt
+++ b/test/spec/memory64/simd_address.txt
@@ -11,17 +11,11 @@ out/test/spec/memory64/simd_address.wast:113: assert_malformed passed:
   out/test/spec/memory64/simd_address/simd_address.2.wat:1:35: error: unexpected token offset=-1, expected ).
   (memory 1)(func  (drop (v128.load offset=-1 (i32.const 0))))
                                     ^^^^^^^^^
-  out/test/spec/memory64/simd_address/simd_address.2.wat:1:60: error: unexpected token ), expected EOF.
-  (memory 1)(func  (drop (v128.load offset=-1 (i32.const 0))))
-                                                             ^
 out/test/spec/memory64/simd_address.wast:128: assert_trap passed: out of bounds memory access: access at 65521+16 >= max value 65536
 out/test/spec/memory64/simd_address.wast:131: assert_malformed passed:
   out/test/spec/memory64/simd_address/simd_address.4.wat:1:30: error: unexpected token offset=-1, expected ).
   (memory 1)(func  (v128.store offset=-1 (i32.const 0) (v128.const i32x4 0 0 0 ...
                                ^^^^^^^^^
-  out/test/spec/memory64/simd_address/simd_address.4.wat:1:81: error: unexpected token ), expected EOF.
-  ...ory 1)(func  (v128.store offset=-1 (i32.const 0) (v128.const i32x4 0 0 0 0)))
-                                                                                 ^
 out/test/spec/memory64/simd_address.wast:144: assert_invalid passed:
   out/test/spec/memory64/simd_address/simd_address.5.wat:1:24: error: offset must be less than or equal to 0xffffffff
   (memory 1)(func (drop (v128.load offset=4294967296 (i32.const 0))))

--- a/test/spec/obsolete-keywords.txt
+++ b/test/spec/obsolete-keywords.txt
@@ -9,9 +9,6 @@ out/test/spec/obsolete-keywords.wast:11: assert_malformed passed:
   out/test/spec/obsolete-keywords/obsolete-keywords.1.wat:1:24: error: unexpected token "grow_memory", expected an expr.
   (memory 1)(func (drop (grow_memory (i32.const 0))))
                          ^^^^^^^^^^^
-  out/test/spec/obsolete-keywords/obsolete-keywords.1.wat:1:50: error: unexpected token ), expected EOF.
-  (memory 1)(func (drop (grow_memory (i32.const 0))))
-                                                   ^
 out/test/spec/obsolete-keywords.wast:20: assert_malformed passed:
   out/test/spec/obsolete-keywords/obsolete-keywords.2.wat:1:29: error: unexpected token "get_local", expected an expr.
   (func (local $i i32) (drop (get_local $i)))
@@ -24,9 +21,6 @@ out/test/spec/obsolete-keywords.wast:34: assert_malformed passed:
   out/test/spec/obsolete-keywords/obsolete-keywords.4.wat:1:29: error: unexpected token "tee_local", expected an expr.
   (func (local $i i32) (drop (tee_local $i (i32.const 0))))
                               ^^^^^^^^^
-  out/test/spec/obsolete-keywords/obsolete-keywords.4.wat:1:56: error: unexpected token ), expected EOF.
-  (func (local $i i32) (drop (tee_local $i (i32.const 0))))
-                                                         ^
 out/test/spec/obsolete-keywords.wast:41: assert_malformed passed:
   out/test/spec/obsolete-keywords/obsolete-keywords.5.wat:1:12: error: unexpected token "anyfunc", expected i32, i64, f32, f64, v128, externref, exnref or funcref.
   (global $g anyfunc (ref.null func))
@@ -43,22 +37,13 @@ out/test/spec/obsolete-keywords.wast:64: assert_malformed passed:
   out/test/spec/obsolete-keywords/obsolete-keywords.8.wat:1:14: error: unexpected token "i32.wrap/i64", expected an expr.
   (func (drop (i32.wrap/i64 (i64.const 0))))
                ^^^^^^^^^^^^
-  out/test/spec/obsolete-keywords/obsolete-keywords.8.wat:1:41: error: unexpected token ), expected EOF.
-  (func (drop (i32.wrap/i64 (i64.const 0))))
-                                          ^
 out/test/spec/obsolete-keywords.wast:71: assert_malformed passed:
   out/test/spec/obsolete-keywords/obsolete-keywords.9.wat:1:14: error: unexpected token "i32.trunc_s:sat/f32", expected an expr.
   (func (drop (i32.trunc_s:sat/f32 (f32.const 0))))
                ^^^^^^^^^^^^^^^^^^^
-  out/test/spec/obsolete-keywords/obsolete-keywords.9.wat:1:48: error: unexpected token ), expected EOF.
-  (func (drop (i32.trunc_s:sat/f32 (f32.const 0))))
-                                                 ^
 out/test/spec/obsolete-keywords.wast:78: assert_malformed passed:
   out/test/spec/obsolete-keywords/obsolete-keywords.10.wat:1:14: error: unexpected token "f32x4.convert_s/i32x4", expected an expr.
   (func (drop (f32x4.convert_s/i32x4 (v128.const i64x2 0 0))))
                ^^^^^^^^^^^^^^^^^^^^^
-  out/test/spec/obsolete-keywords/obsolete-keywords.10.wat:1:59: error: unexpected token ), expected EOF.
-  (func (drop (f32x4.convert_s/i32x4 (v128.const i64x2 0 0))))
-                                                            ^
 11/11 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/simd_address.txt
+++ b/test/spec/simd_address.txt
@@ -10,17 +10,11 @@ out/test/spec/simd_address.wast:113: assert_malformed passed:
   out/test/spec/simd_address/simd_address.2.wat:1:35: error: unexpected token offset=-1, expected ).
   (memory 1)(func  (drop (v128.load offset=-1 (i32.const 0))))
                                     ^^^^^^^^^
-  out/test/spec/simd_address/simd_address.2.wat:1:60: error: unexpected token ), expected EOF.
-  (memory 1)(func  (drop (v128.load offset=-1 (i32.const 0))))
-                                                             ^
 out/test/spec/simd_address.wast:128: assert_trap passed: out of bounds memory access: access at 65521+16 >= max value 65536
 out/test/spec/simd_address.wast:131: assert_malformed passed:
   out/test/spec/simd_address/simd_address.4.wat:1:30: error: unexpected token offset=-1, expected ).
   (memory 1)(func  (v128.store offset=-1 (i32.const 0) (v128.const i32x4 0 0 0 ...
                                ^^^^^^^^^
-  out/test/spec/simd_address/simd_address.4.wat:1:81: error: unexpected token ), expected EOF.
-  ...ory 1)(func  (v128.store offset=-1 (i32.const 0) (v128.const i32x4 0 0 0 0)))
-                                                                                 ^
 out/test/spec/simd_address.wast:144: assert_malformed passed:
   out/test/spec/simd_address/simd_address.5.wat:1:34: error: offset must be less than or equal to 0xffffffff
   (memory 1)(func (drop (v128.load offset=4294967296 (i32.const 0))))

--- a/test/spec/simd_align.txt
+++ b/test/spec/simd_align.txt
@@ -41,9 +41,6 @@ out/test/spec/simd_align.wast:105: assert_malformed passed:
   out/test/spec/simd_align/simd_align.56.wat:1:35: error: unexpected token align=-1, expected ).
   (memory 1) (func (drop (v128.load align=-1 (i32.const 0))))
                                     ^^^^^^^^
-  out/test/spec/simd_align/simd_align.56.wat:1:59: error: unexpected token ), expected EOF.
-  (memory 1) (func (drop (v128.load align=-1 (i32.const 0))))
-                                                            ^
 out/test/spec/simd_align.wast:111: assert_malformed passed:
   out/test/spec/simd_align/simd_align.57.wat:1:35: error: alignment must be power-of-two
   (memory 1) (func (drop (v128.load align=0 (i32.const 0))))
@@ -56,9 +53,6 @@ out/test/spec/simd_align.wast:123: assert_malformed passed:
   out/test/spec/simd_align/simd_align.59.wat:1:30: error: unexpected token align=-1, expected ).
   (memory 1) (func (v128.store align=-1 (i32.const 0) (v128.const i32x4 0 0 0 0)))
                                ^^^^^^^^
-  out/test/spec/simd_align/simd_align.59.wat:1:80: error: unexpected token ), expected EOF.
-  (memory 1) (func (v128.store align=-1 (i32.const 0) (v128.const i32x4 0 0 0 0)))
-                                                                                 ^
 out/test/spec/simd_align.wast:129: assert_malformed passed:
   out/test/spec/simd_align/simd_align.60.wat:1:30: error: alignment must be power-of-two
   (memory 0) (func (v128.store align=0 (i32.const 0) (v128.const i32x4 0 0 0 0)))
@@ -71,9 +65,6 @@ out/test/spec/simd_align.wast:141: assert_malformed passed:
   out/test/spec/simd_align/simd_align.62.wat:1:48: error: unexpected token align=-1, expected ).
   (memory 1) (func (result v128) (v128.load8x8_s align=-1 (i32.const 0)))
                                                  ^^^^^^^^
-  out/test/spec/simd_align/simd_align.62.wat:1:71: error: unexpected token ), expected EOF.
-  (memory 1) (func (result v128) (v128.load8x8_s align=-1 (i32.const 0)))
-                                                                        ^
 out/test/spec/simd_align.wast:147: assert_malformed passed:
   out/test/spec/simd_align/simd_align.63.wat:1:48: error: alignment must be power-of-two
   (memory 1) (func (result v128) (v128.load8x8_s align=0 (i32.const 0)))
@@ -86,9 +77,6 @@ out/test/spec/simd_align.wast:159: assert_malformed passed:
   out/test/spec/simd_align/simd_align.65.wat:1:48: error: unexpected token align=-1, expected ).
   (memory 1) (func (result v128) (v128.load8x8_u align=-1 (i32.const 0)))
                                                  ^^^^^^^^
-  out/test/spec/simd_align/simd_align.65.wat:1:71: error: unexpected token ), expected EOF.
-  (memory 1) (func (result v128) (v128.load8x8_u align=-1 (i32.const 0)))
-                                                                        ^
 out/test/spec/simd_align.wast:165: assert_malformed passed:
   out/test/spec/simd_align/simd_align.66.wat:1:48: error: alignment must be power-of-two
   (memory 1) (func (result v128) (v128.load8x8_u align=0 (i32.const 0)))
@@ -101,9 +89,6 @@ out/test/spec/simd_align.wast:177: assert_malformed passed:
   out/test/spec/simd_align/simd_align.68.wat:1:49: error: unexpected token align=-1, expected ).
   (memory 1) (func (result v128) (v128.load16x4_s align=-1 (i32.const 0)))
                                                   ^^^^^^^^
-  out/test/spec/simd_align/simd_align.68.wat:1:72: error: unexpected token ), expected EOF.
-  (memory 1) (func (result v128) (v128.load16x4_s align=-1 (i32.const 0)))
-                                                                         ^
 out/test/spec/simd_align.wast:183: assert_malformed passed:
   out/test/spec/simd_align/simd_align.69.wat:1:49: error: alignment must be power-of-two
   (memory 1) (func (result v128) (v128.load16x4_s align=0 (i32.const 0)))
@@ -116,9 +101,6 @@ out/test/spec/simd_align.wast:195: assert_malformed passed:
   out/test/spec/simd_align/simd_align.71.wat:1:49: error: unexpected token align=-1, expected ).
   (memory 1) (func (result v128) (v128.load16x4_u align=-1 (i32.const 0)))
                                                   ^^^^^^^^
-  out/test/spec/simd_align/simd_align.71.wat:1:72: error: unexpected token ), expected EOF.
-  (memory 1) (func (result v128) (v128.load16x4_u align=-1 (i32.const 0)))
-                                                                         ^
 out/test/spec/simd_align.wast:201: assert_malformed passed:
   out/test/spec/simd_align/simd_align.72.wat:1:49: error: alignment must be power-of-two
   (memory 1) (func (result v128) (v128.load16x4_u align=0 (i32.const 0)))
@@ -131,9 +113,6 @@ out/test/spec/simd_align.wast:213: assert_malformed passed:
   out/test/spec/simd_align/simd_align.74.wat:1:49: error: unexpected token align=-1, expected ).
   (memory 1) (func (result v128) (v128.load32x2_s align=-1 (i32.const 0)))
                                                   ^^^^^^^^
-  out/test/spec/simd_align/simd_align.74.wat:1:72: error: unexpected token ), expected EOF.
-  (memory 1) (func (result v128) (v128.load32x2_s align=-1 (i32.const 0)))
-                                                                         ^
 out/test/spec/simd_align.wast:219: assert_malformed passed:
   out/test/spec/simd_align/simd_align.75.wat:1:49: error: alignment must be power-of-two
   (memory 1) (func (result v128) (v128.load32x2_s align=0 (i32.const 0)))
@@ -146,9 +125,6 @@ out/test/spec/simd_align.wast:231: assert_malformed passed:
   out/test/spec/simd_align/simd_align.77.wat:1:49: error: unexpected token align=-1, expected ).
   (memory 1) (func (result v128) (v128.load32x2_u align=-1 (i32.const 0)))
                                                   ^^^^^^^^
-  out/test/spec/simd_align/simd_align.77.wat:1:72: error: unexpected token ), expected EOF.
-  (memory 1) (func (result v128) (v128.load32x2_u align=-1 (i32.const 0)))
-                                                                         ^
 out/test/spec/simd_align.wast:237: assert_malformed passed:
   out/test/spec/simd_align/simd_align.78.wat:1:49: error: alignment must be power-of-two
   (memory 1) (func (result v128) (v128.load32x2_u align=0 (i32.const 0)))
@@ -161,9 +137,6 @@ out/test/spec/simd_align.wast:249: assert_malformed passed:
   out/test/spec/simd_align/simd_align.80.wat:1:50: error: unexpected token align=-1, expected ).
   (memory 1) (func (result v128) (v128.load8_splat align=-1 (i32.const 0)))
                                                    ^^^^^^^^
-  out/test/spec/simd_align/simd_align.80.wat:1:73: error: unexpected token ), expected EOF.
-  (memory 1) (func (result v128) (v128.load8_splat align=-1 (i32.const 0)))
-                                                                          ^
 out/test/spec/simd_align.wast:255: assert_malformed passed:
   out/test/spec/simd_align/simd_align.81.wat:1:50: error: alignment must be power-of-two
   (memory 1) (func (result v128) (v128.load8_splat align=0 (i32.const 0)))
@@ -172,9 +145,6 @@ out/test/spec/simd_align.wast:261: assert_malformed passed:
   out/test/spec/simd_align/simd_align.82.wat:1:51: error: unexpected token align=-1, expected ).
   (memory 1) (func (result v128) (v128.load16_splat align=-1 (i32.const 0)))
                                                     ^^^^^^^^
-  out/test/spec/simd_align/simd_align.82.wat:1:74: error: unexpected token ), expected EOF.
-  (memory 1) (func (result v128) (v128.load16_splat align=-1 (i32.const 0)))
-                                                                           ^
 out/test/spec/simd_align.wast:267: assert_malformed passed:
   out/test/spec/simd_align/simd_align.83.wat:1:51: error: alignment must be power-of-two
   (memory 1) (func (result v128) (v128.load16_splat align=0 (i32.const 0)))
@@ -183,9 +153,6 @@ out/test/spec/simd_align.wast:273: assert_malformed passed:
   out/test/spec/simd_align/simd_align.84.wat:1:51: error: unexpected token align=-1, expected ).
   (memory 1) (func (result v128) (v128.load32_splat align=-1 (i32.const 0)))
                                                     ^^^^^^^^
-  out/test/spec/simd_align/simd_align.84.wat:1:74: error: unexpected token ), expected EOF.
-  (memory 1) (func (result v128) (v128.load32_splat align=-1 (i32.const 0)))
-                                                                           ^
 out/test/spec/simd_align.wast:279: assert_malformed passed:
   out/test/spec/simd_align/simd_align.85.wat:1:51: error: alignment must be power-of-two
   (memory 1) (func (result v128) (v128.load32_splat align=0 (i32.const 0)))
@@ -198,9 +165,6 @@ out/test/spec/simd_align.wast:291: assert_malformed passed:
   out/test/spec/simd_align/simd_align.87.wat:1:51: error: unexpected token align=-1, expected ).
   (memory 1) (func (result v128) (v128.load64_splat align=-1 (i32.const 0)))
                                                     ^^^^^^^^
-  out/test/spec/simd_align/simd_align.87.wat:1:74: error: unexpected token ), expected EOF.
-  (memory 1) (func (result v128) (v128.load64_splat align=-1 (i32.const 0)))
-                                                                           ^
 out/test/spec/simd_align.wast:297: assert_malformed passed:
   out/test/spec/simd_align/simd_align.88.wat:1:51: error: alignment must be power-of-two
   (memory 1) (func (result v128) (v128.load64_splat align=0 (i32.const 0)))

--- a/test/spec/simd_lane.txt
+++ b/test/spec/simd_lane.txt
@@ -5,198 +5,114 @@ out/test/spec/simd_lane.wast:398: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.1.wat:1:21: error: invalid literal "-1"
   (func (result i32) (i8x16.extract_lane_s  -1 (v128.const i8x16 0 0 0 0 0 0 0 ...
                       ^^^^^^^^^^^^^^^^^^^^
-  out/test/spec/simd_lane/simd_lane.1.wat:1:97: error: unexpected token ), expected EOF.
-  ...i8x16.extract_lane_s  -1 (v128.const i8x16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0)))
-                                                                                 ^
 out/test/spec/simd_lane.wast:399: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.2.wat:1:21: error: invalid literal "-1"
   (func (result i32) (i8x16.extract_lane_u  -1 (v128.const i8x16 0 0 0 0 0 0 0 ...
                       ^^^^^^^^^^^^^^^^^^^^
-  out/test/spec/simd_lane/simd_lane.2.wat:1:97: error: unexpected token ), expected EOF.
-  ...i8x16.extract_lane_u  -1 (v128.const i8x16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0)))
-                                                                                 ^
 out/test/spec/simd_lane.wast:400: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.3.wat:1:21: error: invalid literal "-1"
   (func (result i32) (i16x8.extract_lane_s  -1 (v128.const i16x8 0 0 0 0 0 0 0 ...
                       ^^^^^^^^^^^^^^^^^^^^
-  out/test/spec/simd_lane/simd_lane.3.wat:1:81: error: unexpected token ), expected EOF.
-  ...c (result i32) (i16x8.extract_lane_s  -1 (v128.const i16x8 0 0 0 0 0 0 0 0)))
-                                                                                 ^
 out/test/spec/simd_lane.wast:401: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.4.wat:1:21: error: invalid literal "-1"
   (func (result i32) (i16x8.extract_lane_u  -1 (v128.const i16x8 0 0 0 0 0 0 0 ...
                       ^^^^^^^^^^^^^^^^^^^^
-  out/test/spec/simd_lane/simd_lane.4.wat:1:81: error: unexpected token ), expected EOF.
-  ...c (result i32) (i16x8.extract_lane_u  -1 (v128.const i16x8 0 0 0 0 0 0 0 0)))
-                                                                                 ^
 out/test/spec/simd_lane.wast:402: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.5.wat:1:21: error: invalid literal "-1"
   (func (result i32) (i32x4.extract_lane  -1 (v128.const i32x4 0 0 0 0)))
                       ^^^^^^^^^^^^^^^^^^
-  out/test/spec/simd_lane/simd_lane.5.wat:1:71: error: unexpected token ), expected EOF.
-  (func (result i32) (i32x4.extract_lane  -1 (v128.const i32x4 0 0 0 0)))
-                                                                        ^
 out/test/spec/simd_lane.wast:403: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.6.wat:1:21: error: invalid literal "-1"
   (func (result f32) (f32x4.extract_lane  -1 (v128.const f32x4 0 0 0 0)))
                       ^^^^^^^^^^^^^^^^^^
-  out/test/spec/simd_lane/simd_lane.6.wat:1:71: error: unexpected token ), expected EOF.
-  (func (result f32) (f32x4.extract_lane  -1 (v128.const f32x4 0 0 0 0)))
-                                                                        ^
 out/test/spec/simd_lane.wast:404: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.7.wat:1:22: error: invalid literal "-1"
   (func (result v128) (i8x16.replace_lane  -1 (v128.const i8x16 0 0 0 0 0 0 0 0...
                        ^^^^^^^^^^^^^^^^^^
-  out/test/spec/simd_lane/simd_lane.7.wat:1:110: error: unexpected token ), expected EOF.
-  ...e_lane  -1 (v128.const i8x16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0) (i32.const 1)))
-                                                                                 ^
 out/test/spec/simd_lane.wast:405: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.8.wat:1:22: error: invalid literal "-1"
   (func (result v128) (i16x8.replace_lane  -1 (v128.const i16x8 0 0 0 0 0 0 0 0...
                        ^^^^^^^^^^^^^^^^^^
-  out/test/spec/simd_lane/simd_lane.8.wat:1:94: error: unexpected token ), expected EOF.
-  ...8) (i16x8.replace_lane  -1 (v128.const i16x8 0 0 0 0 0 0 0 0) (i32.const 1)))
-                                                                                 ^
 out/test/spec/simd_lane.wast:406: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.9.wat:1:22: error: invalid literal "-1"
   (func (result v128) (i32x4.replace_lane  -1 (v128.const i32x4 0 0 0 0) (i32.c...
                        ^^^^^^^^^^^^^^^^^^
-  out/test/spec/simd_lane/simd_lane.9.wat:1:86: error: unexpected token ), expected EOF.
-  ...sult v128) (i32x4.replace_lane  -1 (v128.const i32x4 0 0 0 0) (i32.const 1)))
-                                                                                 ^
 out/test/spec/simd_lane.wast:407: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.10.wat:1:22: error: invalid literal "-1"
   (func (result v128) (f32x4.replace_lane  -1 (v128.const f32x4 0 0 0 0) (i32.c...
                        ^^^^^^^^^^^^^^^^^^
-  out/test/spec/simd_lane/simd_lane.10.wat:1:86: error: unexpected token ), expected EOF.
-  ...sult v128) (f32x4.replace_lane  -1 (v128.const f32x4 0 0 0 0) (i32.const 1)))
-                                                                                 ^
 out/test/spec/simd_lane.wast:408: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.11.wat:1:21: error: invalid literal "-1"
   (func (result i64) (i64x2.extract_lane  -1 (v128.const i64x2 0 0)))
                       ^^^^^^^^^^^^^^^^^^
-  out/test/spec/simd_lane/simd_lane.11.wat:1:67: error: unexpected token ), expected EOF.
-  (func (result i64) (i64x2.extract_lane  -1 (v128.const i64x2 0 0)))
-                                                                    ^
 out/test/spec/simd_lane.wast:409: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.12.wat:1:21: error: invalid literal "-1"
   (func (result f64) (f64x2.extract_lane  -1 (v128.const f64x2 0 0)))
                       ^^^^^^^^^^^^^^^^^^
-  out/test/spec/simd_lane/simd_lane.12.wat:1:67: error: unexpected token ), expected EOF.
-  (func (result f64) (f64x2.extract_lane  -1 (v128.const f64x2 0 0)))
-                                                                    ^
 out/test/spec/simd_lane.wast:410: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.13.wat:1:22: error: invalid literal "-1"
   (func (result v128) (i64x2.replace_lane  -1 (v128.const i64x2 0 0) (i64.const...
                        ^^^^^^^^^^^^^^^^^^
-  out/test/spec/simd_lane/simd_lane.13.wat:1:82: error: unexpected token ), expected EOF.
-  ... (result v128) (i64x2.replace_lane  -1 (v128.const i64x2 0 0) (i64.const 1)))
-                                                                                 ^
 out/test/spec/simd_lane.wast:411: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.14.wat:1:22: error: invalid literal "-1"
   (func (result v128) (f64x2.replace_lane  -1 (v128.const f64x2 0 0) (f64.const...
                        ^^^^^^^^^^^^^^^^^^
-  out/test/spec/simd_lane/simd_lane.14.wat:1:82: error: unexpected token ), expected EOF.
-  ... (result v128) (f64x2.replace_lane  -1 (v128.const f64x2 0 0) (f64.const 1)))
-                                                                                 ^
 out/test/spec/simd_lane.wast:415: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.15.wat:1:21: error: lane index "256" out-of-range [0, 32)
   (func (result i32) (i8x16.extract_lane_s 256 (v128.const i8x16 0 0 0 0 0 0 0 ...
                       ^^^^^^^^^^^^^^^^^^^^
-  out/test/spec/simd_lane/simd_lane.15.wat:1:97: error: unexpected token ), expected EOF.
-  ...i8x16.extract_lane_s 256 (v128.const i8x16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0)))
-                                                                                 ^
 out/test/spec/simd_lane.wast:416: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.16.wat:1:21: error: lane index "256" out-of-range [0, 32)
   (func (result i32) (i8x16.extract_lane_u 256 (v128.const i8x16 0 0 0 0 0 0 0 ...
                       ^^^^^^^^^^^^^^^^^^^^
-  out/test/spec/simd_lane/simd_lane.16.wat:1:97: error: unexpected token ), expected EOF.
-  ...i8x16.extract_lane_u 256 (v128.const i8x16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0)))
-                                                                                 ^
 out/test/spec/simd_lane.wast:417: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.17.wat:1:21: error: lane index "256" out-of-range [0, 32)
   (func (result i32) (i16x8.extract_lane_s 256 (v128.const i16x8 0 0 0 0 0 0 0 ...
                       ^^^^^^^^^^^^^^^^^^^^
-  out/test/spec/simd_lane/simd_lane.17.wat:1:81: error: unexpected token ), expected EOF.
-  ...c (result i32) (i16x8.extract_lane_s 256 (v128.const i16x8 0 0 0 0 0 0 0 0)))
-                                                                                 ^
 out/test/spec/simd_lane.wast:418: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.18.wat:1:21: error: lane index "256" out-of-range [0, 32)
   (func (result i32) (i16x8.extract_lane_u 256 (v128.const i16x8 0 0 0 0 0 0 0 ...
                       ^^^^^^^^^^^^^^^^^^^^
-  out/test/spec/simd_lane/simd_lane.18.wat:1:81: error: unexpected token ), expected EOF.
-  ...c (result i32) (i16x8.extract_lane_u 256 (v128.const i16x8 0 0 0 0 0 0 0 0)))
-                                                                                 ^
 out/test/spec/simd_lane.wast:419: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.19.wat:1:21: error: lane index "256" out-of-range [0, 32)
   (func (result i32) (i32x4.extract_lane 256 (v128.const i32x4 0 0 0 0)))
                       ^^^^^^^^^^^^^^^^^^
-  out/test/spec/simd_lane/simd_lane.19.wat:1:71: error: unexpected token ), expected EOF.
-  (func (result i32) (i32x4.extract_lane 256 (v128.const i32x4 0 0 0 0)))
-                                                                        ^
 out/test/spec/simd_lane.wast:420: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.20.wat:1:21: error: lane index "256" out-of-range [0, 32)
   (func (result f32) (f32x4.extract_lane 256 (v128.const f32x4 0 0 0 0)))
                       ^^^^^^^^^^^^^^^^^^
-  out/test/spec/simd_lane/simd_lane.20.wat:1:71: error: unexpected token ), expected EOF.
-  (func (result f32) (f32x4.extract_lane 256 (v128.const f32x4 0 0 0 0)))
-                                                                        ^
 out/test/spec/simd_lane.wast:421: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.21.wat:1:22: error: lane index "256" out-of-range [0, 32)
   (func (result v128) (i8x16.replace_lane 256 (v128.const i8x16 0 0 0 0 0 0 0 0...
                        ^^^^^^^^^^^^^^^^^^
-  out/test/spec/simd_lane/simd_lane.21.wat:1:110: error: unexpected token ), expected EOF.
-  ...e_lane 256 (v128.const i8x16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0) (i32.const 1)))
-                                                                                 ^
 out/test/spec/simd_lane.wast:422: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.22.wat:1:22: error: lane index "256" out-of-range [0, 32)
   (func (result v128) (i16x8.replace_lane 256 (v128.const i16x8 0 0 0 0 0 0 0 0...
                        ^^^^^^^^^^^^^^^^^^
-  out/test/spec/simd_lane/simd_lane.22.wat:1:94: error: unexpected token ), expected EOF.
-  ...8) (i16x8.replace_lane 256 (v128.const i16x8 0 0 0 0 0 0 0 0) (i32.const 1)))
-                                                                                 ^
 out/test/spec/simd_lane.wast:423: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.23.wat:1:22: error: lane index "256" out-of-range [0, 32)
   (func (result v128) (i32x4.replace_lane 256 (v128.const i32x4 0 0 0 0) (i32.c...
                        ^^^^^^^^^^^^^^^^^^
-  out/test/spec/simd_lane/simd_lane.23.wat:1:86: error: unexpected token ), expected EOF.
-  ...sult v128) (i32x4.replace_lane 256 (v128.const i32x4 0 0 0 0) (i32.const 1)))
-                                                                                 ^
 out/test/spec/simd_lane.wast:424: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.24.wat:1:22: error: lane index "256" out-of-range [0, 32)
   (func (result v128) (f32x4.replace_lane 256 (v128.const f32x4 0 0 0 0) (i32.c...
                        ^^^^^^^^^^^^^^^^^^
-  out/test/spec/simd_lane/simd_lane.24.wat:1:86: error: unexpected token ), expected EOF.
-  ...sult v128) (f32x4.replace_lane 256 (v128.const f32x4 0 0 0 0) (i32.const 1)))
-                                                                                 ^
 out/test/spec/simd_lane.wast:425: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.25.wat:1:21: error: lane index "256" out-of-range [0, 32)
   (func (result i64) (i64x2.extract_lane 256 (v128.const i64x2 0 0)))
                       ^^^^^^^^^^^^^^^^^^
-  out/test/spec/simd_lane/simd_lane.25.wat:1:67: error: unexpected token ), expected EOF.
-  (func (result i64) (i64x2.extract_lane 256 (v128.const i64x2 0 0)))
-                                                                    ^
 out/test/spec/simd_lane.wast:426: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.26.wat:1:21: error: lane index "256" out-of-range [0, 32)
   (func (result f64) (f64x2.extract_lane 256 (v128.const f64x2 0 0)))
                       ^^^^^^^^^^^^^^^^^^
-  out/test/spec/simd_lane/simd_lane.26.wat:1:67: error: unexpected token ), expected EOF.
-  (func (result f64) (f64x2.extract_lane 256 (v128.const f64x2 0 0)))
-                                                                    ^
 out/test/spec/simd_lane.wast:427: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.27.wat:1:22: error: lane index "256" out-of-range [0, 32)
   (func (result v128) (i64x2.replace_lane 256 (v128.const i64x2 0 0) (i64.const...
                        ^^^^^^^^^^^^^^^^^^
-  out/test/spec/simd_lane/simd_lane.27.wat:1:82: error: unexpected token ), expected EOF.
-  ... (result v128) (i64x2.replace_lane 256 (v128.const i64x2 0 0) (i64.const 1)))
-                                                                                 ^
 out/test/spec/simd_lane.wast:428: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.28.wat:1:22: error: lane index "256" out-of-range [0, 32)
   (func (result v128) (f64x2.replace_lane 256 (v128.const f64x2 0 0) (f64.const...
                        ^^^^^^^^^^^^^^^^^^
-  out/test/spec/simd_lane/simd_lane.28.wat:1:82: error: unexpected token ), expected EOF.
-  ... (result v128) (f64x2.replace_lane 256 (v128.const f64x2 0 0) (f64.const 1)))
-                                                                                 ^
 out/test/spec/simd_lane.wast:432: assert_invalid passed:
   out/test/spec/simd_lane/simd_lane.29.wasm:000002d: error: lane index must be less than 16 (got 16)
   000002d: error: OnSimdLaneOpExpr callback failed
@@ -390,30 +306,18 @@ out/test/spec/simd_lane.wast:515: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.92.wat:1:83: error: unexpected token "(", expected a natural number in range [0, 32).
   ...8x16.shuffle 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 (local.get 0) (local.get 0)))
                                                      ^
-  out/test/spec/simd_lane/simd_lane.92.wat:1:97: error: unexpected token (, expected EOF.
-  ...8x16.shuffle 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 (local.get 0) (local.get 0)))
-                                                                   ^
 out/test/spec/simd_lane.wast:518: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.93.wat:1:86: error: unexpected token 16, expected ).
   ...huffle 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 (local.get 0) (local.get 0)))
                                                   ^^
-  out/test/spec/simd_lane/simd_lane.93.wat:1:117: error: unexpected token ), expected EOF.
-  ...huffle 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 (local.get 0) (local.get 0)))
-                                                                                 ^
 out/test/spec/simd_lane.wast:521: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.94.wat:1:70: error: invalid literal "-1"
   ... 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 -1(v128.const i8x16 15 14 13 12 11 10 ...
                                          ^^
-  out/test/spec/simd_lane/simd_lane.94.wat:1:185: error: unexpected token ), expected EOF.
-  ... 8 7 6 5 4 3 2 1 0)(v128.const i8x16 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15)))
-                                                                                 ^
 out/test/spec/simd_lane.wast:525: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.95.wat:1:70: error: lane index "256" out-of-range [0, 32)
   ... 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 256(v128.const i8x16 15 14 13 12 11 10...
                                          ^^^
-  out/test/spec/simd_lane/simd_lane.95.wat:1:186: error: unexpected token ), expected EOF.
-  ... 8 7 6 5 4 3 2 1 0)(v128.const i8x16 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15)))
-                                                                                 ^
 out/test/spec/simd_lane.wast:529: assert_invalid passed:
   out/test/spec/simd_lane/simd_lane.96.wasm:000004e: error: lane index must be less than 32 (got 255)
   000004e: error: OnSimdShuffleOpExpr callback failed
@@ -461,184 +365,106 @@ out/test/spec/simd_lane.wast:570: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.107.wat:1:54: error: unexpected token "(", expected a natural number in range [0, 32).
   ...) (result i32) (i8x16.extract_lane_s (local.get 0) (v128.const i8x16 0 0 0...
                                           ^
-  out/test/spec/simd_lane/simd_lane.107.wat:1:68: error: unexpected token (, expected EOF.
-  ... (i8x16.extract_lane_s (local.get 0) (v128.const i8x16 0 0 0 0 0 0 0 0 0 0...
-                                          ^
 out/test/spec/simd_lane.wast:571: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.108.wat:1:54: error: unexpected token "(", expected a natural number in range [0, 32).
   ...) (result i32) (i8x16.extract_lane_u (local.get 0) (v128.const i8x16 0 0 0...
-                                          ^
-  out/test/spec/simd_lane/simd_lane.108.wat:1:68: error: unexpected token (, expected EOF.
-  ... (i8x16.extract_lane_u (local.get 0) (v128.const i8x16 0 0 0 0 0 0 0 0 0 0...
                                           ^
 out/test/spec/simd_lane.wast:572: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.109.wat:1:54: error: unexpected token "(", expected a natural number in range [0, 32).
   ...) (result i32) (i16x8.extract_lane_s (local.get 0) (v128.const i16x8 0 0 0...
                                           ^
-  out/test/spec/simd_lane/simd_lane.109.wat:1:68: error: unexpected token (, expected EOF.
-  ...i32) (i16x8.extract_lane_s (local.get 0) (v128.const i16x8 0 0 0 0 0 0 0 0)))
-                                              ^
 out/test/spec/simd_lane.wast:573: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.110.wat:1:54: error: unexpected token "(", expected a natural number in range [0, 32).
   ...) (result i32) (i16x8.extract_lane_u (local.get 0) (v128.const i16x8 0 0 0...
                                           ^
-  out/test/spec/simd_lane/simd_lane.110.wat:1:68: error: unexpected token (, expected EOF.
-  ...i32) (i16x8.extract_lane_u (local.get 0) (v128.const i16x8 0 0 0 0 0 0 0 0)))
-                                              ^
 out/test/spec/simd_lane.wast:574: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.111.wat:1:52: error: unexpected token "(", expected a natural number in range [0, 32).
   ...32) (result i32) (i32x4.extract_lane (local.get 0) (v128.const i32x4 0 0 0...
                                           ^
-  out/test/spec/simd_lane/simd_lane.111.wat:1:66: error: unexpected token (, expected EOF.
-  ...) (result i32) (i32x4.extract_lane (local.get 0) (v128.const i32x4 0 0 0 0)))
-                                                      ^
 out/test/spec/simd_lane.wast:575: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.112.wat:1:52: error: unexpected token "(", expected a natural number in range [0, 32).
   ...32) (result f32) (f32x4.extract_lane (local.get 0) (v128.const f32x4 0 0 0...
                                           ^
-  out/test/spec/simd_lane/simd_lane.112.wat:1:66: error: unexpected token (, expected EOF.
-  ...) (result f32) (f32x4.extract_lane (local.get 0) (v128.const f32x4 0 0 0 0)))
-                                                      ^
 out/test/spec/simd_lane.wast:576: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.113.wat:1:53: error: unexpected token "(", expected a natural number in range [0, 32).
   ...2) (result v128) (i8x16.replace_lane (local.get 0) (v128.const i8x16 0 0 0...
-                                          ^
-  out/test/spec/simd_lane/simd_lane.113.wat:1:67: error: unexpected token (, expected EOF.
-  ...8) (i8x16.replace_lane (local.get 0) (v128.const i8x16 0 0 0 0 0 0 0 0 0 0...
                                           ^
 out/test/spec/simd_lane.wast:577: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.114.wat:1:53: error: unexpected token "(", expected a natural number in range [0, 32).
   ...2) (result v128) (i16x8.replace_lane (local.get 0) (v128.const i16x8 0 0 0...
                                           ^
-  out/test/spec/simd_lane/simd_lane.114.wat:1:67: error: unexpected token (, expected EOF.
-  ...8) (i16x8.replace_lane (local.get 0) (v128.const i16x8 0 0 0 0 0 0 0 0) (i...
-                                          ^
 out/test/spec/simd_lane.wast:578: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.115.wat:1:53: error: unexpected token "(", expected a natural number in range [0, 32).
   ...2) (result v128) (i32x4.replace_lane (local.get 0) (v128.const i32x4 0 0 0...
-                                          ^
-  out/test/spec/simd_lane/simd_lane.115.wat:1:67: error: unexpected token (, expected EOF.
-  ...8) (i32x4.replace_lane (local.get 0) (v128.const i32x4 0 0 0 0) (i32.const...
                                           ^
 out/test/spec/simd_lane.wast:579: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.116.wat:1:53: error: unexpected token "(", expected a natural number in range [0, 32).
   ...2) (result v128) (f32x4.replace_lane (local.get 0) (v128.const f32x4 0 0 0...
                                           ^
-  out/test/spec/simd_lane/simd_lane.116.wat:1:67: error: unexpected token (, expected EOF.
-  ...8) (f32x4.replace_lane (local.get 0) (v128.const f32x4 0 0 0 0) (f32.const...
-                                          ^
 out/test/spec/simd_lane.wast:581: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.117.wat:1:52: error: unexpected token "(", expected a natural number in range [0, 32).
   ... i32) (result i64) (i64x2.extract_lane (local.get 0) (v128.const i64x2 0 0)))
                                             ^
-  out/test/spec/simd_lane/simd_lane.117.wat:1:66: error: unexpected token (, expected EOF.
-  ... i32) (result i64) (i64x2.extract_lane (local.get 0) (v128.const i64x2 0 0)))
-                                                          ^
 out/test/spec/simd_lane.wast:582: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.118.wat:1:52: error: unexpected token "(", expected a natural number in range [0, 32).
   ... i32) (result f64) (f64x2.extract_lane (local.get 0) (v128.const f64x2 0 0)))
                                             ^
-  out/test/spec/simd_lane/simd_lane.118.wat:1:66: error: unexpected token (, expected EOF.
-  ... i32) (result f64) (f64x2.extract_lane (local.get 0) (v128.const f64x2 0 0)))
-                                                          ^
 out/test/spec/simd_lane.wast:583: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.119.wat:1:53: error: unexpected token "(", expected a natural number in range [0, 32).
   ...2) (result v128) (i64x2.replace_lane (local.get 0) (v128.const i64x2 0 0) ...
                                           ^
-  out/test/spec/simd_lane/simd_lane.119.wat:1:67: error: unexpected token (, expected EOF.
-  ...128) (i64x2.replace_lane (local.get 0) (v128.const i64x2 0 0) (i64.const 1)))
-                                            ^
 out/test/spec/simd_lane.wast:584: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.120.wat:1:53: error: unexpected token "(", expected a natural number in range [0, 32).
   ...2) (result v128) (f64x2.replace_lane (local.get 0) (v128.const f64x2 0 0) ...
-                                          ^
-  out/test/spec/simd_lane/simd_lane.120.wat:1:67: error: unexpected token (, expected EOF.
-  ...8) (f64x2.replace_lane (local.get 0) (v128.const f64x2 0 0) (f64.const 1.0)))
                                           ^
 out/test/spec/simd_lane.wast:588: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.121.wat:1:42: error: unexpected token "1.5", expected a natural number in range [0, 32).
   ... (result i32) (i8x16.extract_lane_s 1.5 (v128.const i8x16 0 0 0 0 0 0 0 0 ...
                                          ^^^
-  out/test/spec/simd_lane/simd_lane.121.wat:1:97: error: unexpected token ), expected EOF.
-  ...i8x16.extract_lane_s 1.5 (v128.const i8x16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0)))
-                                                                                 ^
 out/test/spec/simd_lane.wast:589: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.122.wat:1:42: error: unexpected token "nan", expected a natural number in range [0, 32).
   ... (result i32) (i8x16.extract_lane_u nan (v128.const i8x16 0 0 0 0 0 0 0 0 ...
                                          ^^^
-  out/test/spec/simd_lane/simd_lane.122.wat:1:97: error: unexpected token ), expected EOF.
-  ...i8x16.extract_lane_u nan (v128.const i8x16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0)))
-                                                                                 ^
 out/test/spec/simd_lane.wast:590: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.123.wat:1:42: error: unexpected token "inf", expected a natural number in range [0, 32).
   ...c (result i32) (i16x8.extract_lane_s inf (v128.const i16x8 0 0 0 0 0 0 0 0)))
                                           ^^^
-  out/test/spec/simd_lane/simd_lane.123.wat:1:81: error: unexpected token ), expected EOF.
-  ...c (result i32) (i16x8.extract_lane_s inf (v128.const i16x8 0 0 0 0 0 0 0 0)))
-                                                                                 ^
 out/test/spec/simd_lane.wast:591: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.124.wat:1:42: error: unexpected token "-inf", expected a natural number in range [0, 32).
   ... (result i32) (i16x8.extract_lane_u -inf (v128.const i16x8 0 0 0 0 0 0 0 0)))
                                          ^^^^
-  out/test/spec/simd_lane/simd_lane.124.wat:1:82: error: unexpected token ), expected EOF.
-  ... (result i32) (i16x8.extract_lane_u -inf (v128.const i16x8 0 0 0 0 0 0 0 0)))
-                                                                                 ^
 out/test/spec/simd_lane.wast:592: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.125.wat:1:40: error: unexpected token "nan", expected a natural number in range [0, 32).
   (func (result i32) (i32x4.extract_lane nan (v128.const i32x4 0 0 0 0)))
                                          ^^^
-  out/test/spec/simd_lane/simd_lane.125.wat:1:71: error: unexpected token ), expected EOF.
-  (func (result i32) (i32x4.extract_lane nan (v128.const i32x4 0 0 0 0)))
-                                                                        ^
 out/test/spec/simd_lane.wast:593: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.126.wat:1:40: error: unexpected token "nan", expected a natural number in range [0, 32).
   (func (result f32) (f32x4.extract_lane nan (v128.const f32x4 0 0 0 0)))
                                          ^^^
-  out/test/spec/simd_lane/simd_lane.126.wat:1:71: error: unexpected token ), expected EOF.
-  (func (result f32) (f32x4.extract_lane nan (v128.const f32x4 0 0 0 0)))
-                                                                        ^
 out/test/spec/simd_lane.wast:594: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.127.wat:1:41: error: unexpected token "-2.5", expected a natural number in range [0, 32).
   ... (result v128) (i8x16.replace_lane -2.5 (v128.const i8x16 0 0 0 0 0 0 0 0 ...
                                         ^^^^
-  out/test/spec/simd_lane/simd_lane.127.wat:1:111: error: unexpected token ), expected EOF.
-  ..._lane -2.5 (v128.const i8x16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0) (i32.const 1)))
-                                                                                 ^
 out/test/spec/simd_lane.wast:595: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.128.wat:1:41: error: unexpected token "nan", expected a natural number in range [0, 32).
   ...c (result v128) (i16x8.replace_lane nan (v128.const i16x8 0 0 0 0 0 0 0 0)...
                                          ^^^
-  out/test/spec/simd_lane/simd_lane.128.wat:1:94: error: unexpected token ), expected EOF.
-  ...8) (i16x8.replace_lane nan (v128.const i16x8 0 0 0 0 0 0 0 0) (i32.const 1)))
-                                                                                 ^
 out/test/spec/simd_lane.wast:596: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.129.wat:1:41: error: unexpected token "inf", expected a natural number in range [0, 32).
   ...c (result v128) (i32x4.replace_lane inf (v128.const i32x4 0 0 0 0) (i32.co...
                                          ^^^
-  out/test/spec/simd_lane/simd_lane.129.wat:1:86: error: unexpected token ), expected EOF.
-  ...sult v128) (i32x4.replace_lane inf (v128.const i32x4 0 0 0 0) (i32.const 1)))
-                                                                                 ^
 out/test/spec/simd_lane.wast:597: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.130.wat:1:41: error: unexpected token "-inf", expected a natural number in range [0, 32).
   ... (result v128) (f32x4.replace_lane -inf (v128.const f32x4 0 0 0 0) (f32.co...
                                         ^^^^
-  out/test/spec/simd_lane/simd_lane.130.wat:1:89: error: unexpected token ), expected EOF.
-  ...t v128) (f32x4.replace_lane -inf (v128.const f32x4 0 0 0 0) (f32.const 1.1)))
-                                                                                 ^
 out/test/spec/simd_lane.wast:600: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.131.wat:1:36: error: unexpected token "(", expected a natural number in range [0, 32).
   (func (result v128) (i8x16.shuffle (v128.const i8x16 16 17 18 19 20 21 22 23 ...
                                      ^
-  out/test/spec/simd_lane/simd_lane.131.wat:1:103: error: unexpected token (, expected EOF.
-  ...20 21 22 23 24 25 26 27 28 29 30 31) (v128.const i8x16 15 14 13 12 11 10 9...
-                                          ^
 out/test/spec/simd_lane.wast:604: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.132.wat:1:71: error: unexpected token "15.0", expected a natural number in range [0, 32).
   ...0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15.0) (v128.const i8x16 15 14 13 12 11 ...
                                         ^^^^
-  out/test/spec/simd_lane/simd_lane.132.wat:1:191: error: unexpected token ), expected EOF.
-  ...8 7 6 5 4 3 2 1 0) (v128.const i8x16 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15)))
-                                                                                 ^
 out/test/spec/simd_lane.wast:608: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.133.wat:1:36: error: unexpected token "0.5", expected a natural number in range [0, 32).
   (func (result v128) (i8x16.shuffle 0.5 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15) (...
@@ -651,9 +477,6 @@ out/test/spec/simd_lane.wast:616: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.135.wat:1:71: error: unexpected token "inf", expected a natural number in range [0, 32).
   ... 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 inf) (v128.const i8x16 15 14 13 12 11 ...
                                          ^^^
-  out/test/spec/simd_lane/simd_lane.135.wat:1:190: error: unexpected token ), expected EOF.
-  ...8 7 6 5 4 3 2 1 0) (v128.const i8x16 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15)))
-                                                                                 ^
 out/test/spec/simd_lane.wast:620: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.136.wat:1:36: error: unexpected token "nan", expected a natural number in range [0, 32).
   (func (result v128) (i8x16.shuffle nan 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15) (...
@@ -662,65 +485,38 @@ out/test/spec/simd_lane.wast:877: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.141.wat:1:21: error: invalid literal "+0x0f"
   (func (result i32) (i8x16.extract_lane_u +0x0f (v128.const i8x16 0 0 0 0 0 0 ...
                       ^^^^^^^^^^^^^^^^^^^^
-  out/test/spec/simd_lane/simd_lane.141.wat:1:99: error: unexpected token ), expected EOF.
-  ...x16.extract_lane_u +0x0f (v128.const i8x16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0)))
-                                                                                 ^
 out/test/spec/simd_lane.wast:878: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.142.wat:1:21: error: invalid literal "+03"
   (func (result f32) (f32x4.extract_lane +03 (v128.const f32x4 0 0 0 0)))
                       ^^^^^^^^^^^^^^^^^^
-  out/test/spec/simd_lane/simd_lane.142.wat:1:71: error: unexpected token ), expected EOF.
-  (func (result f32) (f32x4.extract_lane +03 (v128.const f32x4 0 0 0 0)))
-                                                                        ^
 out/test/spec/simd_lane.wast:879: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.143.wat:1:21: error: invalid literal "+1"
   (func (result i64) (i64x2.extract_lane +1 (v128.const i64x2 0 0)))
                       ^^^^^^^^^^^^^^^^^^
-  out/test/spec/simd_lane/simd_lane.143.wat:1:66: error: unexpected token ), expected EOF.
-  (func (result i64) (i64x2.extract_lane +1 (v128.const i64x2 0 0)))
-                                                                   ^
 out/test/spec/simd_lane.wast:880: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.144.wat:1:22: error: invalid literal "+015"
   (func (result v128) (i8x16.replace_lane +015 (v128.const i8x16 0 0 0 0 0 0 0 ...
                        ^^^^^^^^^^^^^^^^^^
-  out/test/spec/simd_lane/simd_lane.144.wat:1:111: error: unexpected token ), expected EOF.
-  ..._lane +015 (v128.const i8x16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0) (i32.const 1)))
-                                                                                 ^
 out/test/spec/simd_lane.wast:881: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.145.wat:1:22: error: invalid literal "+0x7"
   (func (result v128) (i16x8.replace_lane +0x7 (v128.const i16x8 0 0 0 0 0 0 0 ...
                        ^^^^^^^^^^^^^^^^^^
-  out/test/spec/simd_lane/simd_lane.145.wat:1:95: error: unexpected token ), expected EOF.
-  ...) (i16x8.replace_lane +0x7 (v128.const i16x8 0 0 0 0 0 0 0 0) (i32.const 1)))
-                                                                                 ^
 out/test/spec/simd_lane.wast:882: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.146.wat:1:22: error: invalid literal "+3"
   (func (result v128) (i32x4.replace_lane +3 (v128.const i32x4 0 0 0 0) (i32.co...
                        ^^^^^^^^^^^^^^^^^^
-  out/test/spec/simd_lane/simd_lane.146.wat:1:85: error: unexpected token ), expected EOF.
-  ...esult v128) (i32x4.replace_lane +3 (v128.const i32x4 0 0 0 0) (i32.const 1)))
-                                                                                 ^
 out/test/spec/simd_lane.wast:883: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.147.wat:1:22: error: invalid literal "+0x01"
   (func (result v128) (f64x2.replace_lane +0x01 (v128.const f64x2 0 0) (f64.con...
                        ^^^^^^^^^^^^^^^^^^
-  out/test/spec/simd_lane/simd_lane.147.wat:1:86: error: unexpected token ), expected EOF.
-  ...sult v128) (f64x2.replace_lane +0x01 (v128.const f64x2 0 0) (f64.const 1.0)))
-                                                                                 ^
 out/test/spec/simd_lane.wast:897: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.155.wat:1:42: error: unexpected token "1.0", expected a natural number in range [0, 32).
   ... (result i32) (i8x16.extract_lane_s 1.0 (v128.const i8x16 0 0 0 0 0 0 0 0 ...
                                          ^^^
-  out/test/spec/simd_lane/simd_lane.155.wat:1:97: error: unexpected token ), expected EOF.
-  ...i8x16.extract_lane_s 1.0 (v128.const i8x16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0)))
-                                                                                 ^
 out/test/spec/simd_lane.wast:902: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.156.wat:1:79: error: unexpected token "(", expected a natural number in range [0, 32).
   ... (result i32)  (i8x16.extract_lane_s (v128.const i8x16 0 0 0 0 0 0 0 0 0 0...
                                           ^
-  out/test/spec/simd_lane/simd_lane.156.wat:1:129: error: unexpected token ), expected EOF.
-  ...)  (i8x16.extract_lane_s (v128.const i8x16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0)))
-                                                                                ^
 out/test/spec/simd_lane.wast:910: assert_invalid passed:
   out/test/spec/simd_lane/simd_lane.157.wasm:000001b: error: type mismatch in i8x16.extract_lane_s, expected [v128] but got []
   000001b: error: OnSimdLaneOpExpr callback failed
@@ -732,9 +528,6 @@ out/test/spec/simd_lane.wast:926: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.159.wat:1:79: error: unexpected token "(", expected a natural number in range [0, 32).
   ...mpty (result i32)  (i16x8.extract_lane_u (v128.const i16x8 0 0 0 0 0 0 0 0)))
                                               ^
-  out/test/spec/simd_lane/simd_lane.159.wat:1:113: error: unexpected token ), expected EOF.
-  ...mpty (result i32)  (i16x8.extract_lane_u (v128.const i16x8 0 0 0 0 0 0 0 0)))
-                                                                                ^
 out/test/spec/simd_lane.wast:934: assert_invalid passed:
   out/test/spec/simd_lane/simd_lane.160.wasm:000001b: error: type mismatch in i16x8.extract_lane_u, expected [v128] but got []
   000001b: error: OnSimdLaneOpExpr callback failed
@@ -746,9 +539,6 @@ out/test/spec/simd_lane.wast:950: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.162.wat:1:75: error: unexpected token "(", expected a natural number in range [0, 32).
   ...-1st-arg-empty (result i32)  (i32x4.extract_lane (v128.const i32x4 0 0 0 0)))
                                                       ^
-  out/test/spec/simd_lane/simd_lane.162.wat:1:101: error: unexpected token ), expected EOF.
-  ...-1st-arg-empty (result i32)  (i32x4.extract_lane (v128.const i32x4 0 0 0 0)))
-                                                                                ^
 out/test/spec/simd_lane.wast:958: assert_invalid passed:
   out/test/spec/simd_lane/simd_lane.163.wasm:000001b: error: type mismatch in i32x4.extract_lane, expected [v128] but got []
   000001b: error: OnSimdLaneOpExpr callback failed
@@ -760,9 +550,6 @@ out/test/spec/simd_lane.wast:974: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.165.wat:1:75: error: unexpected token "(", expected a natural number in range [0, 32).
   ...lane-1st-arg-empty (result i64)  (i64x2.extract_lane (v128.const i64x2 0 0)))
                                                           ^
-  out/test/spec/simd_lane/simd_lane.165.wat:1:97: error: unexpected token ), expected EOF.
-  ...lane-1st-arg-empty (result i64)  (i64x2.extract_lane (v128.const i64x2 0 0)))
-                                                                                ^
 out/test/spec/simd_lane.wast:982: assert_invalid passed:
   out/test/spec/simd_lane/simd_lane.166.wasm:000001b: error: type mismatch in i64x2.extract_lane, expected [v128] but got []
   000001b: error: OnSimdLaneOpExpr callback failed
@@ -774,9 +561,6 @@ out/test/spec/simd_lane.wast:998: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.168.wat:1:75: error: unexpected token "(", expected a natural number in range [0, 32).
   ...-1st-arg-empty (result f32)  (f32x4.extract_lane (v128.const f32x4 0 0 0 0)))
                                                       ^
-  out/test/spec/simd_lane/simd_lane.168.wat:1:101: error: unexpected token ), expected EOF.
-  ...-1st-arg-empty (result f32)  (f32x4.extract_lane (v128.const f32x4 0 0 0 0)))
-                                                                                ^
 out/test/spec/simd_lane.wast:1006: assert_invalid passed:
   out/test/spec/simd_lane/simd_lane.169.wasm:000001b: error: type mismatch in f32x4.extract_lane, expected [v128] but got []
   000001b: error: OnSimdLaneOpExpr callback failed
@@ -788,9 +572,6 @@ out/test/spec/simd_lane.wast:1022: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.171.wat:1:75: error: unexpected token "(", expected a natural number in range [0, 32).
   ...lane-1st-arg-empty (result f64)  (f64x2.extract_lane (v128.const f64x2 0 0)))
                                                           ^
-  out/test/spec/simd_lane/simd_lane.171.wat:1:97: error: unexpected token ), expected EOF.
-  ...lane-1st-arg-empty (result f64)  (f64x2.extract_lane (v128.const f64x2 0 0)))
-                                                                                ^
 out/test/spec/simd_lane.wast:1030: assert_invalid passed:
   out/test/spec/simd_lane/simd_lane.172.wasm:000001b: error: type mismatch in f64x2.extract_lane, expected [v128] but got []
   000001b: error: OnSimdLaneOpExpr callback failed
@@ -802,9 +583,6 @@ out/test/spec/simd_lane.wast:1046: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.174.wat:1:76: error: unexpected token "(", expected a natural number in range [0, 32).
   ...y (result v128)  (i8x16.replace_lane (v128.const i8x16 0 0 0 0 0 0 0 0 0 0...
                                           ^
-  out/test/spec/simd_lane/simd_lane.174.wat:1:127: error: unexpected token (, expected EOF.
-  ...place_lane (v128.const i8x16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0) (i32.const 1)))
-                                                                   ^
 out/test/spec/simd_lane.wast:1054: assert_invalid passed:
   out/test/spec/simd_lane/simd_lane.175.wasm:000001d: error: type mismatch in i8x16.replace_lane, expected [v128, i32] but got [i32]
   000001d: error: OnSimdLaneOpExpr callback failed
@@ -819,9 +597,6 @@ out/test/spec/simd_lane.wast:1078: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.178.wat:1:76: error: unexpected token "(", expected a natural number in range [0, 32).
   ...y (result v128)  (i16x8.replace_lane (v128.const i16x8 0 0 0 0 0 0 0 0) (i...
                                           ^
-  out/test/spec/simd_lane/simd_lane.178.wat:1:111: error: unexpected token (, expected EOF.
-  ...v128)  (i16x8.replace_lane (v128.const i16x8 0 0 0 0 0 0 0 0) (i32.const 1)))
-                                                                   ^
 out/test/spec/simd_lane.wast:1086: assert_invalid passed:
   out/test/spec/simd_lane/simd_lane.179.wasm:000001d: error: type mismatch in i16x8.replace_lane, expected [v128, i32] but got [i32]
   000001d: error: OnSimdLaneOpExpr callback failed
@@ -836,9 +611,6 @@ out/test/spec/simd_lane.wast:1110: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.182.wat:1:76: error: unexpected token "(", expected a natural number in range [0, 32).
   ...y (result v128)  (i32x4.replace_lane (v128.const i32x4 0 0 0 0) (i32.const...
                                           ^
-  out/test/spec/simd_lane/simd_lane.182.wat:1:103: error: unexpected token (, expected EOF.
-  ...(result v128)  (i32x4.replace_lane (v128.const i32x4 0 0 0 0) (i32.const 1)))
-                                                                   ^
 out/test/spec/simd_lane.wast:1118: assert_invalid passed:
   out/test/spec/simd_lane/simd_lane.183.wasm:000001d: error: type mismatch in i32x4.replace_lane, expected [v128, i32] but got [i32]
   000001d: error: OnSimdLaneOpExpr callback failed
@@ -853,9 +625,6 @@ out/test/spec/simd_lane.wast:1142: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.186.wat:1:76: error: unexpected token "(", expected a natural number in range [0, 32).
   ...y (result v128)  (f32x4.replace_lane (v128.const f32x4 0 0 0 0) (f32.const...
                                           ^
-  out/test/spec/simd_lane/simd_lane.186.wat:1:103: error: unexpected token (, expected EOF.
-  ...esult v128)  (f32x4.replace_lane (v128.const f32x4 0 0 0 0) (f32.const 1.0)))
-                                                                 ^
 out/test/spec/simd_lane.wast:1150: assert_invalid passed:
   out/test/spec/simd_lane/simd_lane.187.wasm:0000020: error: type mismatch in f32x4.replace_lane, expected [v128, f32] but got [f32]
   0000020: error: OnSimdLaneOpExpr callback failed
@@ -870,9 +639,6 @@ out/test/spec/simd_lane.wast:1174: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.190.wat:1:76: error: unexpected token "(", expected a natural number in range [0, 32).
   ...pty (result v128)  (i64x2.replace_lane (v128.const i64x2 0 0) (i64.const 1)))
                                             ^
-  out/test/spec/simd_lane/simd_lane.190.wat:1:99: error: unexpected token (, expected EOF.
-  ...pty (result v128)  (i64x2.replace_lane (v128.const i64x2 0 0) (i64.const 1)))
-                                                                   ^
 out/test/spec/simd_lane.wast:1182: assert_invalid passed:
   out/test/spec/simd_lane/simd_lane.191.wasm:000001d: error: type mismatch in i64x2.replace_lane, expected [v128, i64] but got [i64]
   000001d: error: OnSimdLaneOpExpr callback failed
@@ -887,9 +653,6 @@ out/test/spec/simd_lane.wast:1206: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.194.wat:1:76: error: unexpected token "(", expected a natural number in range [0, 32).
   ...y (result v128)  (f64x2.replace_lane (v128.const f64x2 0 0) (f64.const 1.0)))
                                           ^
-  out/test/spec/simd_lane/simd_lane.194.wat:1:99: error: unexpected token (, expected EOF.
-  ...y (result v128)  (f64x2.replace_lane (v128.const f64x2 0 0) (f64.const 1.0)))
-                                                                 ^
 out/test/spec/simd_lane.wast:1214: assert_invalid passed:
   out/test/spec/simd_lane/simd_lane.195.wasm:0000024: error: type mismatch in f64x2.replace_lane, expected [v128, f64] but got [f64]
   0000024: error: OnSimdLaneOpExpr callback failed
@@ -903,9 +666,6 @@ out/test/spec/simd_lane.wast:1230: assert_malformed passed:
 out/test/spec/simd_lane.wast:1238: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.198.wat:1:69: error: unexpected token "(", expected a natural number in range [0, 32).
   ...pty (result v128)  (i8x16.shuffle    (v128.const i8x16 0 1 2 3 5 6 6 7 8 9...
-                                          ^
-  out/test/spec/simd_lane/simd_lane.198.wat:1:129: error: unexpected token (, expected EOF.
-  ... 3 5 6 6 7 8 9 10 11 12 13 14 15)    (v128.const i8x16 1 2 3 5 6 6 7 8 9 1...
                                           ^
 out/test/spec/simd_lane.wast:1249: assert_invalid passed:
   out/test/spec/simd_lane/simd_lane.199.wasm:000003c: error: type mismatch in i8x16.shuffle, expected [v128, v128] but got [v128]

--- a/test/spec/simd_load.txt
+++ b/test/spec/simd_load.txt
@@ -5,23 +5,14 @@ out/test/spec/simd_load.wast:141: assert_malformed passed:
   out/test/spec/simd_load/simd_load.14.wat:1:37: error: unexpected token "v128.load8", expected an expr.
   (memory 1)(func (local v128) (drop (v128.load8 (i32.const 0))))
                                       ^^^^^^^^^^
-  out/test/spec/simd_load/simd_load.14.wat:1:62: error: unexpected token ), expected EOF.
-  (memory 1)(func (local v128) (drop (v128.load8 (i32.const 0))))
-                                                               ^
 out/test/spec/simd_load.wast:148: assert_malformed passed:
   out/test/spec/simd_load/simd_load.15.wat:1:37: error: unexpected token "v128.load16", expected an expr.
   (memory 1)(func (local v128) (drop (v128.load16 (i32.const 0))))
                                       ^^^^^^^^^^^
-  out/test/spec/simd_load/simd_load.15.wat:1:63: error: unexpected token ), expected EOF.
-  (memory 1)(func (local v128) (drop (v128.load16 (i32.const 0))))
-                                                                ^
 out/test/spec/simd_load.wast:155: assert_malformed passed:
   out/test/spec/simd_load/simd_load.16.wat:1:37: error: unexpected token "v128.load32", expected an expr.
   (memory 1)(func (local v128) (drop (v128.load32 (i32.const 0))))
                                       ^^^^^^^^^^^
-  out/test/spec/simd_load/simd_load.16.wat:1:63: error: unexpected token ), expected EOF.
-  (memory 1)(func (local v128) (drop (v128.load32 (i32.const 0))))
-                                                                ^
 out/test/spec/simd_load.wast:166: assert_invalid passed:
   out/test/spec/simd_load/simd_load.17.wasm:0000027: error: type mismatch in v128.load, expected [i32] but got [f32]
   0000027: error: OnLoadExpr callback failed

--- a/test/spec/simd_load_extend.txt
+++ b/test/spec/simd_load_extend.txt
@@ -53,43 +53,25 @@ out/test/spec/simd_load_extend.wast:301: assert_malformed passed:
   out/test/spec/simd_load_extend/simd_load_extend.13.wat:1:25: error: unexpected token "i16x8.load16x4_s", expected an expr.
   (memory 1) (func (drop (i16x8.load16x4_s (i32.const 0))))
                           ^^^^^^^^^^^^^^^^
-  out/test/spec/simd_load_extend/simd_load_extend.13.wat:1:56: error: unexpected token ), expected EOF.
-  (memory 1) (func (drop (i16x8.load16x4_s (i32.const 0))))
-                                                         ^
 out/test/spec/simd_load_extend.wast:302: assert_malformed passed:
   out/test/spec/simd_load_extend/simd_load_extend.14.wat:1:25: error: unexpected token "i16x8.load16x4_u", expected an expr.
   (memory 1) (func (drop (i16x8.load16x4_u (i32.const 0))))
                           ^^^^^^^^^^^^^^^^
-  out/test/spec/simd_load_extend/simd_load_extend.14.wat:1:56: error: unexpected token ), expected EOF.
-  (memory 1) (func (drop (i16x8.load16x4_u (i32.const 0))))
-                                                         ^
 out/test/spec/simd_load_extend.wast:303: assert_malformed passed:
   out/test/spec/simd_load_extend/simd_load_extend.15.wat:1:25: error: unexpected token "i32x4.load32x2_s", expected an expr.
   (memory 1) (func (drop (i32x4.load32x2_s (i32.const 0))))
                           ^^^^^^^^^^^^^^^^
-  out/test/spec/simd_load_extend/simd_load_extend.15.wat:1:56: error: unexpected token ), expected EOF.
-  (memory 1) (func (drop (i32x4.load32x2_s (i32.const 0))))
-                                                         ^
 out/test/spec/simd_load_extend.wast:304: assert_malformed passed:
   out/test/spec/simd_load_extend/simd_load_extend.16.wat:1:25: error: unexpected token "i32x4.load32x2_u", expected an expr.
   (memory 1) (func (drop (i32x4.load32x2_u (i32.const 0))))
                           ^^^^^^^^^^^^^^^^
-  out/test/spec/simd_load_extend/simd_load_extend.16.wat:1:56: error: unexpected token ), expected EOF.
-  (memory 1) (func (drop (i32x4.load32x2_u (i32.const 0))))
-                                                         ^
 out/test/spec/simd_load_extend.wast:305: assert_malformed passed:
   out/test/spec/simd_load_extend/simd_load_extend.17.wat:1:25: error: unexpected token "i64x2.load64x1_s", expected an expr.
   (memory 1) (func (drop (i64x2.load64x1_s (i32.const 0))))
                           ^^^^^^^^^^^^^^^^
-  out/test/spec/simd_load_extend/simd_load_extend.17.wat:1:56: error: unexpected token ), expected EOF.
-  (memory 1) (func (drop (i64x2.load64x1_s (i32.const 0))))
-                                                         ^
 out/test/spec/simd_load_extend.wast:306: assert_malformed passed:
   out/test/spec/simd_load_extend/simd_load_extend.18.wat:1:25: error: unexpected token "i64x2.load64x1_u", expected an expr.
   (memory 1) (func (drop (i64x2.load64x1_u (i32.const 0))))
                           ^^^^^^^^^^^^^^^^
-  out/test/spec/simd_load_extend/simd_load_extend.18.wat:1:56: error: unexpected token ), expected EOF.
-  (memory 1) (func (drop (i64x2.load64x1_u (i32.const 0))))
-                                                         ^
 104/104 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/simd_load_splat.txt
+++ b/test/spec/simd_load_splat.txt
@@ -49,30 +49,18 @@ out/test/spec/simd_load_splat.wast:222: assert_malformed passed:
   out/test/spec/simd_load_splat/simd_load_splat.6.wat:1:25: error: unexpected token "i8x16.load_splat", expected an expr.
   (memory 1) (func (drop (i8x16.load_splat (i32.const 0))))
                           ^^^^^^^^^^^^^^^^
-  out/test/spec/simd_load_splat/simd_load_splat.6.wat:1:56: error: unexpected token ), expected EOF.
-  (memory 1) (func (drop (i8x16.load_splat (i32.const 0))))
-                                                         ^
 out/test/spec/simd_load_splat.wast:223: assert_malformed passed:
   out/test/spec/simd_load_splat/simd_load_splat.7.wat:1:25: error: unexpected token "i16x8.load_splat", expected an expr.
   (memory 1) (func (drop (i16x8.load_splat (i32.const 0))))
                           ^^^^^^^^^^^^^^^^
-  out/test/spec/simd_load_splat/simd_load_splat.7.wat:1:56: error: unexpected token ), expected EOF.
-  (memory 1) (func (drop (i16x8.load_splat (i32.const 0))))
-                                                         ^
 out/test/spec/simd_load_splat.wast:224: assert_malformed passed:
   out/test/spec/simd_load_splat/simd_load_splat.8.wat:1:25: error: unexpected token "i32x4.load_splat", expected an expr.
   (memory 1) (func (drop (i32x4.load_splat (i32.const 0))))
                           ^^^^^^^^^^^^^^^^
-  out/test/spec/simd_load_splat/simd_load_splat.8.wat:1:56: error: unexpected token ), expected EOF.
-  (memory 1) (func (drop (i32x4.load_splat (i32.const 0))))
-                                                         ^
 out/test/spec/simd_load_splat.wast:225: assert_malformed passed:
   out/test/spec/simd_load_splat/simd_load_splat.9.wat:1:25: error: unexpected token "i64x2.load_splat", expected an expr.
   (memory 1) (func (drop (i64x2.load_splat (i32.const 0))))
                           ^^^^^^^^^^^^^^^^
-  out/test/spec/simd_load_splat/simd_load_splat.9.wat:1:56: error: unexpected token ), expected EOF.
-  (memory 1) (func (drop (i64x2.load_splat (i32.const 0))))
-                                                         ^
 out/test/spec/simd_load_splat.wast:231: assert_invalid passed:
   out/test/spec/simd_load_splat/simd_load_splat.10.wasm:0000021: error: type mismatch in v128.load8_splat, expected [i32] but got []
   0000021: error: OnLoadSplatExpr callback failed

--- a/test/spec/simd_load_zero.txt
+++ b/test/spec/simd_load_zero.txt
@@ -21,43 +21,25 @@ out/test/spec/simd_load_zero.wast:119: assert_malformed passed:
   out/test/spec/simd_load_zero/simd_load_zero.5.wat:1:25: error: unexpected token "i16x8.load16x4_s", expected an expr.
   (memory 1) (func (drop (i16x8.load16x4_s (i32.const 0))))
                           ^^^^^^^^^^^^^^^^
-  out/test/spec/simd_load_zero/simd_load_zero.5.wat:1:56: error: unexpected token ), expected EOF.
-  (memory 1) (func (drop (i16x8.load16x4_s (i32.const 0))))
-                                                         ^
 out/test/spec/simd_load_zero.wast:120: assert_malformed passed:
   out/test/spec/simd_load_zero/simd_load_zero.6.wat:1:25: error: unexpected token "i16x8.load16x4_u", expected an expr.
   (memory 1) (func (drop (i16x8.load16x4_u (i32.const 0))))
                           ^^^^^^^^^^^^^^^^
-  out/test/spec/simd_load_zero/simd_load_zero.6.wat:1:56: error: unexpected token ), expected EOF.
-  (memory 1) (func (drop (i16x8.load16x4_u (i32.const 0))))
-                                                         ^
 out/test/spec/simd_load_zero.wast:121: assert_malformed passed:
   out/test/spec/simd_load_zero/simd_load_zero.7.wat:1:25: error: unexpected token "i32x4.load32x2_s", expected an expr.
   (memory 1) (func (drop (i32x4.load32x2_s (i32.const 0))))
                           ^^^^^^^^^^^^^^^^
-  out/test/spec/simd_load_zero/simd_load_zero.7.wat:1:56: error: unexpected token ), expected EOF.
-  (memory 1) (func (drop (i32x4.load32x2_s (i32.const 0))))
-                                                         ^
 out/test/spec/simd_load_zero.wast:122: assert_malformed passed:
   out/test/spec/simd_load_zero/simd_load_zero.8.wat:1:25: error: unexpected token "i32x4.load32x2_u", expected an expr.
   (memory 1) (func (drop (i32x4.load32x2_u (i32.const 0))))
                           ^^^^^^^^^^^^^^^^
-  out/test/spec/simd_load_zero/simd_load_zero.8.wat:1:56: error: unexpected token ), expected EOF.
-  (memory 1) (func (drop (i32x4.load32x2_u (i32.const 0))))
-                                                         ^
 out/test/spec/simd_load_zero.wast:123: assert_malformed passed:
   out/test/spec/simd_load_zero/simd_load_zero.9.wat:1:25: error: unexpected token "i64x2.load64x1_s", expected an expr.
   (memory 1) (func (drop (i64x2.load64x1_s (i32.const 0))))
                           ^^^^^^^^^^^^^^^^
-  out/test/spec/simd_load_zero/simd_load_zero.9.wat:1:56: error: unexpected token ), expected EOF.
-  (memory 1) (func (drop (i64x2.load64x1_s (i32.const 0))))
-                                                         ^
 out/test/spec/simd_load_zero.wast:124: assert_malformed passed:
   out/test/spec/simd_load_zero/simd_load_zero.10.wat:1:25: error: unexpected token "i64x2.load64x1_u", expected an expr.
   (memory 1) (func (drop (i64x2.load64x1_u (i32.const 0))))
                           ^^^^^^^^^^^^^^^^
-  out/test/spec/simd_load_zero/simd_load_zero.10.wat:1:56: error: unexpected token ), expected EOF.
-  (memory 1) (func (drop (i64x2.load64x1_u (i32.const 0))))
-                                                         ^
 39/39 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/tail-call/return_call_indirect.txt
+++ b/test/spec/tail-call/return_call_indirect.txt
@@ -14,51 +14,30 @@ out/test/spec/tail-call/return_call_indirect.wast:301: assert_malformed passed:
   out/test/spec/tail-call/return_call_indirect/return_call_indirect.1.wat:1:129: error: unexpected token "param", expected an expr.
   ...indirect (type $sig) (result i32) (param i32)    (i32.const 0) (i32.const ...
                                         ^^^^^
-  out/test/spec/tail-call/return_call_indirect/return_call_indirect.1.wat:1:173: error: unexpected token ), expected EOF.
-  ...irect (type $sig) (result i32) (param i32)    (i32.const 0) (i32.const 0)  ))
-                                                                                 ^
 out/test/spec/tail-call/return_call_indirect.wast:313: assert_malformed passed:
   out/test/spec/tail-call/return_call_indirect/return_call_indirect.2.wat:1:116: error: unexpected token "type", expected an expr.
   ...(return_call_indirect (param i32) (type $sig) (result i32)    (i32.const 0...
                                         ^^^^
-  out/test/spec/tail-call/return_call_indirect/return_call_indirect.2.wat:1:173: error: unexpected token ), expected EOF.
-  ...irect (param i32) (type $sig) (result i32)    (i32.const 0) (i32.const 0)  ))
-                                                                                 ^
 out/test/spec/tail-call/return_call_indirect.wast:325: assert_malformed passed:
   out/test/spec/tail-call/return_call_indirect/return_call_indirect.3.wat:1:129: error: unexpected token "type", expected an expr.
   ...indirect (param i32) (result i32) (type $sig)    (i32.const 0) (i32.const ...
                                         ^^^^
-  out/test/spec/tail-call/return_call_indirect/return_call_indirect.3.wat:1:173: error: unexpected token ), expected EOF.
-  ...irect (param i32) (result i32) (type $sig)    (i32.const 0) (i32.const 0)  ))
-                                                                                 ^
 out/test/spec/tail-call/return_call_indirect.wast:337: assert_malformed passed:
   out/test/spec/tail-call/return_call_indirect/return_call_indirect.4.wat:1:117: error: unexpected token "type", expected an expr.
   ...return_call_indirect (result i32) (type $sig) (param i32)    (i32.const 0)...
                                         ^^^^
-  out/test/spec/tail-call/return_call_indirect/return_call_indirect.4.wat:1:173: error: unexpected token ), expected EOF.
-  ...irect (result i32) (type $sig) (param i32)    (i32.const 0) (i32.const 0)  ))
-                                                                                 ^
 out/test/spec/tail-call/return_call_indirect.wast:349: assert_malformed passed:
   out/test/spec/tail-call/return_call_indirect/return_call_indirect.5.wat:1:117: error: unexpected token "param", expected an expr.
   ...return_call_indirect (result i32) (param i32) (type $sig)    (i32.const 0)...
                                         ^^^^^
-  out/test/spec/tail-call/return_call_indirect/return_call_indirect.5.wat:1:173: error: unexpected token ), expected EOF.
-  ...irect (result i32) (param i32) (type $sig)    (i32.const 0) (i32.const 0)  ))
-                                                                                 ^
 out/test/spec/tail-call/return_call_indirect.wast:361: assert_malformed passed:
   out/test/spec/tail-call/return_call_indirect/return_call_indirect.6.wat:1:74: error: unexpected token "param", expected an expr.
   ...return_call_indirect (result i32) (param i32)    (i32.const 0) (i32.const ...
                                         ^^^^^
-  out/test/spec/tail-call/return_call_indirect/return_call_indirect.6.wat:1:118: error: unexpected token ), expected EOF.
-  ...urn_call_indirect (result i32) (param i32)    (i32.const 0) (i32.const 0)  ))
-                                                                                 ^
 out/test/spec/tail-call/return_call_indirect.wast:373: assert_malformed passed:
   out/test/spec/tail-call/return_call_indirect/return_call_indirect.7.wat:1:53: error: unexpected token $x, expected ).
   ...cref)(func (return_call_indirect (param $x i32) (i32.const 0) (i32.const 0)))
                                              ^^
-  out/test/spec/tail-call/return_call_indirect/return_call_indirect.7.wat:1:89: error: unexpected token ), expected EOF.
-  ...cref)(func (return_call_indirect (param $x i32) (i32.const 0) (i32.const 0)))
-                                                                                 ^
 out/test/spec/tail-call/return_call_indirect.wast:380: assert_malformed passed:
   out/test/spec/tail-call/return_call_indirect/return_call_indirect.8.wat:1:57: error: expected 0 results, got 1
   ...ncref)(func (result i32)  (return_call_indirect (type $sig) (result i32) (...


### PR DESCRIPTION
`wat2wasm`, `wast2json` and `wat-desugar` read freed memory on malformed text input — #2820. The parser holds raw `TypeVector*` pointers to block signatures in `resolve_type_vectors_` and only dereferences them once the whole module has parsed, so a block destroyed on an error path in between leaves a dangling entry behind.

The diagnosis is @zherczeg's, from the issue thread: `ParseModuleField` was returning Ok for a field that had in fact failed. Instrumenting it shows exactly that — the field records 8 errors and still succeeds:

```
[DBG] ParseExprList: ParseExpr failed, synchronising and returning Ok anyway
[DBG] field -> Ok, errors 0 -> 8
```

`ParseInstrList` and `ParseExprList` synchronise past a bad sub-expression and then return `Result::Ok` unconditionally, so the failure never reaches `ParseModuleField` and the rollback added in #2805 never runs.

So this just passes the error back. Both loops still recover and carry on, so every error is still reported — they only remember that something was dropped. `ParseModuleField` then fails as it should, and #2805's rollback discards the stale resolutions.

## The test churn

20 expected outputs get shorter, which is most of the diff: 470 lines removed against 43 added.

Previously, having reported the real error, the parser would carry on and emit a second redundant one — nearly always `unexpected token ), expected EOF` pointing at the end of the module. That no longer appears:

```
 out/test/parse/expr/bad-load-align.txt:3:25: error: unexpected token align=foo, expected ).
 (module (func (i32.load align=foo (i32.const 0))))
                         ^^^^^^^^^
-out/test/parse/expr/bad-load-align.txt:3:50: error: unexpected token ), expected EOF.
-(module (func (i32.load align=foo (i32.const 0))))
-                                                 ^
```

I checked the direction of every one of those diffs: they only ever remove lines. No test gains an error and no valid module starts being rejected. Still, it does touch spec test expectations, so shout if you would rather it were done differently.

## Test

`test/parse/bad-block-ref-result-discarded.txt` is the reproducer from the issue. It is deliberately malformed, and it only *aborts* under a sanitizer, so realistically it is the asan CI jobs that would catch a regression rather than a normal run.

Full suite is green locally against a debug ASAN/UBSAN build with all submodules checked out: 2495 tests, 0 failures.

Fixes #2820.
