### PR TITLE
[interp] Fix operand types when tracing table.set

### DIFF
--- a/include/wabt/opcode.def
+++ b/include/wabt/opcode.def
@@ -26,6 +26,8 @@
  *     t1: type of the 1st parameter
  *     t2: type of the 2nd parameter
  *     t3: type of the 3rd parameter
+ *         (___ = no parameter; Any = the parameter exists but its type is not
+ *         statically known, e.g. table.set's value comes from the table type)
  *      m: memory size of the operation, if any
  * prefix: the 1-byte opcode prefix, if any
  *   code: opcode
@@ -268,7 +270,7 @@ WABT_OPCODE(___, ___, I32,  I32,  I32,  0,  0xfc, 0x0e, TableCopy, "table.copy",
 
 /* Reference types */
 WABT_OPCODE(___, ___,  I32,  ___,  ___,  0,  0,    0x25, TableGet, "table.get", "")
-WABT_OPCODE(___, ___,  I32,  ___,  ___,  0,  0,    0x26, TableSet, "table.set", "")
+WABT_OPCODE(___, ___,  I32,  Any,  ___,  0,  0,    0x26, TableSet, "table.set", "")
 WABT_OPCODE(___, ___,  ___,  I32,  ___,  0,  0xfc, 0x0f, TableGrow, "table.grow", "")
 WABT_OPCODE(___, ___,  ___,  ___,  ___,  0,  0xfc, 0x10, TableSize, "table.size", "")
 WABT_OPCODE(___, ___,  I32,  ___,  I32,  0,  0xfc, 0x11, TableFill, "table.fill", "")

--- a/src/interp/interp.cc
+++ b/src/interp/interp.cc
@@ -2948,6 +2948,13 @@ std::string Thread::TraceSource::Pick(Index index, Instr instr) {
       break;
     }
   }
+  // table.set stores a reference whose type comes from the table, so opcode.def
+  // leaves that top operand's param type Void. The loop above then stops at the
+  // i32 index below it and undercounts, swapping the operand types so the i32
+  // index is read back as a reference. It always has two operands.
+  if (instr.op == Opcode::TableSet) {
+    num_operands = 2;
+  }
   auto type = index > num_operands
                   ? Type(ValueType::Void)
                   : instr.op.GetParamType(num_operands - index + 1);

--- a/src/interp/interp.cc
+++ b/src/interp/interp.cc
@@ -2948,20 +2948,15 @@ std::string Thread::TraceSource::Pick(Index index, Instr instr) {
       break;
     }
   }
-  // table.set stores a reference whose type comes from the table, so opcode.def
-  // leaves that top operand's param type Void. The loop above then stops at the
-  // i32 index below it and undercounts, swapping the operand types so the i32
-  // index is read back as a reference. It always has two operands.
-  if (instr.op == Opcode::TableSet) {
-    num_operands = 2;
-  }
   auto type = index > num_operands
                   ? Type(ValueType::Void)
                   : instr.op.GetParamType(num_operands - index + 1);
-  if (type == ValueType::Void) {
+  if (type == ValueType::Void || type == ValueType::Any) {
     // Void should never be displayed normally; we only expect to see it when
     // the stack may have different a different type. This is likely to occur
-    // with an index; try to see which type we should expect.
+    // with an index; try to see which type we should expect. Any marks an
+    // operand that exists but whose type isn't statically known, e.g.
+    // table.set's value, whose type comes from the table.
     switch (instr.op) {
       case Opcode::GlobalSet: type = GetGlobalType(instr.imm_u32); break;
       case Opcode::LocalSet:

--- a/test/interp/tracing-table-set.txt
+++ b/test/interp/tracing-table-set.txt
@@ -1,0 +1,21 @@
+;;; TOOL: run-interp-spec
+;;; ARGS1: --trace
+(module
+  ;; table.set's stored value is a reference whose type is taken from the table,
+  ;; so opcode.def leaves that operand's param type Void. The tracer's operand
+  ;; count heuristic then stops at the i32 index below it and undercounts, which
+  ;; swaps the operand types and reads the i32 index back as a reference.
+  (table 1 funcref)
+  (elem declare func $f)
+  (func $f)
+  (func (export "set")
+    (table.set 0 (i32.const 0) (ref.func $f))))
+(invoke "set")
+(;; STDOUT ;;;
+#0.   16: V:0  | i32.const 0
+#0.   24: V:1  | ref.func $0
+#0.   32: V:2  | table.set $0, 0, funcref:17
+#0.   40: V:0  | return
+set() =>
+2/2 tests passed.
+;;; STDOUT ;;)

--- a/test/interp/tracing-table-set.txt
+++ b/test/interp/tracing-table-set.txt
@@ -1,10 +1,11 @@
 ;;; TOOL: run-interp-spec
 ;;; ARGS1: --trace
 (module
-  ;; table.set's stored value is a reference whose type is taken from the table,
-  ;; so opcode.def leaves that operand's param type Void. The tracer's operand
-  ;; count heuristic then stops at the i32 index below it and undercounts, which
-  ;; swaps the operand types and reads the i32 index back as a reference.
+  ;; table.set's stored value is a reference whose type is taken from the
+  ;; table, so opcode.def marks that operand Any. If it were left Void the
+  ;; tracer's operand count heuristic would strip it as a trailing no-operand
+  ;; slot, swapping the operand types and reading the i32 index back as a
+  ;; reference.
   (table 1 funcref)
   (elem declare func $f)
   (func $f)


### PR DESCRIPTION
wasm-interp --trace, on a valid module that stores through a funcref table:

    interp.h:596: assert `t == type || type == ValueType::Any' failed
        Thread::TraceSource::Pick(Index, Instr)   interp.cc:2992
        Istream::Trace(...)                        istream.cc:909

table.set has two operands, an i32 index and a reference value, but opcode.def leaves the value operand Void because its type is taken from the table. Pick estimates the operand count by stripping trailing Void params, so it counts one instead of two and the operand-to-type mapping slips by one: the i32 index is handed the table element type and read back through Value::Get<Ref>(). Under NDEBUG the assert is gone but the trace still prints the index as a bogus funcref.

Set table.set to two operands so the existing GetTableElementType fallback lands on the value operand and the index keeps its i32 type. table.get, table.grow and table.fill already map correctly.

Repro:

    wasm-interp --enable-all --trace --dummy-import-func -r store_fn -a i32:0 mod.wasm