### PR TITLE
[interp] Fix wasm-interp stack cleanup for tail calls

### DIFF
--- a/src/interp/binary-reader-interp.cc
+++ b/src/interp/binary-reader-interp.cc
@@ -1236,10 +1236,17 @@ Result BinaryReaderInterp::OnCallRefExpr(Type sig_type) {
 }
 
 Result BinaryReaderInterp::OnReturnCallExpr(Index func_index) {
-  // Validation below rejects an invalid index before cleanup is emitted.
-  Index param_count = func_index < func_types_.size()
-                          ? func_types_[func_index].params.size()
-                          : 0;
+  // Don't use OnReturnCall to check the index here: it consumes the call
+  // operands from the type stack. That will cause drop/keep counts to be
+  // incorrect.
+  if (func_index >= func_types_.size()) {
+    validator_.PrintError(GetLocation(),
+                          "function variable out of range: %" PRIindex
+                          " (max %" PRIindex ")",
+                          func_index, static_cast<Index>(func_types_.size()));
+    return Result::Error;
+  }
+  Index param_count = func_types_[func_index].params.size();
 
   Index drop_count, keep_count, catch_drop_count;
   // Validation consumes the tail-call operands, so compute cleanup first.
@@ -1247,6 +1254,8 @@ Result BinaryReaderInterp::OnReturnCallExpr(Index func_index) {
       GetReturnCallDropKeepCount(param_count, 0, &drop_count, &keep_count));
   CHECK_RESULT(
       validator_.GetCatchCount(label_stack_.size() - 1, &catch_drop_count));
+  // The validator must be run after we get the drop/keep counts, since it
+  // will change the type stack.
   CHECK_RESULT(
       validator_.OnReturnCall(GetLocation(), Var(func_index, GetLocation())));
   istream_.EmitDropKeep(drop_count, keep_count);
@@ -1268,10 +1277,18 @@ Result BinaryReaderInterp::OnReturnCallExpr(Index func_index) {
 
 Result BinaryReaderInterp::OnReturnCallIndirectExpr(Index sig_index,
                                                     Index table_index) {
-  // Validation below rejects an invalid index before cleanup is emitted.
-  Index param_count = sig_index < module_.func_types.size()
-                          ? module_.func_types[sig_index].params.size()
-                          : 0;
+  // Don't use OnReturnCallIndirect to check the index here: it consumes the
+  // call operands from the type stack. That will cause drop/keep counts to be
+  // incorrect.
+  if (sig_index >= module_.func_types.size()) {
+    validator_.PrintError(GetLocation(),
+                          "function type variable out of range: %" PRIindex
+                          " (max %" PRIindex ")",
+                          sig_index,
+                          static_cast<Index>(module_.func_types.size()));
+    return Result::Error;
+  }
+  Index param_count = module_.func_types[sig_index].params.size();
 
   Index drop_count, keep_count, catch_drop_count;
   // +1 to include the index of the function.
@@ -1280,6 +1297,8 @@ Result BinaryReaderInterp::OnReturnCallIndirectExpr(Index sig_index,
       GetReturnCallDropKeepCount(param_count, +1, &drop_count, &keep_count));
   CHECK_RESULT(
       validator_.GetCatchCount(label_stack_.size() - 1, &catch_drop_count));
+  // The validator must be run after we get the drop/keep counts, since it
+  // will change the type stack.
   CHECK_RESULT(validator_.OnReturnCallIndirect(
       GetLocation(), Var(sig_index, GetLocation()),
       Var(table_index, GetLocation())));

--- a/src/interp/binary-reader-interp.cc
+++ b/src/interp/binary-reader-interp.cc
@@ -319,6 +319,7 @@ class BinaryReaderInterp : public BinaryReaderNop {
                             Index* out_keep_count);
   Result GetReturnDropKeepCount(Index* out_drop_count, Index* out_keep_count);
   Result GetReturnCallDropKeepCount(const FuncType&,
+                                    size_t orig_type_stack_size,
                                     Index keep_extra,
                                     Index* out_drop_count,
                                     Index* out_keep_count);
@@ -456,13 +457,17 @@ Result BinaryReaderInterp::GetReturnDropKeepCount(Index* out_drop_count,
   return Result::Ok;
 }
 
-Result BinaryReaderInterp::GetReturnCallDropKeepCount(const FuncType& func_type,
-                                                      Index keep_extra,
-                                                      Index* out_drop_count,
-                                                      Index* out_keep_count) {
+Result BinaryReaderInterp::GetReturnCallDropKeepCount(
+    const FuncType& func_type,
+    size_t orig_type_stack_size,
+    Index keep_extra,
+    Index* out_drop_count,
+    Index* out_keep_count) {
   Index keep_count = static_cast<Index>(func_type.params.size()) + keep_extra;
-  CHECK_RESULT(GetDropCount(keep_count, 0, out_drop_count));
-  *out_drop_count += validator_.GetLocalCount();
+  *out_drop_count =
+      (orig_type_stack_size >= keep_count ? orig_type_stack_size - keep_count
+                                          : 0) +
+      validator_.GetLocalCount();
   *out_keep_count = keep_count;
   return Result::Ok;
 }
@@ -1236,25 +1241,18 @@ Result BinaryReaderInterp::OnCallRefExpr(Type sig_type) {
 }
 
 Result BinaryReaderInterp::OnReturnCallExpr(Index func_index) {
-  // Do not unconditionally call OnReturnCall here: it consumes the call
-  // operands from the type stack, which would make subsequent drop/keep count
-  // calculations incorrect. We only call it here to report a standard
-  // validation error and bail out when the function index is out of bounds.
-  if (func_index >= func_types_.size()) {
-    return validator_.OnReturnCall(GetLocation(),
-                                   Var(func_index, GetLocation()));
-  }
+  // Capture type stack size before validation sets the block to unreachable.
+  size_t orig_type_stack_size = validator_.type_stack_size();
+  CHECK_RESULT(
+      validator_.OnReturnCall(GetLocation(), Var(func_index, GetLocation())));
+
   FuncType& func_type = func_types_[func_index];
 
   Index drop_count, keep_count, catch_drop_count;
-  CHECK_RESULT(
-      GetReturnCallDropKeepCount(func_type, 0, &drop_count, &keep_count));
+  CHECK_RESULT(GetReturnCallDropKeepCount(func_type, orig_type_stack_size, 0,
+                                          &drop_count, &keep_count));
   CHECK_RESULT(
       validator_.GetCatchCount(label_stack_.size() - 1, &catch_drop_count));
-  // The validator must be run after we get the drop/keep counts, since it
-  // will change the type stack.
-  CHECK_RESULT(
-      validator_.OnReturnCall(GetLocation(), Var(func_index, GetLocation())));
   istream_.EmitDropKeep(drop_count, keep_count);
   istream_.EmitCatchDrop(catch_drop_count);
 
@@ -1274,29 +1272,20 @@ Result BinaryReaderInterp::OnReturnCallExpr(Index func_index) {
 
 Result BinaryReaderInterp::OnReturnCallIndirectExpr(Index sig_index,
                                                     Index table_index) {
-  // Do not unconditionally call OnReturnCallIndirect here: it consumes the call
-  // operands from the type stack, which would make subsequent drop/keep count
-  // calculations incorrect. We only call it here to report a standard
-  // validation error and bail out when the function type index is out of
-  // bounds.
-  if (sig_index >= module_.func_types.size()) {
-    return validator_.OnReturnCallIndirect(GetLocation(),
-                                           Var(sig_index, GetLocation()),
-                                           Var(table_index, GetLocation()));
-  }
+  // Capture type stack size before validation sets the block to unreachable.
+  size_t orig_type_stack_size = validator_.type_stack_size();
+  CHECK_RESULT(validator_.OnReturnCallIndirect(
+      GetLocation(), Var(sig_index, GetLocation()),
+      Var(table_index, GetLocation())));
+
   FuncType& func_type = module_.func_types[sig_index];
 
   Index drop_count, keep_count, catch_drop_count;
   // +1 to include the index of the function.
-  CHECK_RESULT(
-      GetReturnCallDropKeepCount(func_type, +1, &drop_count, &keep_count));
+  CHECK_RESULT(GetReturnCallDropKeepCount(func_type, orig_type_stack_size, +1,
+                                          &drop_count, &keep_count));
   CHECK_RESULT(
       validator_.GetCatchCount(label_stack_.size() - 1, &catch_drop_count));
-  // The validator must be run after we get the drop/keep counts, since it
-  // changes the type stack.
-  CHECK_RESULT(validator_.OnReturnCallIndirect(
-      GetLocation(), Var(sig_index, GetLocation()),
-      Var(table_index, GetLocation())));
   istream_.EmitDropKeep(drop_count, keep_count);
   istream_.EmitCatchDrop(catch_drop_count);
   istream_.Emit(Opcode::ReturnCallIndirect, table_index, sig_index);

--- a/src/interp/binary-reader-interp.cc
+++ b/src/interp/binary-reader-interp.cc
@@ -1236,10 +1236,10 @@ Result BinaryReaderInterp::OnCallRefExpr(Type sig_type) {
 }
 
 Result BinaryReaderInterp::OnReturnCallExpr(Index func_index) {
-  // Do not unconditionally call OnReturnCall here: it consumes the call operands
-  // from the type stack, which would make subsequent drop/keep count calculations
-  // incorrect. We only call it here to report a standard validation error and bail
-  // out when the function index is out of bounds.
+  // Do not unconditionally call OnReturnCall here: it consumes the call
+  // operands from the type stack, which would make subsequent drop/keep count
+  // calculations incorrect. We only call it here to report a standard
+  // validation error and bail out when the function index is out of bounds.
   if (func_index >= func_types_.size()) {
     return validator_.OnReturnCall(GetLocation(),
                                    Var(func_index, GetLocation()));
@@ -1276,12 +1276,13 @@ Result BinaryReaderInterp::OnReturnCallIndirectExpr(Index sig_index,
                                                     Index table_index) {
   // Do not unconditionally call OnReturnCallIndirect here: it consumes the call
   // operands from the type stack, which would make subsequent drop/keep count
-  // calculations incorrect. We only call it here to report a standard validation
-  // error and bail out when the function type index is out of bounds.
+  // calculations incorrect. We only call it here to report a standard
+  // validation error and bail out when the function type index is out of
+  // bounds.
   if (sig_index >= module_.func_types.size()) {
-    return validator_.OnReturnCallIndirect(
-        GetLocation(), Var(sig_index, GetLocation()),
-        Var(table_index, GetLocation()));
+    return validator_.OnReturnCallIndirect(GetLocation(),
+                                           Var(sig_index, GetLocation()),
+                                           Var(table_index, GetLocation()));
   }
   FuncType& func_type = module_.func_types[sig_index];
 

--- a/src/interp/binary-reader-interp.cc
+++ b/src/interp/binary-reader-interp.cc
@@ -318,7 +318,7 @@ class BinaryReaderInterp : public BinaryReaderNop {
                             Index* out_drop_count,
                             Index* out_keep_count);
   Result GetReturnDropKeepCount(Index* out_drop_count, Index* out_keep_count);
-  Result GetReturnCallDropKeepCount(const FuncType&,
+  Result GetReturnCallDropKeepCount(Index param_count,
                                     Index keep_extra,
                                     Index* out_drop_count,
                                     Index* out_keep_count);
@@ -456,11 +456,11 @@ Result BinaryReaderInterp::GetReturnDropKeepCount(Index* out_drop_count,
   return Result::Ok;
 }
 
-Result BinaryReaderInterp::GetReturnCallDropKeepCount(const FuncType& func_type,
+Result BinaryReaderInterp::GetReturnCallDropKeepCount(Index param_count,
                                                       Index keep_extra,
                                                       Index* out_drop_count,
                                                       Index* out_keep_count) {
-  Index keep_count = static_cast<Index>(func_type.params.size()) + keep_extra;
+  Index keep_count = param_count + keep_extra;
   CHECK_RESULT(GetDropCount(keep_count, 0, out_drop_count));
   *out_drop_count += validator_.GetLocalCount();
   *out_keep_count = keep_count;
@@ -1236,18 +1236,17 @@ Result BinaryReaderInterp::OnCallRefExpr(Type sig_type) {
 }
 
 Result BinaryReaderInterp::OnReturnCallExpr(Index func_index) {
-  CHECK_RESULT(
-      validator_.OnReturnCall(GetLocation(), Var(func_index, GetLocation())));
-
-  FuncType& func_type = func_types_[func_index];
+  // Validation below rejects an invalid index before cleanup is emitted.
+  Index param_count = func_index < func_types_.size()
+                          ? func_types_[func_index].params.size()
+                          : 0;
 
   Index drop_count, keep_count, catch_drop_count;
+  // Validation consumes the tail-call operands, so compute cleanup first.
   CHECK_RESULT(
-      GetReturnCallDropKeepCount(func_type, 0, &drop_count, &keep_count));
+      GetReturnCallDropKeepCount(param_count, 0, &drop_count, &keep_count));
   CHECK_RESULT(
       validator_.GetCatchCount(label_stack_.size() - 1, &catch_drop_count));
-  // The validator must be run after we get the drop/keep counts, since it
-  // will change the type stack.
   CHECK_RESULT(
       validator_.OnReturnCall(GetLocation(), Var(func_index, GetLocation())));
   istream_.EmitDropKeep(drop_count, keep_count);
@@ -1269,20 +1268,18 @@ Result BinaryReaderInterp::OnReturnCallExpr(Index func_index) {
 
 Result BinaryReaderInterp::OnReturnCallIndirectExpr(Index sig_index,
                                                     Index table_index) {
-  CHECK_RESULT(validator_.OnReturnCallIndirect(
-      GetLocation(), Var(sig_index, GetLocation()),
-      Var(table_index, GetLocation())));
-
-  FuncType& func_type = module_.func_types[sig_index];
+  // Validation below rejects an invalid index before cleanup is emitted.
+  Index param_count = sig_index < module_.func_types.size()
+                          ? module_.func_types[sig_index].params.size()
+                          : 0;
 
   Index drop_count, keep_count, catch_drop_count;
   // +1 to include the index of the function.
+  // Validation consumes the tail-call operands, so compute cleanup first.
   CHECK_RESULT(
-      GetReturnCallDropKeepCount(func_type, +1, &drop_count, &keep_count));
+      GetReturnCallDropKeepCount(param_count, +1, &drop_count, &keep_count));
   CHECK_RESULT(
       validator_.GetCatchCount(label_stack_.size() - 1, &catch_drop_count));
-  // The validator must be run after we get the drop/keep counts, since it
-  // changes the type stack.
   CHECK_RESULT(validator_.OnReturnCallIndirect(
       GetLocation(), Var(sig_index, GetLocation()),
       Var(table_index, GetLocation())));

--- a/src/interp/binary-reader-interp.cc
+++ b/src/interp/binary-reader-interp.cc
@@ -318,7 +318,7 @@ class BinaryReaderInterp : public BinaryReaderNop {
                             Index* out_drop_count,
                             Index* out_keep_count);
   Result GetReturnDropKeepCount(Index* out_drop_count, Index* out_keep_count);
-  Result GetReturnCallDropKeepCount(Index param_count,
+  Result GetReturnCallDropKeepCount(const FuncType&,
                                     Index keep_extra,
                                     Index* out_drop_count,
                                     Index* out_keep_count);
@@ -456,11 +456,11 @@ Result BinaryReaderInterp::GetReturnDropKeepCount(Index* out_drop_count,
   return Result::Ok;
 }
 
-Result BinaryReaderInterp::GetReturnCallDropKeepCount(Index param_count,
+Result BinaryReaderInterp::GetReturnCallDropKeepCount(const FuncType& func_type,
                                                       Index keep_extra,
                                                       Index* out_drop_count,
                                                       Index* out_keep_count) {
-  Index keep_count = param_count + keep_extra;
+  Index keep_count = static_cast<Index>(func_type.params.size()) + keep_extra;
   CHECK_RESULT(GetDropCount(keep_count, 0, out_drop_count));
   *out_drop_count += validator_.GetLocalCount();
   *out_keep_count = keep_count;
@@ -1236,22 +1236,19 @@ Result BinaryReaderInterp::OnCallRefExpr(Type sig_type) {
 }
 
 Result BinaryReaderInterp::OnReturnCallExpr(Index func_index) {
-  // Don't use OnReturnCall to check the index here: it consumes the call
-  // operands from the type stack. That will cause drop/keep counts to be
-  // incorrect.
+  // Do not unconditionally call OnReturnCall here: it consumes the call operands
+  // from the type stack, which would make subsequent drop/keep count calculations
+  // incorrect. We only call it here to report a standard validation error and bail
+  // out when the function index is out of bounds.
   if (func_index >= func_types_.size()) {
-    validator_.PrintError(GetLocation(),
-                          "function variable out of range: %" PRIindex
-                          " (max %" PRIindex ")",
-                          func_index, static_cast<Index>(func_types_.size()));
-    return Result::Error;
+    return validator_.OnReturnCall(GetLocation(),
+                                   Var(func_index, GetLocation()));
   }
-  Index param_count = func_types_[func_index].params.size();
+  FuncType& func_type = func_types_[func_index];
 
   Index drop_count, keep_count, catch_drop_count;
-  // Validation consumes the tail-call operands, so compute cleanup first.
   CHECK_RESULT(
-      GetReturnCallDropKeepCount(param_count, 0, &drop_count, &keep_count));
+      GetReturnCallDropKeepCount(func_type, 0, &drop_count, &keep_count));
   CHECK_RESULT(
       validator_.GetCatchCount(label_stack_.size() - 1, &catch_drop_count));
   // The validator must be run after we get the drop/keep counts, since it
@@ -1277,28 +1274,25 @@ Result BinaryReaderInterp::OnReturnCallExpr(Index func_index) {
 
 Result BinaryReaderInterp::OnReturnCallIndirectExpr(Index sig_index,
                                                     Index table_index) {
-  // Don't use OnReturnCallIndirect to check the index here: it consumes the
-  // call operands from the type stack. That will cause drop/keep counts to be
-  // incorrect.
+  // Do not unconditionally call OnReturnCallIndirect here: it consumes the call
+  // operands from the type stack, which would make subsequent drop/keep count
+  // calculations incorrect. We only call it here to report a standard validation
+  // error and bail out when the function type index is out of bounds.
   if (sig_index >= module_.func_types.size()) {
-    validator_.PrintError(GetLocation(),
-                          "function type variable out of range: %" PRIindex
-                          " (max %" PRIindex ")",
-                          sig_index,
-                          static_cast<Index>(module_.func_types.size()));
-    return Result::Error;
+    return validator_.OnReturnCallIndirect(
+        GetLocation(), Var(sig_index, GetLocation()),
+        Var(table_index, GetLocation()));
   }
-  Index param_count = module_.func_types[sig_index].params.size();
+  FuncType& func_type = module_.func_types[sig_index];
 
   Index drop_count, keep_count, catch_drop_count;
   // +1 to include the index of the function.
-  // Validation consumes the tail-call operands, so compute cleanup first.
   CHECK_RESULT(
-      GetReturnCallDropKeepCount(param_count, +1, &drop_count, &keep_count));
+      GetReturnCallDropKeepCount(func_type, +1, &drop_count, &keep_count));
   CHECK_RESULT(
       validator_.GetCatchCount(label_stack_.size() - 1, &catch_drop_count));
   // The validator must be run after we get the drop/keep counts, since it
-  // will change the type stack.
+  // changes the type stack.
   CHECK_RESULT(validator_.OnReturnCallIndirect(
       GetLocation(), Var(sig_index, GetLocation()),
       Var(table_index, GetLocation())));

--- a/test/interp/return-call-indirect-stack-cleanup.txt
+++ b/test/interp/return-call-indirect-stack-cleanup.txt
@@ -1,0 +1,23 @@
+;;; TOOL: run-interp
+;;; ARGS1: --host-print
+(module
+  (type $i_i (func (param i32) (result i32)))
+  (import "host" "print" (func $imported (type $i_i)))
+  (table funcref (elem $imported))
+
+  (func $tail (result i32)
+    i32.const 777
+    i32.const 0
+    i32.const 0
+    return_call_indirect (type $i_i))
+
+  (func (export "f") (result i32)
+    (local i32)
+    call $tail
+    local.get 0
+    return)
+)
+(;; STDOUT ;;;
+called host host.print(i32:0) => i32:0
+f() => i32:0
+;;; STDOUT ;;)

--- a/test/interp/return-call-stack-cleanup.txt
+++ b/test/interp/return-call-stack-cleanup.txt
@@ -1,0 +1,21 @@
+;;; TOOL: run-interp
+;;; ARGS1: --host-print
+(module
+  (type $i_i (func (param i32) (result i32)))
+  (import "host" "print" (func $imported (type $i_i)))
+
+  (func $tail (result i32)
+    i32.const 777
+    i32.const 0
+    return_call $imported)
+
+  (func (export "f") (result i32)
+    (local i32)
+    call $tail
+    local.get 0
+    return)
+)
+(;; STDOUT ;;;
+called host host.print(i32:0) => i32:0
+f() => i32:0
+;;; STDOUT ;;)


### PR DESCRIPTION
## Summary
Fix incorrect value-stack cleanup when lowering `return_call` and `return_call_indirect` in `wasm-interp`.

In `wasm-interp`, all call frames share a single flat value stack. When performing a tail call, `InterpDropKeep` is emitted to drop the current frame's locals and intermediate stack values while keeping the arguments to be passed to the callee.

`GetReturnCallDropKeepCount` calculates `drop_count` based on the validator's current type-stack height. Previously, `validator_.OnReturnCall*` was invoked before `GetReturnCallDropKeepCount`, which immediately popped the call arguments from the type stack. Consequently, `drop_count` was undercounted by the number of call arguments, leaving dead stack values behind that could corrupt subsequent operations (e.g., being incorrectly observed as the caller's return value).

## Fix
1. In `OnReturnCallExpr` / `OnReturnCallIndirectExpr`, if the function/type index is out of bounds, delegate directly to `validator_.OnReturnCall*` to report the standard validation error.
2. On valid paths, compute `GetReturnCallDropKeepCount` and `GetCatchCount` **before** invoking `validator_.OnReturnCall*`, ensuring the call arguments are still present on the validator's type stack during cleanup calculation.

## Tests
- Added `return-call-stack-cleanup.txt` and `return-call-indirect-stack-cleanup.txt` covering both direct and indirect tail calls with unconsumed stack values.
- Verified against existing interpreter, validation, and spec test suites.