### PR TITLE
Keep code metadata annotations attached when folding

### DIFF
--- a/include/wabt/wast-parser.h
+++ b/include/wabt/wast-parser.h
@@ -242,6 +242,9 @@ class WastParser {
   Result ParseTerminatingInstrList(ExprList*);
   Result ParseInstr(ExprList*);
   Result ParseCodeMetadataAnnotation(ExprList*);
+  void AppendAnnotatedInstr(ExprList* exprs,
+                            ExprList* annotation,
+                            ExprList* annotated);
   Result ParsePlainInstr(std::unique_ptr<Expr>*);
   Result ParseF32(Const*, ConstType type);
   Result ParseF64(Const*, ConstType type);

--- a/src/wast-parser.cc
+++ b/src/wast-parser.cc
@@ -2280,6 +2280,23 @@ Result WastParser::ParseResultList(TypeVector* result_types,
   return ParseUnboundValueTypeList(TokenType::Result, result_types, type_vars);
 }
 
+void WastParser::AppendAnnotatedInstr(ExprList* exprs,
+                                      ExprList* annotation,
+                                      ExprList* annotated) {
+  // A code metadata annotation decorates the operator of the instruction that
+  // follows it. A folded expression expands to its operands before that
+  // operator, so appending the annotation first would attach it to the first
+  // operand instead; it goes between the two.
+  if (annotated->empty()) {
+    exprs->splice(exprs->end(), *annotation);
+    return;
+  }
+  std::unique_ptr<Expr> op = annotated->extract_back();
+  exprs->splice(exprs->end(), *annotated);
+  exprs->splice(exprs->end(), *annotation);
+  exprs->push_back(std::move(op));
+}
+
 Result WastParser::ParseInstrList(ExprList* exprs) {
   WABT_TRACE(ParseInstrList);
   // Keep going after a bad instruction so the rest of the errors get reported,
@@ -2298,11 +2315,22 @@ Result WastParser::ParseInstrList(ExprList* exprs) {
         CHECK_RESULT(Synchronize(IsInstr));
       }
     } else if (IsLparAnn(pair)) {
-      if (Succeeded(ParseCodeMetadataAnnotation(&new_exprs))) {
-        exprs->splice(exprs->end(), new_exprs);
-      } else {
+      ExprList annotation;
+      if (Failed(ParseCodeMetadataAnnotation(&annotation))) {
         result = Result::Error;
         CHECK_RESULT(Synchronize(IsLparAnn));
+        continue;
+      }
+      ExprList annotated;
+      if (IsInstr(PeekPair()) && Succeeded(ParseInstr(&annotated))) {
+        AppendAnnotatedInstr(exprs, &annotation, &annotated);
+      } else {
+        // Nothing follows it to decorate; keep it rather than lose it.
+        exprs->splice(exprs->end(), annotation);
+        if (IsInstr(PeekPair())) {
+          result = Result::Error;
+          CHECK_RESULT(Synchronize(IsInstr));
+        }
       }
     } else {
       break;
@@ -3442,7 +3470,34 @@ Result WastParser::ParseExprList(ExprList* exprs) {
   WABT_TRACE(ParseExprList);
   Result result = Result::Ok;
   ExprList new_exprs;
-  while (PeekMatchExpr()) {
+  while (true) {
+    if (IsLparAnn(PeekPair())) {
+      // A code metadata annotation here decorates the operator of the
+      // expression that follows it, not the first instruction that expression
+      // expands to, so it is emitted after that expression's operands and
+      // immediately before its operator.
+      ExprList annotation;
+      if (Failed(ParseCodeMetadataAnnotation(&annotation))) {
+        result = Result::Error;
+        CHECK_RESULT(Synchronize(IsLparAnn));
+        continue;
+      }
+      ExprList annotated;
+      if (!PeekMatchExpr() || Failed(ParseExpr(&annotated))) {
+        // Nothing to decorate; keep the annotation so it is not silently lost.
+        exprs->splice(exprs->end(), annotation);
+        if (PeekMatchExpr()) {
+          result = Result::Error;
+          CHECK_RESULT(Synchronize(IsExpr));
+        }
+        continue;
+      }
+      AppendAnnotatedInstr(exprs, &annotation, &annotated);
+      continue;
+    }
+    if (!PeekMatchExpr()) {
+      break;
+    }
     if (Succeeded(ParseExpr(&new_exprs))) {
       exprs->splice(exprs->end(), new_exprs);
     } else {

--- a/src/wat-writer.cc
+++ b/src/wat-writer.cc
@@ -87,6 +87,10 @@ struct ExprTree {
   const Expr* expr;
   std::vector<ExprTree> children;
   Index result_count;
+  /* Code metadata annotations decorating this instruction. They have to travel
+   * with it, since folding moves the instruction relative to the annotation's
+   * position in the flat instruction list. */
+  std::vector<const CodeMetadataExpr*> annotations;
 };
 
 class WatWriter : ModuleContext {
@@ -142,6 +146,7 @@ class WatWriter : ModuleContext {
   void WriteLoadStoreExpr(const Expr* expr);
   template <typename T>
   void WriteMemoryLoadStoreExpr(const Expr* expr);
+  void WriteCodeMetadataExpr(const CodeMetadataExpr& expr);
   void WriteExprList(const ExprList& exprs);
   void WriteInitExpr(const ExprList& expr);
   template <typename T>
@@ -187,6 +192,7 @@ class WatWriter : ModuleContext {
   int indent_ = 0;
   NextChar next_char_ = NextChar::None;
   std::vector<ExprTree> expr_tree_stack_;
+  std::vector<const CodeMetadataExpr*> pending_annotations_;
   std::multimap<std::pair<ExternalKind, Index>, const Export*>
       inline_export_map_;
   std::vector<const Import*> inline_import_map_[kExternalKindCount];
@@ -720,11 +726,7 @@ Result WatWriter::ExprVisitorDelegate::OnCallRefExpr(CallRefExpr* expr) {
 
 Result WatWriter::ExprVisitorDelegate::OnCodeMetadataExpr(
     CodeMetadataExpr* expr) {
-  writer_->WriteOpen("@metadata.code.", NextChar::None);
-  writer_->WriteDataWithNextChar(expr->name.data(), expr->name.size());
-  writer_->WritePutc(' ');
-  writer_->WriteQuotedData(expr->data.data(), expr->data.size());
-  writer_->WriteCloseSpace();
+  writer_->WriteCodeMetadataExpr(*expr);
   return Result::Ok;
 }
 
@@ -1217,8 +1219,26 @@ void WatWriter::WriteExprList(const ExprList& exprs) {
   (void)visitor.VisitExprList(const_cast<ExprList&>(exprs));
 }
 
+void WatWriter::WriteCodeMetadataExpr(const CodeMetadataExpr& expr) {
+  WriteOpen("@metadata.code.", NextChar::None);
+  WriteDataWithNextChar(expr.name.data(), expr.name.size());
+  WritePutc(' ');
+  WriteQuotedData(expr.data.data(), expr.data.size());
+  WriteCloseSpace();
+}
+
 void WatWriter::WriteFoldedExpr(const Expr* expr) {
   WABT_TRACE_ARGS(WriteFoldedExpr, "%s", GetExprTypeName(*expr));
+  if (expr->type() == ExprType::CodeMetadata) {
+    /* A code metadata annotation is not an instruction, it decorates the one
+     * that follows it. Putting it on the expression stack would wrap it in its
+     * own parentheses, and since it has no results it would also flush the
+     * operands of the instruction it belongs to. Hold it until that
+     * instruction is pushed, so it can be written immediately before that
+     * instruction's folded expression. */
+    pending_annotations_.push_back(cast<CodeMetadataExpr>(expr));
+    return;
+  }
   auto arity = GetExprArity(*expr);
   PushExpr(expr, arity.nargs, arity.nreturns);
 }
@@ -1263,6 +1283,8 @@ void WatWriter::PushExpr(const Expr* expr,
   }
 
   ExprTree tree(expr, result_count);
+  tree.annotations = std::move(pending_annotations_);
+  pending_annotations_.clear();
 
   if (current_count == operand_count && operand_count > 0) {
     auto last_operand = expr_tree_stack_.end();
@@ -1278,6 +1300,9 @@ void WatWriter::PushExpr(const Expr* expr,
 
 void WatWriter::FlushExprTree(const ExprTree& expr_tree) {
   WABT_TRACE_ARGS(FlushExprTree, "%s", GetExprTypeName(*expr_tree.expr));
+  for (const CodeMetadataExpr* annotation : expr_tree.annotations) {
+    WriteCodeMetadataExpr(*annotation);
+  }
   switch (expr_tree.expr->type()) {
     case ExprType::Block:
       WritePuts("(", NextChar::None);
@@ -1435,6 +1460,14 @@ void WatWriter::FlushExprTreeStack() {
   std::vector<ExprTree> stack_copy(std::move(expr_tree_stack_));
   expr_tree_stack_.clear();
   FlushExprTreeVector(stack_copy);
+  /* Anything still pending here trails the last instruction of the list, so
+   * there is nothing left to attach it to; write it rather than drop it. */
+  std::vector<const CodeMetadataExpr*> trailing(
+      std::move(pending_annotations_));
+  pending_annotations_.clear();
+  for (const CodeMetadataExpr* annotation : trailing) {
+    WriteCodeMetadataExpr(*annotation);
+  }
 }
 
 void WatWriter::WriteInitExpr(const ExprList& expr) {

--- a/test/roundtrip/fold-code-metadata.txt
+++ b/test/roundtrip/fold-code-metadata.txt
@@ -1,0 +1,46 @@
+;;; TOOL: run-roundtrip
+;;; ARGS: --stdout --fold-exprs --enable-annotations --enable-code-metadata
+(module
+  ;; The annotation decorates i32.add. Folding must not move it onto another
+  ;; instruction, and must not fold the operands into i32.add either, since a
+  ;; folded expression expands to its operands first.
+  (func $f (param i32) (result i32)
+    i32.const 1234
+    local.get 0
+    (@metadata.code.test "aa\01a") i32.add
+    return)
+
+  ;; An annotation on an instruction that takes no operands.
+  (func $g
+    (@metadata.code.test "b") nop)
+
+  ;; An annotation on a block-like instruction, which the writer emits at
+  ;; statement level rather than as an operand. A branch hint is this shape.
+  (func $h (param i32)
+    local.get 0
+    i32.const 1
+    i32.eq
+    (@metadata.code.test "c") if
+      nop
+    end))
+(;; STDOUT ;;;
+(module
+  (type (;0;) (func (param i32) (result i32)))
+  (type (;1;) (func))
+  (type (;2;) (func (param i32)))
+  (func (;0;) (type 0) (param i32) (result i32)
+    (return
+      (@metadata.code.test "aa\01a") (i32.add
+        (i32.const 1234)
+        (local.get 0))))
+  (func (;1;) (type 1)
+    (@metadata.code.test "b") (nop))
+  (func (;2;) (type 2) (param i32)
+    (@metadata.code.test "c") (if  ;; label = @1
+      (i32.eq
+        (local.get 0)
+        (i32.const 1))
+      (then
+        (nop))))
+  (@custom "metadata.code.test" "\03\00\01\06\04aa\01a\01\01\01\01b\02\01\06\01c"))
+;;; STDOUT ;;)


### PR DESCRIPTION
`wasm2wat --fold-exprs` produces output it cannot read back for any module carrying code metadata, and corrupts the instruction the metadata belongs to on the way.

For `test/dump/code-metadata.txt`, where the annotation decorates `i32.add`:

```wat
(i32.const 1234)
(local.get 0)
((@metadata.code.test "aa\01a"))
(return
  (i32.add))
```

The annotation has been wrapped in parentheses of its own, which does not parse — `error: unexpected token "metadata.code.test", expected an instr.` — and `i32.add` has lost both operands. Branch hints are code metadata too, so `test/parse/branch-hints.txt` breaks the same way.

The cause is that a `CodeMetadataExpr` has arity `{0, 0}`, so `WriteFoldedExpr` hands it to `PushExpr` like an instruction. That gives it its own node, hence the parentheses, and since `result_count == 0` it also flushes the expression stack, which detaches the operands of the instruction it was supposed to decorate.

### The output form

Annotations are now held until the instruction they decorate is pushed and carried on that instruction's tree node, so they are written immediately before its folded expression:

```wat
(return
  (@metadata.code.test "aa\01a") (i32.add
    (i32.const 1234)
    (local.get 0)))
```

This is what binaryen and wasm-tools both emit and round-trip, as @keithw showed above; `test/lit/branch-hinting.wast` in binaryen has the same shape with `RTRIP` checks over it. Thanks to both of you for pushing back on the first version of this, which de-folded the annotated instruction instead. I had described the flat form as a limitation of the text format, and that was wrong — it is a limitation of wabt's parser, which is a different thing and fixable.

### The parser change

wabt rejected an annotation in that position, so it learns to accept one. The rule is that an annotation decorates the *operator* of the expression that follows it, and a folded expression expands to its operands before that operator, so the annotation is spliced between the two. Get that wrong and the output still parses but the offset recorded in the metadata section moves to a different instruction, which is the quiet failure rather than the loud one.

It has to happen in two places: in an operand list, and at statement level, where block-like instructions are written. The second is the case branch hints actually hit, since they decorate an `if`. Both paths share `AppendAnnotatedInstr`.

### Testing

`test/roundtrip/fold-code-metadata.txt` covers an annotation on an instruction with operands, one on an instruction without, and one on an `if`, that last being the branch-hint shape. `run-roundtrip` re-assembles and compares against the original binary, so it catches a moved offset as well as a parse failure.

Both reproducers above now round-trip to byte-identical binaries.

I ran every module in `test/` through `wasm2wat` in each of its writer variants — default, `--fold-exprs`, `--inline-exports`, `--inline-imports`, `--generate-names`, `--no-debug-names` — and assembled each result again. `--fold-exprs` was 1102 of 1108 before this change and is 1108 now, with the other five unchanged.

Suites: `roundtrip` 95, `dump` 148, `parse` 758, `typecheck` 119, `desugar` 6, no failures, and unit tests 135. No existing expectation changed.
