### PR TITLE
Don't generate a bare "$" from an empty export name

### DIFF
--- a/src/generate-names.cc
+++ b/src/generate-names.cc
@@ -179,6 +179,12 @@ void NameGenerator::MaybeUseAndBindName(BindingHash* bindings,
                                         Index index,
                                         std::string* str) {
   if (!HasName(*str)) {
+    if (!HasName(name)) {
+      // An empty import or export name would produce a bare "$", which is not
+      // a valid identifier. Leave the name unset; the index-based pass that
+      // runs afterwards will give it a usable one.
+      return;
+    }
     unsigned disambiguator = 0;
     while (true) {
       GenerateName(name, kInvalidIndex, disambiguator, str);

--- a/test/roundtrip/generate-empty-export-name.txt
+++ b/test/roundtrip/generate-empty-export-name.txt
@@ -1,0 +1,22 @@
+;;; TOOL: run-roundtrip
+;;; ARGS: --stdout --generate-names
+
+(module
+  ;; With no name section the generated names come from the exports. An empty
+  ;; export name cannot be used as an identifier, since it would produce a bare
+  ;; "$", so it has to be skipped: this func has no other export to take a name
+  ;; from and falls back to an index-based name.
+  (func $f)
+  (export "" (func $f))
+
+  (func $g)
+  (export "named" (func $g))
+)
+(;; STDOUT ;;;
+(module
+  (type $t0 (func))
+  (func $f0 (type $t0))
+  (func $named (type $t0))
+  (export "" (func $f0))
+  (export "named" (func $named)))
+;;; STDOUT ;;)

--- a/test/wasm2c/export-names.txt
+++ b/test/wasm2c/export-names.txt
@@ -926,7 +926,7 @@ DEFINE_TABLE_FILL(externref)
                                   wasm_rt_tailcallee_t* next)
 #endif
 
-static void w2c_test__0(w2c_test*);
+static void w2c_test_0x2A0x2F_0(w2c_test*);
 
 FUNC_TYPE_T(w2c_test_t0) = "\x36\xa9\xe7\xf1\xc9\x5b\x82\xff\xb9\x97\x43\xe0\xc5\xc4\xce\x95\xd8\x3c\x9a\x43\x0a\xac\x59\xf8\x4e\xf3\xcb\xfa\xb6\x14\x50\x68";
 
@@ -941,7 +941,7 @@ void w2c_test_(w2c_test* instance) {
 #endif
   wasm_rt_segue_write_base((*instance->w2c_0x5Cmodule_import0x200x2A0x2F).data);
 #endif
-  w2c_test__0(instance);
+  w2c_test_0x2A0x2F_0(instance);
 #if WASM_RT_USE_SEGUE_FOR_THIS_MODULE && !WASM_RT_SEGUE_FREE_SEGMENT
   wasm_rt_segue_write_base(segue_saved_base);
 #endif
@@ -955,7 +955,7 @@ void w2c_test_0x2A0x2F(w2c_test* instance) {
 #endif
   wasm_rt_segue_write_base((*instance->w2c_0x5Cmodule_import0x200x2A0x2F).data);
 #endif
-  w2c_test__0(instance);
+  w2c_test_0x2A0x2F_0(instance);
 #if WASM_RT_USE_SEGUE_FOR_THIS_MODULE && !WASM_RT_SEGUE_FREE_SEGMENT
   wasm_rt_segue_write_base(segue_saved_base);
 #endif
@@ -969,7 +969,7 @@ void w2c_test_0x3F0x3F0x2F(w2c_test* instance) {
 #endif
   wasm_rt_segue_write_base((*instance->w2c_0x5Cmodule_import0x200x2A0x2F).data);
 #endif
-  w2c_test__0(instance);
+  w2c_test_0x2A0x2F_0(instance);
 #if WASM_RT_USE_SEGUE_FOR_THIS_MODULE && !WASM_RT_SEGUE_FREE_SEGMENT
   wasm_rt_segue_write_base(segue_saved_base);
 #endif
@@ -983,7 +983,7 @@ void w2c_test_0x0A(w2c_test* instance) {
 #endif
   wasm_rt_segue_write_base((*instance->w2c_0x5Cmodule_import0x200x2A0x2F).data);
 #endif
-  w2c_test__0(instance);
+  w2c_test_0x2A0x2F_0(instance);
 #if WASM_RT_USE_SEGUE_FOR_THIS_MODULE && !WASM_RT_SEGUE_FREE_SEGMENT
   wasm_rt_segue_write_base(segue_saved_base);
 #endif
@@ -997,7 +997,7 @@ void w2c_test_0xE20x9D0xA40xEF0xB80x8F(w2c_test* instance) {
 #endif
   wasm_rt_segue_write_base((*instance->w2c_0x5Cmodule_import0x200x2A0x2F).data);
 #endif
-  w2c_test__0(instance);
+  w2c_test_0x2A0x2F_0(instance);
 #if WASM_RT_USE_SEGUE_FOR_THIS_MODULE && !WASM_RT_SEGUE_FREE_SEGMENT
   wasm_rt_segue_write_base(segue_saved_base);
 #endif
@@ -1045,7 +1045,7 @@ wasm_rt_func_type_t wasm2c_test_get_func_type(uint32_t param_count, uint32_t res
   return NULL;
 }
 
-void w2c_test__0(w2c_test* instance) {
+void w2c_test_0x2A0x2F_0(w2c_test* instance) {
   FUNC_PROLOGUE;
   uint8_t* const wasm_rt_local_memory_base = (instance->w2c_0x5Cmodule_import0x200x2A0x2F)->data;
   uint64_t wasm_rt_local_memory_size = (instance->w2c_0x5Cmodule_import0x200x2A0x2F)->size;


### PR DESCRIPTION
`wasm2wat --generate-names` produces output it can't read back when a module has an export with an empty name.

```wat
(module (func $f) (export "" (func $f)))
```

Disassembled with `--generate-names`:

```wat
(func $ (type $t0))
(export "" (func $))
```

and assembling that back gives `error: empty identifier.`

Generated names are derived from import and export names, built as `"$"` followed by the name, so an empty export name leaves just the sigil. This skips an empty name instead, and the item keeps whatever name the rest of the pass gives it — another of its export names if it has one, otherwise the index-based name it would have had anyway.

Empty export names are legal and do turn up: `test/wasm2c/export-names.txt` already has one, which is where I hit this.

Imports go through the same helper but can't reach it, because the name there is always `module_name + "." + field_name` and so is never empty. I put the check in the shared helper anyway rather than in the export path, since it's guarding a property of the generated identifier rather than anything specific to exports.

### How I found it

Same round-trip sweep as #2830, extended to the writer variants rather than just the default one: for every module in `test/`, disassemble with `--fold-exprs`, `--inline-exports`, `--inline-imports`, `--generate-names` and `--no-debug-names` in turn, then assemble the result again. `--generate-names` was 1105 of 1106, and this was the one failure. It is 1106 now.

### Testing

`test/roundtrip/generate-empty-export-name.txt` covers a func whose only export name is empty, alongside one with a usable export name so both paths are visible in the output. It fails without the change with the `empty identifier` error above.

Note it deliberately does not pass `--debug-names`: with a name section present the original names survive and the generator never runs, so the test wouldn't exercise this at all.

`roundtrip` goes from 93 to 94, and `desugar`, `typecheck`, `parse` and the unit tests are unchanged.

### Unrelated, while I was in there

The same sweep found `--fold-exprs` output failing to re-assemble for code metadata annotations and for branch hints:

```
test/dump/code-metadata.txt          error: unexpected token "metadata.code.test", expected an instr.
test/parse/branch-hints.txt          error: unexpected token (, expected ).
```

That looks like a separate problem in how annotations are placed in folded output, so I've left it out of this PR. Happy to open an issue for it if it isn't already known.
