### PR TITLE
Support u64 limits for wasm 3.0

### DIFF
--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -640,9 +640,12 @@ Result BinaryReader::ReadTable(Limits* out_elem_limits) {
            "memory64 not allowed");
   ERROR_UNLESS(unknown_flags == 0, "malformed table limits flag: %d", flags);
 
-  CHECK_RESULT(ReadU32OrU64Leb128(&initial, is_64, "table initial elem count"));
+  CHECK_RESULT(ReadU32OrU64Leb128(&initial,
+                                  options_.features.memory64_enabled(),
+                                  "table initial elem count"));
   if (has_max) {
-    CHECK_RESULT(ReadU32OrU64Leb128(&max, is_64, "table max elem count"));
+    CHECK_RESULT(ReadU32OrU64Leb128(&max, options_.features.memory64_enabled(),
+                                    "table max elem count"));
   }
 
   out_elem_limits->has_max = has_max;

--- a/src/binary-writer.cc
+++ b/src/binary-writer.cc
@@ -78,8 +78,8 @@ uint32_t ComputeLimitsFlags(const Limits* limits) {
   return flags;
 }
 
-void WriteLimitsData(Stream* stream, const Limits* limits) {
-  if (limits->is_64) {
+void WriteLimitsData(Stream* stream, const Limits* limits, bool is_64) {
+  if (is_64) {
     WriteU64Leb128(stream, limits->initial, "limits: initial");
     if (limits->has_max) {
       WriteU64Leb128(stream, limits->max, "limits: max");
@@ -1238,7 +1238,8 @@ void BinaryWriter::WriteTable(const Table* table) {
   }
   WriteType(stream_, table->elem_type);
   WriteLimitsFlags(stream_, ComputeLimitsFlags(&table->elem_limits));
-  WriteLimitsData(stream_, &table->elem_limits);
+  WriteLimitsData(stream_, &table->elem_limits,
+                  options_.features.memory64_enabled());
 
   if (!table->init_expr.empty()) {
     WriteInitExpr(table->init_expr);
@@ -1250,7 +1251,8 @@ void BinaryWriter::WriteMemory(const Memory* memory) {
   const bool custom_page_size = memory->page_size != WABT_DEFAULT_PAGE_SIZE;
   flags |= custom_page_size ? WABT_BINARY_LIMITS_HAS_CUSTOM_PAGE_SIZE_FLAG : 0;
   WriteLimitsFlags(stream_, flags);
-  WriteLimitsData(stream_, &memory->page_limits);
+  WriteLimitsData(stream_, &memory->page_limits,
+                  options_.features.memory64_enabled());
   if (custom_page_size) {
     WriteU32Leb128(stream_, log2_u32(memory->page_size), "memory page size");
   }

--- a/src/wast-parser.cc
+++ b/src/wast-parser.cc
@@ -1211,9 +1211,11 @@ Result WastParser::ParseLimitsIndex(Limits* out_limits) {
 Result WastParser::ParseLimits(Limits* out_limits) {
   WABT_TRACE(ParseLimits);
 
-  CHECK_RESULT(ParseNat(&out_limits->initial, out_limits->is_64));
+  CHECK_RESULT(
+      ParseNat(&out_limits->initial, options_->features.memory64_enabled()));
   if (PeekMatch(TokenType::Nat)) {
-    CHECK_RESULT(ParseNat(&out_limits->max, out_limits->is_64));
+    CHECK_RESULT(
+        ParseNat(&out_limits->max, options_->features.memory64_enabled()));
     out_limits->has_max = true;
   } else {
     out_limits->has_max = false;

--- a/test/interp/custom-page-sizes.txt
+++ b/test/interp/custom-page-sizes.txt
@@ -44,7 +44,7 @@
 ;; or invalid (for other pagesizes).
 
 ;; i32 (pagesize 1)
-(assert_malformed
+(assert_invalid
   (module quote "(memory 0x1_0000_0000 (pagesize 1))")
   "constant out of range")
 
@@ -105,10 +105,10 @@ out/test/interp/custom-page-sizes.txt:29: assert_unlinkable passed:
   error: invalid import "test.unknown"
 out/test/interp/custom-page-sizes.txt:36: assert_unlinkable passed:
   error: invalid import "test.unknown"
-out/test/interp/custom-page-sizes.txt:48: assert_malformed passed:
-  out/test/interp/custom-page-sizes/custom-page-sizes.5.wat:1:9: error: invalid int "0x1_0000_0000"
+out/test/interp/custom-page-sizes.txt:48: assert_invalid passed:
+  out/test/interp/custom-page-sizes/custom-page-sizes.5.wat:1:2: error: initial pages (4294967296) must be <= (4294967295)
   (memory 0x1_0000_0000 (pagesize 1))
-          ^^^^^^^^^^^^^
+   ^^^^^^
 out/test/interp/custom-page-sizes.txt:53: assert_malformed passed:
   out/test/interp/custom-page-sizes/custom-page-sizes.6.wat:1:13: error: invalid int "0x1_0000_0000_0000_0000"
   (memory i64 0x1_0000_0000_0000_0000 (pagesize 1))

--- a/test/parse/memory64-limits.txt
+++ b/test/parse/memory64-limits.txt
@@ -1,0 +1,13 @@
+;;; TOOL: wat2wasm
+;;; ERROR: 1
+(module
+  (memory 0x1_0000_0000)
+  (table 0x1_0000_0000 funcref))
+(;; STDERR ;;;
+out/test/parse/memory64-limits.txt:5:4: error: initial elems (4294967296) must be <= (4294967295)
+  (table 0x1_0000_0000 funcref))
+   ^^^^^
+out/test/parse/memory64-limits.txt:4:4: error: initial pages (4294967296) must be <= (65536)
+  (memory 0x1_0000_0000)
+   ^^^^^^
+;;; STDERR ;;)

--- a/test/roundtrip/memory64-limits.txt
+++ b/test/roundtrip/memory64-limits.txt
@@ -1,0 +1,10 @@
+;;; TOOL: run-roundtrip
+;;; ARGS: --stdout --no-check
+(module
+  (memory 0x1_0000_0000)
+  (table 0x1_0000_0000 funcref))
+(;; STDOUT ;;;
+(module
+  (table (;0;) 4294967296 funcref)
+  (memory (;0;) 4294967296))
+;;; STDOUT ;;)

--- a/test/spec/custom-page-sizes/memory_max.txt
+++ b/test/spec/custom-page-sizes/memory_max.txt
@@ -1,6 +1,6 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/proposals/custom-page-sizes/memory_max.wast
-;;; ARGS*: --enable-custom-page-sizes
+;;; ARGS*: --enable-custom-page-sizes --disable-memory64
 (;; STDOUT ;;;
 out/test/spec/custom-page-sizes/memory_max.wast:13: assert_unlinkable passed:
   error: invalid import "test.unknown"

--- a/test/spec/memory64/memory.txt
+++ b/test/spec/memory64/memory.txt
@@ -50,20 +50,20 @@ out/test/spec/memory64/memory.wast:72: assert_invalid passed:
   out/test/spec/memory64/memory/memory.24.wasm:0000012: error: max pages (4294967295) must be <= (65536)
   0000012: error: OnMemory callback failed
 out/test/spec/memory64/memory.wast:77: assert_invalid passed:
-  out/test/spec/memory64/memory/memory.25.wat:1:9: error: invalid int "0x1_0000_0000"
+  out/test/spec/memory64/memory/memory.25.wat:1:2: error: initial pages (4294967296) must be <= (65536)
   (memory 0x1_0000_0000)
-          ^^^^^^^^^^^^^
+   ^^^^^^
 out/test/spec/memory64/memory.wast:81: assert_invalid passed:
-  out/test/spec/memory64/memory/memory.26.wat:1:9: error: invalid int "0x1_0000_0000"
+  out/test/spec/memory64/memory/memory.26.wat:1:2: error: initial pages (4294967296) must be <= (65536)
   (memory 0x1_0000_0000 0x1_0000_0000)
-          ^^^^^^^^^^^^^
-  out/test/spec/memory64/memory/memory.26.wat:1:23: error: invalid int "0x1_0000_0000"
+   ^^^^^^
+  out/test/spec/memory64/memory/memory.26.wat:1:2: error: max pages (4294967296) must be <= (65536)
   (memory 0x1_0000_0000 0x1_0000_0000)
-                        ^^^^^^^^^^^^^
+   ^^^^^^
 out/test/spec/memory64/memory.wast:85: assert_invalid passed:
-  out/test/spec/memory64/memory/memory.27.wat:1:11: error: invalid int "0x1_0000_0000"
+  out/test/spec/memory64/memory/memory.27.wat:1:2: error: max pages (4294967296) must be <= (65536)
   (memory 0 0x1_0000_0000)
-            ^^^^^^^^^^^^^
+   ^^^^^^
 out/test/spec/memory64/memory.wast:228: assert_malformed passed:
   out/test/spec/memory64/memory/memory.29.wat:1:17: error: redefinition of memory "$foo"
   (memory $foo 1)(memory $foo 1)

--- a/test/spec/memory64/table.txt
+++ b/test/spec/memory64/table.txt
@@ -83,20 +83,20 @@ out/test/spec/memory64/table.txt:20: assert_invalid passed:
   out/test/spec/memory64/table/table.10.wasm:0000013: error: max elems (0) must be >= initial elems (4294967295)
   0000013: error: BeginTable callback failed
 out/test/spec/memory64/table.txt:25: assert_invalid passed:
-  out/test/spec/memory64/table/table.11.wat:1:8: error: invalid int "0x1_0000_0000"
+  out/test/spec/memory64/table/table.11.wat:1:2: error: initial elems (4294967296) must be <= (4294967295)
   (table 0x1_0000_0000 funcref)
-         ^^^^^^^^^^^^^
+   ^^^^^
 out/test/spec/memory64/table.txt:29: assert_invalid passed:
-  out/test/spec/memory64/table/table.12.wat:1:8: error: invalid int "0x1_0000_0000"
+  out/test/spec/memory64/table/table.12.wat:1:2: error: initial elems (4294967296) must be <= (4294967295)
   (table 0x1_0000_0000 0x1_0000_0000 funcref)
-         ^^^^^^^^^^^^^
-  out/test/spec/memory64/table/table.12.wat:1:22: error: invalid int "0x1_0000_0000"
+   ^^^^^
+  out/test/spec/memory64/table/table.12.wat:1:2: error: max elems (4294967296) must be <= (4294967295)
   (table 0x1_0000_0000 0x1_0000_0000 funcref)
-                       ^^^^^^^^^^^^^
+   ^^^^^
 out/test/spec/memory64/table.txt:33: assert_invalid passed:
-  out/test/spec/memory64/table/table.13.wat:1:10: error: invalid int "0x1_0000_0000"
+  out/test/spec/memory64/table/table.13.wat:1:2: error: max elems (4294967296) must be <= (4294967295)
   (table 0 0x1_0000_0000 funcref)
-           ^^^^^^^^^^^^^
+   ^^^^^
 out/test/spec/memory64/table.txt:51: assert_invalid passed:
   out/test/spec/memory64/table/table.23.wasm:000000f: error: max elems (0) must be >= initial elems (1)
   000000f: error: BeginTable callback failed


### PR DESCRIPTION
https://github.com/WebAssembly/memory64/blob/main/proposals/memory64/Overview.md#structure

The `limits` structure uses u64 values, regardless the table/memory is i32.

This is also true for WebAssembly 3.0:
https://webassembly.github.io/spec/core/binary/types.html#binary-limits

Hence `(memory 0x1_0000_0000)` and `(table 0x1_0000_0000 funcref))` are not-malformed, only invalid now. This patch tries to support this behavior.