### PR TITLE
Write init expressions folded so they can be parsed back

### DIFF
--- a/src/wat-writer.cc
+++ b/src/wat-writer.cc
@@ -1439,11 +1439,13 @@ void WatWriter::FlushExprTreeStack() {
 
 void WatWriter::WriteInitExpr(const ExprList& expr) {
   if (!expr.empty()) {
-    WritePuts("(", NextChar::None);
-    WriteExprList(expr);
+    /* Init expressions are always written folded. These positions accept a
+     * single folded expression, so wrapping a sequence of instructions in one
+     * pair of parentheses would produce output that cannot be parsed back. */
+    WriteFoldedExprList(expr);
+    FlushExprTreeStack();
     /* clear the next char, so we don't write a newline after the expr */
-    next_char_ = NextChar::None;
-    WritePuts(")", NextChar::Space);
+    next_char_ = NextChar::Space;
   }
 }
 

--- a/test/roundtrip/extended-const.txt
+++ b/test/roundtrip/extended-const.txt
@@ -1,0 +1,30 @@
+;;; TOOL: run-roundtrip
+;;; ARGS: --stdout --enable-extended-const
+(module
+  (global $g_import (import "foo" "bar") i32)
+  (memory 1)
+  (table 1 funcref)
+  (func)
+  (global (mut i32) (i32.sub (i32.const 44) (i32.const 3)))
+  (global i32 (i32.const 45))
+  (data (i32.add (global.get $g_import) (i32.const 42)) "hello")
+  (elem (i32.mul (i32.const 4) (global.get $g_import)) func 0)
+)
+(;; STDOUT ;;;
+(module
+  (type (;0;) (func))
+  (import "foo" "bar" (global (;0;) i32))
+  (func (;0;) (type 0))
+  (table (;0;) 1 funcref)
+  (memory (;0;) 1)
+  (global (;1;) (mut i32) (i32.sub
+      (i32.const 44)
+      (i32.const 3)))
+  (global (;2;) i32 (i32.const 45))
+  (elem (;0;) (i32.mul
+      (i32.const 4)
+      (global.get 0)) func 0)
+  (data (;0;) (i32.add
+      (global.get 0)
+      (i32.const 42)) "hello"))
+;;; STDOUT ;;)

--- a/test/run-roundtrip.py
+++ b/test/run-roundtrip.py
@@ -117,6 +117,7 @@ def main(args):
     parser.add_argument('--enable-annotations', action='store_true')
     parser.add_argument('--enable-code-metadata', action='store_true')
     parser.add_argument('--enable-custom-page-sizes', action='store_true')
+    parser.add_argument('--enable-extended-const', action='store_true')
     # --inline-exports can reorder exports, so skip roundtrip check
     parser.add_argument('--inline-exports', action='store_true',
                         help="write exports inline and skip end-to-end roundtrip check")
@@ -144,6 +145,7 @@ def main(args):
         '--enable-annotations': options.enable_annotations,
         '--enable-code-metadata': options.enable_code_metadata,
         '--enable-custom-page-sizes': options.enable_custom_page_sizes,
+        '--enable-extended-const': options.enable_extended_const,
         '--reloc': options.reloc,
         '--no-check': options.no_check,
     })
@@ -167,6 +169,7 @@ def main(args):
         '--enable-annotations': options.enable_annotations,
         '--enable-code-metadata': options.enable_code_metadata,
         '--enable-custom-page-sizes': options.enable_custom_page_sizes,
+        '--enable-extended-const': options.enable_extended_const,
         '--inline-exports': options.inline_exports,
         '--inline-imports': options.inline_imports,
         '--no-debug-names': not options.debug_names,


### PR DESCRIPTION
`wasm2wat` produces output it can't read back for modules that use the extended-const proposal.

An init expression with more than one instruction comes out like this:

```wat
(global (;1;) (mut i32) (i32.const 44
    i32.const 3
    i32.sub))
```

which fails to assemble:

```
error: unexpected token i32.const, expected ).
```

`WriteInitExpr` opens a single pair of parentheses around the whole expression list and then writes the instructions unfolded. For the ordinary one-instruction case that gives `(i32.const 45)` and is fine, but with several instructions the leading `(` reads as the start of a folded expression and everything after it is a syntax error. Globals, data offsets and elem offsets are all affected. `--fold-exprs` doesn't help, because init expressions never went through the folded writer at all.

This writes them with `WriteFoldedExprList` instead, which emits one folded expression, valid in every position an init expression can appear:

```wat
(global (;1;) (mut i32) (i32.sub
      (i32.const 44)
      (i32.const 3)))
```

Single-instruction init expressions are unaffected — those still print as `(i32.const 45)`, so existing expectations don't move.

### How I found it

I ran every `.txt` under `test/` through wat2wasm → wasm2wat → wat2wasm with `--enable-all` and compared the two binaries. 1102 modules round-tripped byte-identically and three failed to re-assemble, all for this reason: `test/dump/extended-const.txt`, `test/dump/invalid-data-segment-offset.txt` and `test/parse/module/bad-global-invalid-expr.txt`. After the change all 1105 round-trip and the binaries match.

`test/dump/extended-const.txt` already covers this module, but it's an objdump test, so nothing ever fed the disassembly back to the assembler.

### Testing

Added `test/roundtrip/extended-const.txt`, covering a global, a data offset and an elem offset with extended constant expressions. It fails without the writer change with the parse error above, and passes with it.

`run-roundtrip.py` had no `--enable-extended-const`, which is the reason the roundtrip suite couldn't have caught this in the first place, so I added the flag and passed it to both tools alongside the existing ones.

`test/roundtrip` goes from 92 to 93 passing, and the unit tests are unchanged at 135.

One caveat on my local runs: this is Windows, and a lot of the wider suite can't execute here — Application Control blocks the freshly built tools for several directories, and the wasm2c tests need a `cl.exe` I don't have. `roundtrip`, `desugar` and `typecheck` run clean, and I checked that no expected output anywhere in `test/` contains the old unparseable shape, but I'd rather flag that than imply I ran everything.
